### PR TITLE
feat: 単体テスト: UIコンポーネント（PlayStyleTag / RoomCard）

### DIFF
--- a/components/ui/PlayStyleTag.test.tsx
+++ b/components/ui/PlayStyleTag.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PlayStyleTag } from "./PlayStyleTag";
+
+const tag = { id: "t1", name: "ガチ", slug: "serious" };
+
+describe("PlayStyleTag", () => {
+  it("タグ名が表示される", () => {
+    render(<PlayStyleTag tag={tag} />);
+    expect(screen.getByText("ガチ")).toBeInTheDocument();
+  });
+
+  it('size="sm" のとき px-2 クラスが付与される', () => {
+    render(<PlayStyleTag tag={tag} size="sm" />);
+    expect(screen.getByText("ガチ")).toHaveClass("px-2");
+  });
+
+  it('size="md"（デフォルト）のとき px-3 クラスが付与される', () => {
+    render(<PlayStyleTag tag={tag} />);
+    expect(screen.getByText("ガチ")).toHaveClass("px-3");
+  });
+
+  it("className prop がマージされる", () => {
+    render(<PlayStyleTag tag={tag} className="custom-class" />);
+    expect(screen.getByText("ガチ")).toHaveClass("custom-class");
+  });
+});

--- a/components/ui/RoomCard.test.tsx
+++ b/components/ui/RoomCard.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { RoomSummary } from "@/lib/api/rooms";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("./GamePicker", () => ({
+  GameCover: () => <div data-testid="game-cover" />,
+}));
+
+vi.mock("./StarRating", () => ({
+  RatingDisplay: () => <div data-testid="rating-display" />,
+}));
+
+vi.mock("./UserAvatar", () => ({
+  UserAvatar: () => <div data-testid="user-avatar" />,
+}));
+
+vi.mock("lucide-react", () => ({
+  Users: () => <span />,
+}));
+
+import { RoomCard } from "./RoomCard";
+
+const mockRoom: RoomSummary = {
+  id: "room-1",
+  title: "テストルーム",
+  description: "説明文",
+  game: { id: "g1", name: "Apex Legends", coverImageUrl: null },
+  maxPlayers: 3,
+  currentPlayers: 2,
+  status: "waiting",
+  playStyleTags: [{ id: "t1", name: "ガチ", slug: "serious" }],
+  host: { id: "u1", username: "testuser", iconUrl: null, avgRating: 4.5 },
+  createdAt: "2026-03-11T00:00:00Z",
+};
+
+describe("RoomCard", () => {
+  it("ルームタイトルが表示される", () => {
+    render(<RoomCard room={mockRoom} />);
+    expect(screen.getByText("テストルーム")).toBeInTheDocument();
+  });
+
+  it("ゲーム名が表示される", () => {
+    render(<RoomCard room={mockRoom} />);
+    expect(screen.getByText("Apex Legends")).toBeInTheDocument();
+  });
+
+  it("ホストのユーザー名が表示される", () => {
+    render(<RoomCard room={mockRoom} />);
+    expect(screen.getByText("testuser")).toBeInTheDocument();
+  });
+
+  it("プレイヤー数が「2/3」形式で表示される", () => {
+    render(<RoomCard room={mockRoom} />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("/3")).toBeInTheDocument();
+  });
+
+  it("PlayStyleTag のタグ名が表示される", () => {
+    render(<RoomCard room={mockRoom} />);
+    expect(screen.getByText("ガチ")).toBeInTheDocument();
+  });
+
+  it('status="waiting" のとき「募集中」が表示される', () => {
+    render(<RoomCard room={mockRoom} />);
+    expect(screen.getByText("募集中")).toBeInTheDocument();
+  });
+
+  it('status="closed" のとき「終了」が表示される', () => {
+    render(<RoomCard room={{ ...mockRoom, status: "closed" }} />);
+    expect(screen.getByText("終了")).toBeInTheDocument();
+  });
+
+  it("リンクの href が /rooms/room-1 になっている", () => {
+    render(<RoomCard room={mockRoom} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/rooms/room-1");
+  });
+});


### PR DESCRIPTION
## Summary
- `PlayStyleTag` コンポーネントの Vitest + Testing Library による単体テストを追加（4 tests）
- `RoomCard` コンポーネントの Vitest + Testing Library による単体テストを追加（8 tests）

## Test plan
- [x] `pnpm test` → 20 tests passed（全件グリーン）
- [x] `pnpm lint` → 0 errors

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)