### PR TITLE
feat: 部屋参加・退出・ホスト移譲API実装

### DIFF
--- a/app/api/v1/rooms/[roomId]/join/route.ts
+++ b/app/api/v1/rooms/[roomId]/join/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+
+type RouteParams = { params: Promise<{ roomId: string }> };
+
+export async function POST(_request: Request, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "認証が必要です" } },
+      { status: 401 }
+    );
+  }
+
+  const { roomId } = await params;
+  const userId = session.user.id;
+
+  const room = await prisma.room.findUnique({
+    where: { id: roomId },
+    select: { id: true, status: true, maxPlayers: true },
+  });
+
+  if (!room) {
+    return NextResponse.json(
+      { error: { code: "ROOM_NOT_FOUND", message: "部屋が存在しません" } },
+      { status: 404 }
+    );
+  }
+
+  if (room.status === "closed") {
+    return NextResponse.json(
+      { error: { code: "ROOM_CLOSED", message: "この部屋は解散済みです" } },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const participant = await prisma.$transaction(
+      async (tx) => {
+        // SELECT FOR UPDATE でロックを取得し競合状態を防ぐ
+        await tx.$queryRaw`SELECT id FROM rooms WHERE id = ${roomId}::uuid FOR UPDATE`;
+
+        const [currentCount, existing] = await Promise.all([
+          tx.roomParticipant.count({ where: { roomId, leftAt: null } }),
+          tx.roomParticipant.findFirst({ where: { roomId, userId, leftAt: null } }),
+        ]);
+
+        if (existing) {
+          throw new Error("ALREADY_JOINED");
+        }
+
+        if (currentCount >= room.maxPlayers) {
+          throw new Error("ROOM_FULL");
+        }
+
+        const newParticipant = await tx.roomParticipant.create({
+          data: { roomId, userId, isHost: false },
+        });
+
+        // 満員到達時に status を playing へ自動遷移
+        if (currentCount + 1 >= room.maxPlayers) {
+          await tx.room.update({
+            where: { id: roomId },
+            data: { status: "playing" },
+          });
+        }
+
+        return newParticipant;
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
+
+    return NextResponse.json({
+      data: {
+        roomId: participant.roomId,
+        userId: participant.userId,
+        isHost: participant.isHost,
+        joinedAt: participant.joinedAt,
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === "ALREADY_JOINED") {
+        return NextResponse.json(
+          { error: { code: "ALREADY_JOINED", message: "既にこの部屋に参加しています" } },
+          { status: 409 }
+        );
+      }
+      if (error.message === "ROOM_FULL") {
+        return NextResponse.json(
+          { error: { code: "ROOM_FULL", message: "この部屋は満員です" } },
+          { status: 409 }
+        );
+      }
+    }
+    throw error;
+  }
+}

--- a/app/api/v1/rooms/[roomId]/leave/route.ts
+++ b/app/api/v1/rooms/[roomId]/leave/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+type RouteParams = { params: Promise<{ roomId: string }> };
+
+export async function POST(_request: Request, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "認証が必要です" } },
+      { status: 401 }
+    );
+  }
+
+  const { roomId } = await params;
+  const userId = session.user.id;
+
+  const room = await prisma.room.findUnique({
+    where: { id: roomId },
+    select: { id: true, status: true },
+  });
+
+  if (!room) {
+    return NextResponse.json(
+      { error: { code: "ROOM_NOT_FOUND", message: "部屋が存在しません" } },
+      { status: 404 }
+    );
+  }
+
+  const participant = await prisma.roomParticipant.findFirst({
+    where: { roomId, userId, leftAt: null },
+  });
+
+  if (!participant) {
+    return NextResponse.json(
+      { error: { code: "NOT_IN_ROOM", message: "この部屋に参加していません" } },
+      { status: 400 }
+    );
+  }
+
+  const now = new Date();
+
+  await prisma.$transaction(async (tx) => {
+    // 退室時刻を記録
+    await tx.roomParticipant.update({
+      where: { id: participant.id },
+      data: { leftAt: now },
+    });
+
+    if (participant.isHost) {
+      // ホスト退室: 最も早く参加した残余参加者へ引き継ぎ
+      const nextHost = await tx.roomParticipant.findFirst({
+        where: { roomId, leftAt: null, userId: { not: userId } },
+        orderBy: { joinedAt: "asc" },
+        select: { id: true, userId: true, user: { select: { username: true } } },
+      });
+
+      if (nextHost) {
+        await tx.roomParticipant.update({
+          where: { id: nextHost.id },
+          data: { isHost: true },
+        });
+        await tx.room.update({
+          where: { id: roomId },
+          data: { hostId: nextHost.userId },
+        });
+        // ホスト変更のシステムメッセージ
+        await tx.chatMessage.create({
+          data: {
+            roomId,
+            content: `${nextHost.user.username}さんがホストになりました`,
+            isSystem: true,
+          },
+        });
+      } else {
+        // 残余参加者なし → 部屋を closed に
+        await tx.room.update({
+          where: { id: roomId },
+          data: { status: "closed", closedAt: now },
+        });
+      }
+    }
+  });
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/rooms/[roomId]/RoomActions.tsx
+++ b/app/rooms/[roomId]/RoomActions.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { DoorOpen, LogOut, Loader2, Trash2 } from "lucide-react";
-import { closeRoom } from "@/lib/api/rooms";
+import { joinRoom, leaveRoom, closeRoom } from "@/lib/api/rooms";
 
 type Props = {
   roomId: string;
@@ -16,6 +15,21 @@ type Props = {
 export function RoomActions({ roomId, isParticipant, isHost, status }: Props) {
   const router = useRouter();
   const queryClient = useQueryClient();
+
+  const joinMutation = useMutation({
+    mutationFn: () => joinRoom(roomId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["room", roomId] });
+      await queryClient.invalidateQueries({ queryKey: ["rooms"] });
+    },
+  });
+
+  const leaveMutation = useMutation({
+    mutationFn: () => leaveRoom(roomId),
+    onSuccess: () => {
+      router.push(`/rooms/${roomId}/ratings`);
+    },
+  });
 
   const closeMutation = useMutation({
     mutationFn: () => closeRoom(roomId),
@@ -39,48 +53,72 @@ export function RoomActions({ roomId, isParticipant, isHost, status }: Props) {
 
   if (!isParticipant) {
     return (
-      <button
-        onClick={() => router.push(`/rooms/${roomId}`)}
-        className="flex w-full items-center justify-center gap-2 rounded-xl px-6 py-3.5 text-sm font-semibold text-white transition-all hover:opacity-90"
-        style={{
-          background: "linear-gradient(135deg, var(--accent), #6d28d9)",
-          boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
-        }}
-      >
-        <DoorOpen className="h-4 w-4" />
-        参加する
-      </button>
+      <div className="flex flex-col gap-2">
+        <button
+          onClick={() => joinMutation.mutate()}
+          disabled={joinMutation.isPending || status === "playing"}
+          className="flex w-full items-center justify-center gap-2 rounded-xl px-6 py-3.5 text-sm font-semibold text-white transition-all hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+          style={{
+            background: "linear-gradient(135deg, var(--accent), #6d28d9)",
+            boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
+          }}
+        >
+          {joinMutation.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <DoorOpen className="h-4 w-4" />
+          )}
+          {status === "playing" ? "満員" : "参加する"}
+        </button>
+        {joinMutation.isError && (
+          <p className="text-center text-xs" style={{ color: "#f87171" }}>
+            {joinMutation.error.message}
+          </p>
+        )}
+      </div>
     );
   }
 
   return (
-    <div className="flex gap-3">
-      <Link
-        href={`/rooms/${roomId}/ratings`}
-        className="flex flex-1 items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
-        style={{
-          borderColor: "var(--border)",
-          color: "var(--text-secondary)",
-          backgroundColor: "var(--bg-card)",
-        }}
-      >
-        <LogOut className="h-4 w-4" />
-        退室する
-      </Link>
-      {isHost && (
+    <div className="flex flex-col gap-2">
+      <div className="flex gap-3">
         <button
-          onClick={() => closeMutation.mutate()}
-          disabled={closeMutation.isPending}
-          className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-red-500/30 px-4 py-3 text-sm font-medium text-red-400 transition-all hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed"
-          style={{ backgroundColor: "rgba(239,68,68,0.05)" }}
+          onClick={() => leaveMutation.mutate()}
+          disabled={leaveMutation.isPending}
+          className="flex flex-1 items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80 disabled:opacity-50 disabled:cursor-not-allowed"
+          style={{
+            borderColor: "var(--border)",
+            color: "var(--text-secondary)",
+            backgroundColor: "var(--bg-card)",
+          }}
         >
-          {closeMutation.isPending ? (
+          {leaveMutation.isPending ? (
             <Loader2 className="h-4 w-4 animate-spin" />
           ) : (
-            <Trash2 className="h-4 w-4" />
+            <LogOut className="h-4 w-4" />
           )}
-          解散する
+          退室する
         </button>
+        {isHost && (
+          <button
+            onClick={() => closeMutation.mutate()}
+            disabled={closeMutation.isPending}
+            className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-red-500/30 px-4 py-3 text-sm font-medium text-red-400 transition-all hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{ backgroundColor: "rgba(239,68,68,0.05)" }}
+          >
+            {closeMutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Trash2 className="h-4 w-4" />
+            )}
+            解散する
+          </button>
+        )}
+      </div>
+      {leaveMutation.isError && (
+        <p className="text-center text-xs" style={{ color: "#f87171" }}>
+          {leaveMutation.error.message}
+        </p>
       )}
     </div>
   );

--- a/lib/api/rooms.ts
+++ b/lib/api/rooms.ts
@@ -121,3 +121,35 @@ export async function closeRoom(roomId: string): Promise<void> {
     throw new Error(body.error?.message ?? "部屋の解散に失敗しました");
   }
 }
+
+export type JoinRoomResponse = {
+  data: {
+    roomId: string;
+    userId: string;
+    isHost: boolean;
+    joinedAt: string;
+  };
+};
+
+export async function joinRoom(roomId: string): Promise<JoinRoomResponse> {
+  const res = await fetch(`/api/v1/rooms/${roomId}/join`, {
+    method: "POST",
+    credentials: "include",
+  });
+  if (!res.ok) {
+    const body = (await res.json()) as { error?: { code: string; message: string } };
+    throw new Error(body.error?.message ?? "部屋への参加に失敗しました");
+  }
+  return res.json() as Promise<JoinRoomResponse>;
+}
+
+export async function leaveRoom(roomId: string): Promise<void> {
+  const res = await fetch(`/api/v1/rooms/${roomId}/leave`, {
+    method: "POST",
+    credentials: "include",
+  });
+  if (!res.ok) {
+    const body = (await res.json()) as { error?: { code: string; message: string } };
+    throw new Error(body.error?.message ?? "退室に失敗しました");
+  }
+}


### PR DESCRIPTION
## Summary

- `POST /api/v1/rooms/:roomId/join` を実装（重複参加不可、満員チェック、満員時に `playing` へ自動遷移）
- `POST /api/v1/rooms/:roomId/leave` を実装（`left_at` 更新、ホスト退出時の自動引き継ぎ、参加者0人なら `closed` に更新）
- `lib/api/rooms.ts` に `joinRoom` / `leaveRoom` 関数を追加
- `RoomActions.tsx` を join/leave API に接続し、ローディング・エラー表示を追加

## Test plan

- [x] 参加ボタンで `room_participants` にレコードが追加される
- [ ] 最大人数到達時に `rooms.status` が `playing` に自動更新される
- [x] 満員の部屋に参加しようとすると409エラーが返る
- [ ] 既に参加中の部屋に再参加しようとすると409エラーが返る
- [x] 退出すると `room_participants.left_at` が更新される
- [ ] ホストが退出すると参加者の中から次のホストへ自動引き継がれる
- [ ] ホスト退出時に参加者が0人なら `status = 'closed'` になる
- [x] `pnpm lint` でエラーなし

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)