### PR TITLE
feat: NextAuth.js v5 Google OAuth実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,10 @@
 # PostgreSQL接続URL（Supabase / Railway / ローカル）
 DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE?schema=public"
+
+# NextAuth.js v5 シークレット（openssl rand -base64 32 で生成）
+AUTH_SECRET="your-secret-here"
+
+# Google OAuth 認証情報（Google Cloud Console で取得）
+# 承認済みリダイレクトURI: http://localhost:3000/api/auth/callback/google
+AUTH_GOOGLE_ID="your-google-client-id"
+AUTH_GOOGLE_SECRET="your-google-client-secret"

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/auth";
+
+export const { GET, POST } = handlers;

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
-import { Zap, Shield, Users, Star } from "lucide-react";
+import { Star, Zap, Shield, Users } from "lucide-react";
+import { signIn } from "@/auth";
 
 export default function LoginPage() {
   return (
@@ -86,36 +86,43 @@ export default function LoginPage() {
             Googleアカウントでかんたんにはじめられます
           </p>
 
-          {/* Google Login Button (mocked → /rooms) */}
-          <Link
-            href="/rooms"
-            className="flex w-full items-center justify-center gap-3 rounded-xl border px-6 py-3.5 text-sm font-medium transition-all hover:shadow-lg"
-            style={{
-              backgroundColor: "#fff",
-              borderColor: "#dadce0",
-              color: "#3c4043",
+          {/* Google Login Button */}
+          <form
+            action={async () => {
+              "use server";
+              await signIn("google", { redirectTo: "/rooms" });
             }}
           >
-            <svg width="18" height="18" viewBox="0 0 18 18">
-              <path
-                fill="#4285F4"
-                d="M16.51 8H8.98v3h4.3c-.18 1-.74 1.48-1.6 2.04v2.01h2.6a7.8 7.8 0 0 0 2.38-5.88c0-.57-.05-.66-.15-1.18z"
-              />
-              <path
-                fill="#34A853"
-                d="M8.98 17c2.16 0 3.97-.72 5.3-1.94l-2.6-2a4.8 4.8 0 0 1-7.18-2.54H1.83v2.07A8 8 0 0 0 8.98 17z"
-              />
-              <path
-                fill="#FBBC05"
-                d="M4.5 10.52a4.8 4.8 0 0 1 0-3.04V5.41H1.83a8 8 0 0 0 0 7.18z"
-              />
-              <path
-                fill="#EA4335"
-                d="M8.98 4.18c1.17 0 2.23.4 3.06 1.2l2.3-2.3A8 8 0 0 0 1.83 5.4L4.5 7.49a4.77 4.77 0 0 1 4.48-3.31z"
-              />
-            </svg>
-            Googleでログイン
-          </Link>
+            <button
+              type="submit"
+              className="flex w-full items-center justify-center gap-3 rounded-xl border px-6 py-3.5 text-sm font-medium transition-all hover:shadow-lg"
+              style={{
+                backgroundColor: "#fff",
+                borderColor: "#dadce0",
+                color: "#3c4043",
+              }}
+            >
+              <svg width="18" height="18" viewBox="0 0 18 18">
+                <path
+                  fill="#4285F4"
+                  d="M16.51 8H8.98v3h4.3c-.18 1-.74 1.48-1.6 2.04v2.01h2.6a7.8 7.8 0 0 0 2.38-5.88c0-.57-.05-.66-.15-1.18z"
+                />
+                <path
+                  fill="#34A853"
+                  d="M8.98 17c2.16 0 3.97-.72 5.3-1.94l-2.6-2a4.8 4.8 0 0 1-7.18-2.54H1.83v2.07A8 8 0 0 0 8.98 17z"
+                />
+                <path
+                  fill="#FBBC05"
+                  d="M4.5 10.52a4.8 4.8 0 0 1 0-3.04V5.41H1.83a8 8 0 0 0 0 7.18z"
+                />
+                <path
+                  fill="#EA4335"
+                  d="M8.98 4.18c1.17 0 2.23.4 3.06 1.2l2.3-2.3A8 8 0 0 0 1.83 5.4L4.5 7.49a4.77 4.77 0 0 1 4.48-3.31z"
+                />
+              </svg>
+              Googleでログイン
+            </button>
+          </form>
 
           <p className="mt-4 text-center text-xs" style={{ color: "var(--text-muted)" }}>
             ログインすることで

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -1,0 +1,23 @@
+import type { NextAuthConfig } from "next-auth";
+import Google from "next-auth/providers/google";
+
+export const authConfig = {
+  providers: [Google],
+  pages: {
+    signIn: "/login",
+  },
+  callbacks: {
+    authorized({ auth, request: { nextUrl } }) {
+      const isLoggedIn = !!auth?.user;
+      const pathname = nextUrl.pathname;
+
+      if (pathname === "/login") {
+        if (isLoggedIn) return Response.redirect(new URL("/rooms", nextUrl));
+        return true;
+      }
+
+      if (!isLoggedIn) return false;
+      return true;
+    },
+  },
+} satisfies NextAuthConfig;

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,66 @@
+import NextAuth from "next-auth";
+import { authConfig } from "./auth.config";
+import { prisma } from "@/lib/prisma";
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  ...authConfig,
+  session: { strategy: "jwt" },
+  callbacks: {
+    authorized: authConfig.callbacks.authorized,
+    async signIn({ profile }) {
+      if (!profile?.sub) return false;
+
+      const existing = await prisma.user.findUnique({
+        where: { googleId: profile.sub },
+        select: { id: true },
+      });
+
+      if (!existing) {
+        const baseUsername = String(profile.sub).slice(0, 50);
+        await prisma.user.create({
+          data: {
+            googleId: profile.sub,
+            username: baseUsername,
+            iconUrl: (profile.picture as string | undefined) ?? null,
+          },
+        });
+      } else {
+        await prisma.user.update({
+          where: { googleId: profile.sub },
+          data: { iconUrl: (profile.picture as string | undefined) ?? null },
+        });
+      }
+
+      return true;
+    },
+    async jwt({ token, profile }) {
+      if (profile?.sub) {
+        const user = await prisma.user.findUnique({
+          where: { googleId: profile.sub },
+          select: {
+            id: true,
+            username: true,
+            iconUrl: true,
+            avgRating: true,
+          },
+        });
+        if (user) {
+          token["userId"] = user.id;
+          token["username"] = user.username;
+          token["iconUrl"] = user.iconUrl;
+          token["avgRating"] = Number(user.avgRating);
+        }
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (token["userId"]) {
+        session.user.id = token["userId"] as string;
+        session.user.username = token["username"] as string;
+        session.user.iconUrl = (token["iconUrl"] as string | null) ?? null;
+        session.user.avgRating = token["avgRating"] as number;
+      }
+      return session;
+    },
+  },
+});

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -3,8 +3,9 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
-import { Gamepad2, Users, LogOut, Menu, X, Zap } from "lucide-react";
+import { Gamepad2, Users, Menu, X, Zap } from "lucide-react";
 import clsx from "clsx";
+import { SignOutButton } from "@/components/ui/SignOutButton";
 
 export function Header() {
   const pathname = usePathname();
@@ -64,14 +65,7 @@ export function Header() {
             </Link>
           ))}
           <div className="mx-2 h-6 w-px" style={{ backgroundColor: "var(--border)" }} />
-          <Link
-            href="/login"
-            className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-all hover:text-red-400"
-            style={{ color: "var(--text-secondary)" }}
-          >
-            <LogOut className="h-4 w-4" />
-            ログアウト
-          </Link>
+          <SignOutButton />
         </nav>
 
         {/* Mobile Menu Button */}
@@ -108,14 +102,7 @@ export function Header() {
                 {label}
               </Link>
             ))}
-            <Link
-              href="/login"
-              className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium text-red-400"
-              onClick={() => setMobileOpen(false)}
-            >
-              <LogOut className="h-4 w-4" />
-              ログアウト
-            </Link>
+            <SignOutButton />
           </nav>
         </div>
       )}

--- a/components/ui/SignOutButton.tsx
+++ b/components/ui/SignOutButton.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+import { LogOut } from "lucide-react";
+
+export function SignOutButton() {
+  return (
+    <button
+      onClick={() => void signOut({ callbackUrl: "/login" })}
+      className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-all hover:text-red-400"
+      style={{ color: "var(--text-secondary)" }}
+    >
+      <LogOut className="h-4 w-4" />
+      ログアウト
+    </button>
+  );
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,19 @@
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+function createPrismaClient() {
+  const pool = new Pool({ connectionString: process.env["DATABASE_URL"] });
+  const adapter = new PrismaPg(pool);
+  return new PrismaClient({ adapter });
+}
+
+export const prisma = globalForPrisma.prisma ?? createPrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,8 @@
+import NextAuth from "next-auth";
+import { authConfig } from "@/auth.config";
+
+export const { auth: middleware } = NextAuth(authConfig);
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
+    "@auth/prisma-adapter": "^2.11.1",
     "@prisma/adapter-pg": "^7.4.1",
     "@prisma/client": "^7.4.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.469.0",
     "next": "16.1.6",
+    "next-auth": "5.0.0-beta.30",
     "pg": "^8.18.0",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@auth/prisma-adapter':
+        specifier: ^2.11.1
+        version: 2.11.1(@prisma/client@7.4.1(prisma@7.4.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))
       '@prisma/adapter-pg':
         specifier: ^7.4.1
         version: 7.4.1
@@ -23,6 +26,9 @@ importers:
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next-auth:
+        specifier: 5.0.0-beta.30
+        version: 5.0.0-beta.30(next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       pg:
         specifier: ^8.18.0
         version: 8.18.0
@@ -72,6 +78,39 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@auth/core@0.41.0':
+    resolution: {integrity: sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^6.8.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
+  '@auth/core@0.41.1':
+    resolution: {integrity: sha512-t9cJ2zNYAdWMacGRMT6+r4xr1uybIdmYa49calBPeTqwgAFPV/88ac9TEvCR85pvATiSPt8VaNf+Gt24JIT/uw==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^7.0.7
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
+  '@auth/prisma-adapter@2.11.1':
+    resolution: {integrity: sha512-Ke7DXP0Fy0Mlmjz/ZJLXwQash2UkA4621xCM0rMtEczr1kppLc/njCbUkHkIQ/PnmILjqSPEKeTjDPsYruvkug==}
+    peerDependencies:
+      '@prisma/client': '>=2.26.0 || >=3 || >=4 || >=5 || >=6'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -640,6 +679,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@prisma/adapter-pg@7.4.1':
     resolution: {integrity: sha512-AH9XrqvSoBAaStn0Gm/sAnF97pDKz8uLpNmn51j1S9O9dhUva6LIxGdoDiiU9VXRIR89wAJXsvJSy+mK40m2xw==}
@@ -1752,6 +1794,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1956,6 +2001,22 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-auth@5.0.0-beta.30:
+    resolution: {integrity: sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
+      nodemailer: ^7.0.7
+      react: ^18.2.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
   next@16.1.6:
     resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
     engines: {node: '>=20.9.0'}
@@ -1991,6 +2052,9 @@ packages:
     resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  oauth4webapi@3.8.5:
+    resolution: {integrity: sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2147,6 +2211,14 @@ packages:
   postgres@3.4.7:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
     engines: {node: '>=12'}
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2539,6 +2611,31 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@auth/core@0.41.0':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.1.3
+      oauth4webapi: 3.8.5
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  '@auth/core@0.41.1':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.1.3
+      oauth4webapi: 3.8.5
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  '@auth/prisma-adapter@2.11.1(@prisma/client@7.4.1(prisma@7.4.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))':
+    dependencies:
+      '@auth/core': 0.41.1
+      '@prisma/client': 7.4.1(prisma@7.4.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@simplewebauthn/browser'
+      - '@simplewebauthn/server'
+      - nodemailer
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2991,6 +3088,8 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@panva/hkdf@1.2.1': {}
 
   '@prisma/adapter-pg@7.4.1':
     dependencies:
@@ -4296,6 +4395,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.1.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -4460,6 +4561,12 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-auth@5.0.0-beta.30(next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@auth/core': 0.41.0
+      next: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+
   next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.6
@@ -4500,6 +4607,8 @@ snapshots:
       citty: 0.2.1
       pathe: 2.0.3
       tinyexec: 1.0.2
+
+  oauth4webapi@3.8.5: {}
 
   object-assign@4.1.1: {}
 
@@ -4656,6 +4765,12 @@ snapshots:
       xtend: 4.0.2
 
   postgres@3.4.7: {}
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   prelude-ls@1.2.1: {}
 

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,13 +1,8 @@
 import { defineConfig } from "prisma/config";
-import { PrismaPg } from "@prisma/adapter-pg";
 
 export default defineConfig({
   schema: "./prisma/schema.prisma",
-  migrate: {
-    async adapter(env: NodeJS.ProcessEnv) {
-      const { Pool } = await import("pg");
-      const pool = new Pool({ connectionString: env["DATABASE_URL"] });
-      return new PrismaPg(pool);
-    },
+  datasource: {
+    url: process.env["DATABASE_URL"],
   },
 });

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,21 @@
+import type { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+      username: string;
+      iconUrl: string | null;
+      avgRating: number;
+    } & DefaultSession["user"];
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    userId?: string;
+    username?: string;
+    iconUrl?: string | null;
+    avgRating?: number;
+  }
+}


### PR DESCRIPTION
## Summary

- `auth.config.ts`: エッジ対応のGoogle OAuthプロバイダー設定 + ルート保護（未認証→`/login`、ログイン済みで`/login`→`/rooms`）
- `auth.ts`: JWT戦略のセッション管理 + Prismaでのユーザー upsert（初回ログイン時に`users`テーブルに自動登録）
- `middleware.ts`: 全保護ルートの認証チェック
- `app/api/auth/[...nextauth]/route.ts`: NextAuth APIハンドラー
- `lib/prisma.ts`: Prisma 7 pg アダプター対応のシングルトンクライアント
- `types/next-auth.d.ts`: Session型に `userId`, `username`, `iconUrl`, `avgRating` を追加
- `app/login/page.tsx`: Server ActionでGoogleサインインボタンを実装
- `components/ui/SignOutButton.tsx`: クライアントサイドのサインアウトボタン
- `prisma.config.ts`: Prisma 7対応の正しいdatasource設定に修正

## 補足

- セッションはJWT戦略（`strategy: "jwt"`）を採用。`users`テーブルへのユーザー永続化はsignInコールバックで実施
- 必要な環境変数: `AUTH_SECRET`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `DATABASE_URL`（`.env.example`参照）

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)