### PR TITLE
feat: 初回ログイン時プロフィール設定強制フロー

### DIFF
--- a/app/api/v1/users/me/route.ts
+++ b/app/api/v1/users/me/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function PATCH(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = (await request.json()) as {
+    username?: string;
+    bio?: string;
+    iconUrl?: string | null;
+  };
+
+  const { username, bio, iconUrl } = body;
+
+  if (username !== undefined) {
+    if (typeof username !== "string" || username.trim().length === 0) {
+      return NextResponse.json(
+        { error: "ユーザー名は必須です" },
+        { status: 400 }
+      );
+    }
+    if (username.trim().length > 50) {
+      return NextResponse.json(
+        { error: "ユーザー名は50文字以内で入力してください" },
+        { status: 400 }
+      );
+    }
+  }
+
+  if (bio !== undefined && typeof bio === "string" && bio.length > 500) {
+    return NextResponse.json(
+      { error: "自己紹介は500文字以内で入力してください" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const user = await prisma.user.update({
+      where: { id: session.user.id },
+      data: {
+        ...(username !== undefined && { username: username.trim() }),
+        ...(bio !== undefined && { bio: bio || null }),
+        ...(iconUrl !== undefined && { iconUrl: iconUrl || null }),
+      },
+      select: {
+        id: true,
+        username: true,
+        iconUrl: true,
+        bio: true,
+        avgRating: true,
+      },
+    });
+
+    return NextResponse.json({ data: user });
+  } catch (error) {
+    // ユーザー名の一意制約違反
+    if (
+      error instanceof Error &&
+      error.message.includes("Unique constraint")
+    ) {
+      return NextResponse.json(
+        { error: "このユーザー名はすでに使用されています" },
+        { status: 409 }
+      );
+    }
+    return NextResponse.json(
+      { error: "プロフィールの更新に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { Header } from "@/components/ui/Header";
+import { Providers } from "./providers";
 
 export const metadata: Metadata = {
   title: "QuestLink - ゲーム仲間を見つけよう",
@@ -15,8 +16,10 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className="antialiased min-h-screen" style={{ backgroundColor: "var(--bg-base)", color: "var(--text-primary)" }}>
-        <Header />
-        <main className="min-h-[calc(100vh-64px)]">{children}</main>
+        <Providers>
+          <Header />
+          <main className="min-h-[calc(100vh-64px)]">{children}</main>
+        </Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/app/users/me/edit/page.tsx
+++ b/app/users/me/edit/page.tsx
@@ -2,21 +2,27 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { ArrowLeft, Save } from "lucide-react";
-import { CURRENT_USER, PLAY_STYLE_TAGS, type Game } from "@/lib/mock-data";
+import { PLAY_STYLE_TAGS, type Game } from "@/lib/mock-data";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { MultiGamePicker } from "@/components/ui/GamePicker";
 
 export default function EditProfilePage() {
   const router = useRouter();
-  const [username, setUsername] = useState(CURRENT_USER.username);
-  const [iconUrl, setIconUrl] = useState(CURRENT_USER.iconUrl ?? "");
-  const [bio, setBio] = useState(CURRENT_USER.bio ?? "");
-  const [selectedTagIds, setSelectedTagIds] = useState<string[]>(
-    CURRENT_USER.playStyleTags.map((t) => t.id)
-  );
-  const [selectedGames, setSelectedGames] = useState<Game[]>(CURRENT_USER.games);
+  const { data: session, update } = useSession();
+
+  const currentUsername = session?.user?.username ?? "";
+  const isInitialSetup = /^\d{15,}$/.test(currentUsername);
+
+  const [username, setUsername] = useState(isInitialSetup ? "" : currentUsername);
+  const [iconUrl, setIconUrl] = useState(session?.user?.iconUrl ?? "");
+  const [bio, setBio] = useState("");
+  const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
+  const [selectedGames, setSelectedGames] = useState<Game[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
 
   const toggleTag = (id: string) => {
     setSelectedTagIds((prev) =>
@@ -24,9 +30,37 @@ export default function EditProfilePage() {
     );
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    router.push("/users/me");
+    setError(null);
+    setSaving(true);
+
+    try {
+      const res = await fetch("/api/v1/users/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: username.trim(),
+          bio: bio || null,
+          iconUrl: iconUrl || null,
+        }),
+      });
+
+      const json = (await res.json()) as { error?: string };
+
+      if (!res.ok) {
+        setError(json.error ?? "エラーが発生しました");
+        return;
+      }
+
+      // JWTトークンを最新情報で更新してからリダイレクト
+      await update({ username: username.trim() });
+      router.push("/rooms");
+    } catch {
+      setError("通信エラーが発生しました。再度お試しください");
+    } finally {
+      setSaving(false);
+    }
   };
 
   const inputStyle = {
@@ -37,24 +71,31 @@ export default function EditProfilePage() {
 
   return (
     <div className="mx-auto max-w-2xl px-4 py-8 sm:px-6">
-      <Link
-        href="/users/me"
-        className="mb-6 flex items-center gap-2 text-sm transition-colors hover:text-white"
-        style={{ color: "var(--text-secondary)" }}
-      >
-        <ArrowLeft className="h-4 w-4" />
-        プロフィールに戻る
-      </Link>
+      {!isInitialSetup && (
+        <Link
+          href="/users/me"
+          className="mb-6 flex items-center gap-2 text-sm transition-colors hover:text-white"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          <ArrowLeft className="h-4 w-4" />
+          プロフィールに戻る
+        </Link>
+      )}
 
       <div
         className="rounded-2xl border p-8"
         style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
       >
-        <h1 className="mb-6 text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
-          プロフィール編集
+        <h1 className="mb-2 text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
+          {isInitialSetup ? "プロフィールを設定してください" : "プロフィール編集"}
         </h1>
+        {isInitialSetup && (
+          <p className="mb-6 text-sm" style={{ color: "var(--text-secondary)" }}>
+            ユーザー名を設定するとQuestLinkを利用できます
+          </p>
+        )}
 
-        <form onSubmit={handleSubmit} className="space-y-6">
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-6">
           {/* Avatar preview */}
           <div className="flex items-center gap-4">
             <UserAvatar username={username || "?"} iconUrl={iconUrl || null} size="xl" />
@@ -105,6 +146,7 @@ export default function EditProfilePage() {
               placeholder="プレイスタイルや得意なゲームについて教えてください..."
               value={bio}
               onChange={(e) => setBio(e.target.value)}
+              maxLength={500}
               className="w-full resize-none rounded-xl border px-4 py-2.5 text-sm outline-none focus:border-purple-500 transition-colors"
               style={inputStyle}
             />
@@ -148,7 +190,7 @@ export default function EditProfilePage() {
             </div>
           </div>
 
-          {/* Game Picker (multi) */}
+          {/* Game Picker */}
           <div>
             <label className="mb-1.5 block text-sm font-medium" style={{ color: "var(--text-primary)" }}>
               プレイしているゲーム{" "}
@@ -162,25 +204,35 @@ export default function EditProfilePage() {
             </p>
           </div>
 
+          {/* Error */}
+          {error && (
+            <p className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-400">
+              {error}
+            </p>
+          )}
+
           {/* Buttons */}
           <div className="flex gap-3 pt-2">
-            <Link
-              href="/users/me"
-              className="flex-1 rounded-xl border px-6 py-3 text-center text-sm font-medium transition-all hover:opacity-80"
-              style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
-            >
-              キャンセル
-            </Link>
+            {!isInitialSetup && (
+              <Link
+                href="/users/me"
+                className="flex-1 rounded-xl border px-6 py-3 text-center text-sm font-medium transition-all hover:opacity-80"
+                style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
+              >
+                キャンセル
+              </Link>
+            )}
             <button
               type="submit"
-              className="flex flex-1 items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90"
+              disabled={saving}
+              className="flex flex-1 items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90 disabled:opacity-50"
               style={{
                 background: "linear-gradient(135deg, var(--accent), #6d28d9)",
                 boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
               }}
             >
               <Save className="h-4 w-4" />
-              保存する
+              {saving ? "保存中..." : isInitialSetup ? "はじめる" : "保存する"}
             </button>
           </div>
         </form>

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -7,16 +7,33 @@ export const authConfig = {
     signIn: "/login",
   },
   callbacks: {
+    // セッションにusernameを含める（middlewareで参照するため）
+    session({ session, token }) {
+      if (token["username"]) {
+        session.user.username = token["username"] as string;
+      }
+      return session;
+    },
     authorized({ auth, request: { nextUrl } }) {
       const isLoggedIn = !!auth?.user;
       const pathname = nextUrl.pathname;
+      const isLoginPage = pathname === "/login";
+      const isEditPage = pathname === "/users/me/edit";
 
-      if (pathname === "/login") {
+      if (isLoginPage) {
         if (isLoggedIn) return Response.redirect(new URL("/rooms", nextUrl));
         return true;
       }
 
       if (!isLoggedIn) return false;
+
+      // Google sub IDのまま（初回ログイン未設定）→ プロフィール設定画面へ強制
+      const username = auth?.user?.username ?? "";
+      const needsProfileSetup = /^\d{15,}$/.test(username);
+      if (needsProfileSetup && !isEditPage) {
+        return Response.redirect(new URL("/users/me/edit", nextUrl));
+      }
+
       return true;
     },
   },

--- a/auth.ts
+++ b/auth.ts
@@ -2,11 +2,20 @@ import NextAuth from "next-auth";
 import { authConfig } from "./auth.config";
 import { prisma } from "@/lib/prisma";
 
-export const { handlers, auth, signIn, signOut } = NextAuth({
+export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
   ...authConfig,
   session: { strategy: "jwt" },
   callbacks: {
     authorized: authConfig.callbacks.authorized,
+    session({ session, token }) {
+      if (token["userId"]) {
+        session.user.id = token["userId"] as string;
+        session.user.username = token["username"] as string;
+        session.user.iconUrl = (token["iconUrl"] as string | null) ?? null;
+        session.user.avgRating = token["avgRating"] as number;
+      }
+      return session;
+    },
     async signIn({ profile }) {
       if (!profile?.sub) return false;
 
@@ -16,11 +25,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       });
 
       if (!existing) {
-        const baseUsername = String(profile.sub).slice(0, 50);
+        // 初回ログイン: usernameをGoogle sub IDで仮登録（Issue #4で更新）
         await prisma.user.create({
           data: {
             googleId: profile.sub,
-            username: baseUsername,
+            username: String(profile.sub).slice(0, 50),
             iconUrl: (profile.picture as string | undefined) ?? null,
           },
         });
@@ -33,7 +42,22 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
       return true;
     },
-    async jwt({ token, profile }) {
+    async jwt({ token, profile, trigger }) {
+      // セッション更新時（プロフィール設定完了後）: DBから最新usernameを取得
+      if (trigger === "update" && token["userId"]) {
+        const user = await prisma.user.findUnique({
+          where: { id: token["userId"] as string },
+          select: { username: true, iconUrl: true, avgRating: true },
+        });
+        if (user) {
+          token["username"] = user.username;
+          token["iconUrl"] = user.iconUrl;
+          token["avgRating"] = Number(user.avgRating);
+        }
+        return token;
+      }
+
+      // 初回ログイン時: DBからユーザー情報を取得してトークンに格納
       if (profile?.sub) {
         const user = await prisma.user.findUnique({
           where: { googleId: profile.sub },
@@ -51,16 +75,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           token["avgRating"] = Number(user.avgRating);
         }
       }
+
       return token;
-    },
-    async session({ session, token }) {
-      if (token["userId"]) {
-        session.user.id = token["userId"] as string;
-        session.user.username = token["username"] as string;
-        session.user.iconUrl = (token["iconUrl"] as string | null) ?? null;
-        session.user.avgRating = token["avgRating"] as number;
-      }
-      return session;
     },
   },
 });


### PR DESCRIPTION
## Summary

- `app/providers.tsx`: `SessionProvider` ラッパーを追加し `layout.tsx` に適用（`useSession` / `update` を全クライアントコンポーネントから使用可能に）
- `auth.config.ts`: session callback で `username` をミドルウェアに公開、authorized callback で `username` が Google sub ID形式（15桁以上の数字列）の場合に `/users/me/edit` へリダイレクト
- `auth.ts`: `unstable_update` をエクスポート、`trigger === "update"` 時にDBから最新の `username` を取得してJWTを更新
- `PATCH /api/v1/users/me`: username / bio / iconUrl の更新エンドポイント（バリデーション・一意制約エラーハンドリング含む）
- `app/users/me/edit/page.tsx`: APIへの保存 → `session.update()` でJWT更新 → `/rooms` へリダイレクト。初回設定時は専用UIを表示

## フロー

```
初回Googleログイン
  → username = Google sub ID（数字列）で仮登録
  → middleware: username が数字列 → /users/me/edit へリダイレクト
  → ユーザーがusernameを入力して送信
  → PATCH /api/v1/users/me でDB更新
  → session.update() でJWT更新（triggerで最新username取得）
  → /rooms へリダイレクト → middleware通過
```

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)