### PR TITLE
feat: Docker Compose 開発環境構築（PostgreSQL 16 + Redis 7）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-# PostgreSQL接続URL（Supabase / Railway / ローカル）
-DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE?schema=public"
+# PostgreSQL接続URL（ローカル Docker: docker compose up -d）
+DATABASE_URL="postgresql://postgres:password@localhost:5432/questlink?schema=public"
 
 # NextAuth.js v5 シークレット（openssl rand -base64 32 で生成）
 AUTH_SECRET="your-secret-here"
@@ -13,3 +13,5 @@ AUTH_GOOGLE_SECRET="your-google-client-secret"
 TWITCH_CLIENT_ID=
 TWITCH_CLIENT_SECRET=
 
+# Redis（ローカル Docker: docker compose up -d）
+REDIS_URL="redis://localhost:6379"

--- a/README.md
+++ b/README.md
@@ -42,37 +42,40 @@ pnpm install
 
 ### 3. 環境変数の設定
 
-`.env.local` ファイルをプロジェクトルートに作成し、以下の変数を設定する。
+`.env` ファイルをプロジェクトルートに作成し、以下の変数を設定する。
 
 ```env
 # データベース
-DATABASE_URL="postgresql://postgres:password@localhost:5432/questlink"
+DATABASE_URL="postgresql://postgres:password@localhost:5432/questlink?schema=public"
 
-# NextAuth.js
-NEXTAUTH_URL="http://localhost:3000"
-NEXTAUTH_SECRET="your-secret-key"   # openssl rand -base64 32 で生成
+# NextAuth.js v5 シークレット（openssl rand -base64 32 で生成）
+AUTH_SECRET="your-secret-key"
 
 # Google OAuth 2.0
 # https://console.cloud.google.com/ で取得
-GOOGLE_CLIENT_ID="your-google-client-id"
-GOOGLE_CLIENT_SECRET="your-google-client-secret"
+AUTH_GOOGLE_ID="your-google-client-id"
+AUTH_GOOGLE_SECRET="your-google-client-secret"
 
 # IGDB API (Twitch Developer)
 # https://dev.twitch.tv/console で取得
 TWITCH_CLIENT_ID="your-twitch-client-id"
 TWITCH_CLIENT_SECRET="your-twitch-client-secret"
 
-# Redis（Phase 2 以降）
-# REDIS_URL="redis://localhost:6379"
+# Redis
+REDIS_URL="redis://localhost:6379"
 ```
 
 ### 4. データベースの起動
 
-Docker Compose で PostgreSQL を起動する。
+Docker Compose で PostgreSQL 16 と Redis 7 を起動する。
 
 ```bash
 docker compose up -d
 ```
+
+起動するサービス:
+- **postgres**: PostgreSQL 16（ポート 5432）
+- **redis**: Redis 7、AOF 永続化有効（ポート 6379）
 
 ### 5. データベースのマイグレーション
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  postgres:
+    image: postgres:16
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: questlink
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  redis_data:


### PR DESCRIPTION
## Summary
- `docker-compose.yml` を新規作成（PostgreSQL 16 + Redis 7、ヘルスチェック付き named volumes）
- `.env.example` に `REDIS_URL` を追加、`DATABASE_URL` をローカル Docker 向けデフォルト値に更新
- `README.md` の環境変数名を auth.js v5 の実際の変数名に修正（`AUTH_SECRET`、`AUTH_GOOGLE_ID`、`AUTH_GOOGLE_SECRET`）、`.env.local` → `.env`、`NEXTAUTH_URL` 削除、`REDIS_URL` 追記、セクション4にサービス説明を追加

Close #12

## Test plan
- [ ] `docker compose up -d` で postgres/redis 両コンテナが起動すること
- [ ] `pnpm db:migrate` でマイグレーションが成功すること
- [ ] `pnpm db:seed` でテストデータが投入できること
- [ ] `pnpm dev` で開発サーバーがポート 3000 で起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)