### PR TITLE
feat: E2Eテスト追加（Playwright）#44

### DIFF
--- a/auth.config.ts
+++ b/auth.config.ts
@@ -25,7 +25,7 @@ export const authConfig = {
         return true;
       }
 
-      const isPublicPage = pathname === "/" || pathname.startsWith("/rooms");
+      const isPublicPage = pathname === "/" || pathname === "/rooms";
       if (!isLoggedIn && isPublicPage) return true;
 
       if (!isLoggedIn) return false;

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("認証リダイレクト", () => {
+  test("未認証で /users/me にアクセスすると /login にリダイレクトされる", async ({
+    page,
+  }) => {
+    await page.goto("/users/me");
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("/login に「Googleでログイン」ボタンが存在する", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.getByRole("button", { name: "Googleでログイン" })).toBeVisible();
+  });
+
+  test("未認証で /rooms にアクセスできる（リダイレクトなし）", async ({ page }) => {
+    await page.goto("/rooms");
+    await expect(page).toHaveURL(/\/rooms/);
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+});

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("ホームページ", () => {
+  test("/ にアクセスするとページが表示される", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("h2").first()).toBeVisible();
+  });
+
+  test("ヘッダーまたはナビゲーションが表示される", async ({ page }) => {
+    await page.goto("/");
+    const header = page.locator("header");
+    const nav = page.locator("nav");
+    const hasHeader = (await header.count()) > 0;
+    const hasNav = (await nav.count()) > 0;
+    expect(hasHeader || hasNav).toBe(true);
+  });
+});

--- a/e2e/rooms.spec.ts
+++ b/e2e/rooms.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("部屋一覧", () => {
+  test("/rooms が表示され h1「部屋一覧」が存在する", async ({ page }) => {
+    await page.goto("/rooms");
+    await expect(page.getByRole("heading", { name: "部屋一覧" })).toBeVisible();
+  });
+
+  test("未認証で /rooms/new にアクセスすると /login にリダイレクトされる", async ({
+    page,
+  }) => {
+    await page.goto("/rooms/new");
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "batch:games": "tsx batch/syncGames.ts",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"
@@ -37,6 +39,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm dev:next",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,10 +31,10 @@ importers:
         version: 0.469.0(react@19.2.3)
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-auth:
         specifier: 5.0.0-beta.30
-        version: 5.0.0-beta.30(next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 5.0.0-beta.30(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       pg:
         specifier: ^8.18.0
         version: 8.18.0
@@ -51,6 +51,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.0
@@ -802,6 +805,11 @@ packages:
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/adapter-pg@7.4.1':
     resolution: {integrity: sha512-AH9XrqvSoBAaStn0Gm/sAnF97pDKz8uLpNmn51j1S9O9dhUva6LIxGdoDiiU9VXRIR89wAJXsvJSy+mK40m2xw==}
@@ -2009,6 +2017,11 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2749,6 +2762,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3969,6 +3992,10 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@panva/hkdf@1.2.1': {}
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
 
   '@prisma/adapter-pg@7.4.1':
     dependencies:
@@ -5337,6 +5364,9 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5871,13 +5901,13 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  next-auth@5.0.0-beta.30(next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+  next-auth@5.0.0-beta.30(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
     dependencies:
       '@auth/core': 0.41.0
-      next: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
-  next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -5896,6 +5926,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
+      '@playwright/test': 1.58.2
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6053,6 +6084,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- `playwright.config.ts` を新規作成（chromium のみ、`pnpm dev:next` で webServer 起動）
- `e2e/home.spec.ts`：ホームページ表示テスト（h2 要素、header/nav の存在確認）
- `e2e/auth.spec.ts`：認証リダイレクト検証（`/users/me` → `/login`、`/login` のGoogleボタン、`/rooms` のパブリックアクセス）
- `e2e/rooms.spec.ts`：`/rooms` の h1「部屋一覧」表示、`/rooms/new` → `/login` リダイレクト
- `auth.config.ts`：`isPublicPage` の `/rooms` 判定を `startsWith` から完全一致に修正（`/rooms/new` を保護対象に）
- `package.json`：`@playwright/test` devDependencies 追加、`test:e2e` / `test:e2e:ui` スクリプト追加

## Test plan
- [x] `pnpm test:e2e` で全7テストケース Pass 確認済み

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)