### PR TITLE
feat: 評価API実装とフロント連携 (Issue #11)

### DIFF
--- a/app/api/v1/rooms/[roomId]/pending-ratings/route.test.ts
+++ b/app/api/v1/rooms/[roomId]/pending-ratings/route.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/prisma", () => ({
       findUnique: vi.fn(),
     },
     roomParticipant: {
+      findFirst: vi.fn(),
       findMany: vi.fn(),
     },
     rating: {
@@ -24,6 +25,7 @@ import { GET } from "./route";
 
 const mockAuth = vi.mocked(auth);
 const mockRoomFindUnique = vi.mocked(prisma.room.findUnique);
+const mockParticipantFindFirst = vi.mocked(prisma.roomParticipant.findFirst);
 const mockParticipantFindMany = vi.mocked(prisma.roomParticipant.findMany);
 const mockRatingFindMany = vi.mocked(prisma.rating.findMany);
 
@@ -71,15 +73,39 @@ describe("GET /api/v1/rooms/[roomId]/pending-ratings", () => {
     expect(body.data).toEqual([]);
   });
 
-  it("closedAt が null の場合 200 で空配列を返す", async () => {
+  it("leftAt が null かつ closedAt が null の場合 200 で空配列を返す", async () => {
     mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
     mockRoomFindUnique.mockResolvedValue({ id: "room-1", closedAt: null } as never);
+    mockParticipantFindFirst.mockResolvedValue({ leftAt: null } as never);
 
     const res = await GET(makeRequest(), makeParams());
     const body = await res.json();
 
     expect(res.status).toBe(200);
     expect(body.data).toEqual([]);
+  });
+
+  it("leftAt が設定済み（room.closedAt null）の場合、正常取得できる", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockRoomFindUnique.mockResolvedValue({ id: "room-1", closedAt: null } as never);
+    const recentLeftAt = new Date(Date.now() - 60 * 60 * 1000); // 1時間前
+    mockParticipantFindFirst.mockResolvedValue({ leftAt: recentLeftAt } as never);
+
+    mockParticipantFindMany.mockResolvedValue([
+      {
+        userId: "user-2",
+        user: { username: "Player2", iconUrl: null, avgRating: null },
+      },
+    ] as never);
+
+    mockRatingFindMany.mockResolvedValue([]);
+
+    const res = await GET(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].userId).toBe("user-2");
   });
 
   it("正常取得: 自分を除く・評価済みを除く未評価ユーザーを返す", async () => {

--- a/app/api/v1/rooms/[roomId]/pending-ratings/route.test.ts
+++ b/app/api/v1/rooms/[roomId]/pending-ratings/route.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    room: {
+      findUnique: vi.fn(),
+    },
+    roomParticipant: {
+      findMany: vi.fn(),
+    },
+    rating: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { GET } from "./route";
+
+const mockAuth = vi.mocked(auth);
+const mockRoomFindUnique = vi.mocked(prisma.room.findUnique);
+const mockParticipantFindMany = vi.mocked(prisma.roomParticipant.findMany);
+const mockRatingFindMany = vi.mocked(prisma.rating.findMany);
+
+const makeRequest = () =>
+  new Request("http://localhost/api/v1/rooms/room-1/pending-ratings", { method: "GET" });
+const makeParams = () => ({ params: Promise.resolve({ roomId: "room-1" }) });
+
+const closedAt = new Date(Date.now() - 60 * 60 * 1000); // 1時間前
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/v1/rooms/[roomId]/pending-ratings", () => {
+  it("未認証の場合 401 UNAUTHORIZED を返す", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const res = await GET(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("room が存在しない場合 404 ROOM_NOT_FOUND を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockRoomFindUnique.mockResolvedValue(null);
+
+    const res = await GET(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error.code).toBe("ROOM_NOT_FOUND");
+  });
+
+  it("24時間超過の場合 200 で空配列を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    const expiredClosedAt = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    mockRoomFindUnique.mockResolvedValue({ id: "room-1", closedAt: expiredClosedAt } as never);
+
+    const res = await GET(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toEqual([]);
+  });
+
+  it("closedAt が null の場合 200 で空配列を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockRoomFindUnique.mockResolvedValue({ id: "room-1", closedAt: null } as never);
+
+    const res = await GET(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toEqual([]);
+  });
+
+  it("正常取得: 自分を除く・評価済みを除く未評価ユーザーを返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockRoomFindUnique.mockResolvedValue({ id: "room-1", closedAt } as never);
+
+    // user-2 は未評価、user-3 は評価済み
+    mockParticipantFindMany.mockResolvedValue([
+      {
+        userId: "user-2",
+        user: { username: "Player2", iconUrl: null, avgRating: null },
+      },
+      {
+        userId: "user-3",
+        user: { username: "Player3", iconUrl: "https://example.com/icon.png", avgRating: 4.5 },
+      },
+    ] as never);
+
+    mockRatingFindMany.mockResolvedValue([{ revieweeId: "user-3" }] as never);
+
+    const res = await GET(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].userId).toBe("user-2");
+    expect(body.data[0].username).toBe("Player2");
+    expect(body.data[0].avgRating).toBeNull();
+    expect(body.data[0].expiresAt).toBeDefined();
+  });
+
+  it("全員評価済みの場合 200 で空配列を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockRoomFindUnique.mockResolvedValue({ id: "room-1", closedAt } as never);
+
+    mockParticipantFindMany.mockResolvedValue([
+      {
+        userId: "user-2",
+        user: { username: "Player2", iconUrl: null, avgRating: null },
+      },
+    ] as never);
+
+    mockRatingFindMany.mockResolvedValue([{ revieweeId: "user-2" }] as never);
+
+    const res = await GET(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toEqual([]);
+  });
+});

--- a/app/api/v1/rooms/[roomId]/pending-ratings/route.ts
+++ b/app/api/v1/rooms/[roomId]/pending-ratings/route.ts
@@ -28,11 +28,18 @@ export async function GET(_request: Request, { params }: RouteParams) {
     );
   }
 
-  if (!room.closedAt) {
+  const myParticipant = await prisma.roomParticipant.findFirst({
+    where: { roomId, userId: currentUserId },
+    select: { leftAt: true },
+  });
+
+  const baseTime = myParticipant?.leftAt ?? room.closedAt;
+
+  if (!baseTime) {
     return NextResponse.json({ data: [] });
   }
 
-  const expiresAt = new Date(room.closedAt.getTime() + 24 * 60 * 60 * 1000);
+  const expiresAt = new Date(baseTime.getTime() + 24 * 60 * 60 * 1000);
   const now = new Date();
 
   if (now > expiresAt) {

--- a/app/api/v1/rooms/[roomId]/pending-ratings/route.ts
+++ b/app/api/v1/rooms/[roomId]/pending-ratings/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+type RouteParams = { params: Promise<{ roomId: string }> };
+
+export async function GET(_request: Request, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "認証が必要です" } },
+      { status: 401 }
+    );
+  }
+
+  const { roomId } = await params;
+  const currentUserId = session.user.id;
+
+  const room = await prisma.room.findUnique({
+    where: { id: roomId },
+    select: { id: true, closedAt: true },
+  });
+
+  if (!room) {
+    return NextResponse.json(
+      { error: { code: "ROOM_NOT_FOUND", message: "部屋が存在しません" } },
+      { status: 404 }
+    );
+  }
+
+  if (!room.closedAt) {
+    return NextResponse.json({ data: [] });
+  }
+
+  const expiresAt = new Date(room.closedAt.getTime() + 24 * 60 * 60 * 1000);
+  const now = new Date();
+
+  if (now > expiresAt) {
+    return NextResponse.json({ data: [] });
+  }
+
+  const [participants, ratedUsers] = await Promise.all([
+    prisma.roomParticipant.findMany({
+      where: { roomId, userId: { not: currentUserId } },
+      select: {
+        userId: true,
+        user: {
+          select: {
+            username: true,
+            iconUrl: true,
+            avgRating: true,
+          },
+        },
+      },
+    }),
+    prisma.rating.findMany({
+      where: { roomId, reviewerId: currentUserId },
+      select: { revieweeId: true },
+    }),
+  ]);
+
+  const ratedUserIds = new Set(ratedUsers.map((r) => r.revieweeId));
+
+  const pendingUsers = participants
+    .filter((p) => p.userId !== null && !ratedUserIds.has(p.userId as string))
+    .map((p) => ({
+      userId: p.userId,
+      username: p.user?.username ?? "",
+      iconUrl: p.user?.iconUrl ?? null,
+      avgRating: p.user?.avgRating !== null && p.user?.avgRating !== undefined
+        ? Number(p.user.avgRating)
+        : null,
+      expiresAt,
+    }));
+
+  return NextResponse.json({ data: pendingUsers });
+}

--- a/app/api/v1/rooms/[roomId]/ratings/route.test.ts
+++ b/app/api/v1/rooms/[roomId]/ratings/route.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    room: {
+      findUnique: vi.fn(),
+    },
+    roomParticipant: {
+      findFirst: vi.fn(),
+    },
+    rating: {
+      findFirst: vi.fn(),
+      aggregate: vi.fn(),
+    },
+    user: {
+      update: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { POST } from "./route";
+
+const mockAuth = vi.mocked(auth);
+const mockRoomFindUnique = vi.mocked(prisma.room.findUnique);
+const mockParticipantFindFirst = vi.mocked(prisma.roomParticipant.findFirst);
+const mockRatingFindFirst = vi.mocked(prisma.rating.findFirst);
+const mockTransaction = vi.mocked(prisma.$transaction);
+
+type MockTx = {
+  rating: {
+    create: ReturnType<typeof vi.fn>;
+    aggregate: ReturnType<typeof vi.fn>;
+  };
+  user: {
+    update: ReturnType<typeof vi.fn>;
+  };
+};
+
+let mockTx: MockTx;
+
+const closedAt = new Date(Date.now() - 60 * 60 * 1000); // 1時間前
+const validRoom = { id: "room-1", closedAt };
+
+const makeRequest = (body: unknown = { revieweeId: "user-2", score: 4 }) =>
+  new Request("http://localhost/api/v1/rooms/room-1/ratings", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const makeParams = () => ({ params: Promise.resolve({ roomId: "room-1" }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockTx = {
+    rating: {
+      create: vi.fn(),
+      aggregate: vi.fn(),
+    },
+    user: {
+      update: vi.fn(),
+    },
+  };
+
+  mockTransaction.mockImplementation(async (fn) => fn(mockTx as never));
+});
+
+describe("POST /api/v1/rooms/[roomId]/ratings", () => {
+  it("未認証の場合 401 UNAUTHORIZED を返す", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("score が 0 の場合 400 INVALID_SCORE を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+
+    const res = await POST(makeRequest({ revieweeId: "user-2", score: 0 }), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("INVALID_SCORE");
+  });
+
+  it("score が 6 の場合 400 INVALID_SCORE を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+
+    const res = await POST(makeRequest({ revieweeId: "user-2", score: 6 }), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("INVALID_SCORE");
+  });
+
+  it("自己評価の場合 400 SELF_RATING を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+
+    const res = await POST(makeRequest({ revieweeId: "user-1", score: 3 }), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("SELF_RATING");
+  });
+
+  it("room が存在しない場合 404 ROOM_NOT_FOUND を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockRoomFindUnique.mockResolvedValue(null);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error.code).toBe("ROOM_NOT_FOUND");
+  });
+
+  it("24時間超過の場合 400 RATING_EXPIRED を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    const expiredClosedAt = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    mockRoomFindUnique.mockResolvedValue({ id: "room-1", closedAt: expiredClosedAt } as never);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("RATING_EXPIRED");
+  });
+
+  it("reviewer が参加者でない場合 403 NOT_PARTICIPATED を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockRoomFindUnique.mockResolvedValue(validRoom as never);
+    mockParticipantFindFirst.mockResolvedValue(null);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe("NOT_PARTICIPATED");
+  });
+
+  it("reviewee が参加者でない場合 403 NOT_PARTICIPATED を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockRoomFindUnique.mockResolvedValue(validRoom as never);
+    // reviewer は参加済み、reviewee は未参加
+    mockParticipantFindFirst
+      .mockResolvedValueOnce({ id: "p-1" } as never)
+      .mockResolvedValueOnce(null);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe("NOT_PARTICIPATED");
+  });
+
+  it("重複評価の場合 409 ALREADY_RATED を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockRoomFindUnique.mockResolvedValue(validRoom as never);
+    mockParticipantFindFirst.mockResolvedValue({ id: "p-1" } as never);
+    mockRatingFindFirst.mockResolvedValue({ id: "rating-1" } as never);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("ALREADY_RATED");
+  });
+
+  it("正常送信の場合 201 と rating データを返し user.update が呼ばれる", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockRoomFindUnique.mockResolvedValue(validRoom as never);
+    mockParticipantFindFirst.mockResolvedValue({ id: "p-1" } as never);
+    mockRatingFindFirst.mockResolvedValue(null);
+
+    const now = new Date();
+    const expiresAt = new Date(closedAt.getTime() + 24 * 60 * 60 * 1000);
+    const createdRating = {
+      id: "rating-1",
+      roomId: "room-1",
+      revieweeId: "user-2",
+      score: 4,
+      comment: null,
+      createdAt: now,
+      expiresAt,
+    };
+
+    mockTx.rating.create.mockResolvedValue(createdRating);
+    mockTx.rating.aggregate.mockResolvedValue({
+      _avg: { score: 4 },
+      _count: { score: 1 },
+    });
+    mockTx.user.update.mockResolvedValue({});
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.data.id).toBe("rating-1");
+    expect(body.data.roomId).toBe("room-1");
+    expect(body.data.revieweeId).toBe("user-2");
+    expect(body.data.score).toBe(4);
+    expect(mockTx.user.update).toHaveBeenCalledWith({
+      where: { id: "user-2" },
+      data: { avgRating: 4, ratingCount: 1 },
+    });
+  });
+});

--- a/app/api/v1/rooms/[roomId]/ratings/route.test.ts
+++ b/app/api/v1/rooms/[roomId]/ratings/route.test.ts
@@ -125,10 +125,23 @@ describe("POST /api/v1/rooms/[roomId]/ratings", () => {
     expect(body.error.code).toBe("ROOM_NOT_FOUND");
   });
 
+  it("reviewer の leftAt が null かつ room.closedAt も null の場合 400 NOT_LEFT を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockRoomFindUnique.mockResolvedValue({ id: "room-1", closedAt: null } as never);
+    mockParticipantFindFirst.mockResolvedValue({ leftAt: null } as never);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("NOT_LEFT");
+  });
+
   it("24時間超過の場合 400 RATING_EXPIRED を返す", async () => {
     mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
-    const expiredClosedAt = new Date(Date.now() - 25 * 60 * 60 * 1000);
-    mockRoomFindUnique.mockResolvedValue({ id: "room-1", closedAt: expiredClosedAt } as never);
+    const expiredLeftAt = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    mockRoomFindUnique.mockResolvedValue({ id: "room-1", closedAt: null } as never);
+    mockParticipantFindFirst.mockResolvedValue({ leftAt: expiredLeftAt } as never);
 
     const res = await POST(makeRequest(), makeParams());
     const body = await res.json();
@@ -175,6 +188,37 @@ describe("POST /api/v1/rooms/[roomId]/ratings", () => {
 
     expect(res.status).toBe(409);
     expect(body.error.code).toBe("ALREADY_RATED");
+  });
+
+  it("reviewer の leftAt が設定済み（room.closedAt が null）の場合 201 を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    const recentLeftAt = new Date(Date.now() - 60 * 60 * 1000); // 1時間前
+    mockRoomFindUnique.mockResolvedValue({ id: "room-1", closedAt: null } as never);
+    mockParticipantFindFirst
+      .mockResolvedValueOnce({ leftAt: recentLeftAt } as never)
+      .mockResolvedValueOnce({ leftAt: null } as never);
+    mockRatingFindFirst.mockResolvedValue(null);
+
+    const expiresAtFromLeftAt = new Date(recentLeftAt.getTime() + 24 * 60 * 60 * 1000);
+    const createdRating = {
+      id: "rating-1",
+      roomId: "room-1",
+      revieweeId: "user-2",
+      score: 4,
+      comment: null,
+      createdAt: new Date(),
+      expiresAt: expiresAtFromLeftAt,
+    };
+
+    mockTx.rating.create.mockResolvedValue(createdRating);
+    mockTx.rating.aggregate.mockResolvedValue({ _avg: { score: 4 }, _count: { score: 1 } });
+    mockTx.user.update.mockResolvedValue({});
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.data.id).toBe("rating-1");
   });
 
   it("正常送信の場合 201 と rating データを返し user.update が呼ばれる", async () => {

--- a/app/api/v1/rooms/[roomId]/ratings/route.ts
+++ b/app/api/v1/rooms/[roomId]/ratings/route.ts
@@ -1,0 +1,166 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+type RouteParams = { params: Promise<{ roomId: string }> };
+
+export async function POST(request: Request, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "認証が必要です" } },
+      { status: 401 }
+    );
+  }
+
+  const { roomId } = await params;
+  const reviewerId = session.user.id;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "INVALID_REQUEST", message: "リクエストボディが不正です" } },
+      { status: 400 }
+    );
+  }
+
+  const { revieweeId, score, comment } = body as {
+    revieweeId: unknown;
+    score: unknown;
+    comment?: unknown;
+  };
+
+  if (
+    typeof score !== "number" ||
+    !Number.isInteger(score) ||
+    score < 1 ||
+    score > 5
+  ) {
+    return NextResponse.json(
+      { error: { code: "INVALID_SCORE", message: "スコアは1〜5の整数で指定してください" } },
+      { status: 400 }
+    );
+  }
+
+  if (typeof revieweeId !== "string" || !revieweeId) {
+    return NextResponse.json(
+      { error: { code: "INVALID_REQUEST", message: "revieweeId が不正です" } },
+      { status: 400 }
+    );
+  }
+
+  if (revieweeId === reviewerId) {
+    return NextResponse.json(
+      { error: { code: "SELF_RATING", message: "自分自身を評価することはできません" } },
+      { status: 400 }
+    );
+  }
+
+  const room = await prisma.room.findUnique({
+    where: { id: roomId },
+    select: { id: true, closedAt: true },
+  });
+
+  if (!room) {
+    return NextResponse.json(
+      { error: { code: "ROOM_NOT_FOUND", message: "部屋が存在しません" } },
+      { status: 404 }
+    );
+  }
+
+  if (!room.closedAt) {
+    return NextResponse.json(
+      { error: { code: "ROOM_NOT_CLOSED", message: "部屋がまだ解散されていません" } },
+      { status: 400 }
+    );
+  }
+
+  const expiresAt = new Date(room.closedAt.getTime() + 24 * 60 * 60 * 1000);
+  const now = new Date();
+
+  if (now > expiresAt) {
+    return NextResponse.json(
+      { error: { code: "RATING_EXPIRED", message: "評価期限が切れています" } },
+      { status: 400 }
+    );
+  }
+
+  const reviewerParticipant = await prisma.roomParticipant.findFirst({
+    where: { roomId, userId: reviewerId },
+  });
+
+  if (!reviewerParticipant) {
+    return NextResponse.json(
+      { error: { code: "NOT_PARTICIPATED", message: "この部屋に参加していません" } },
+      { status: 403 }
+    );
+  }
+
+  const revieweeParticipant = await prisma.roomParticipant.findFirst({
+    where: { roomId, userId: revieweeId },
+  });
+
+  if (!revieweeParticipant) {
+    return NextResponse.json(
+      { error: { code: "NOT_PARTICIPATED", message: "評価対象のユーザーはこの部屋に参加していません" } },
+      { status: 403 }
+    );
+  }
+
+  const existing = await prisma.rating.findFirst({
+    where: { roomId, reviewerId, revieweeId },
+  });
+
+  if (existing) {
+    return NextResponse.json(
+      { error: { code: "ALREADY_RATED", message: "既にこのユーザーを評価済みです" } },
+      { status: 409 }
+    );
+  }
+
+  const rating = await prisma.$transaction(async (tx) => {
+    const newRating = await tx.rating.create({
+      data: {
+        roomId,
+        reviewerId,
+        revieweeId,
+        score,
+        comment: typeof comment === "string" ? comment : undefined,
+        expiresAt,
+      },
+    });
+
+    const aggregate = await tx.rating.aggregate({
+      where: { revieweeId },
+      _avg: { score: true },
+      _count: { score: true },
+    });
+
+    await tx.user.update({
+      where: { id: revieweeId },
+      data: {
+        avgRating: aggregate._avg.score ?? 0,
+        ratingCount: aggregate._count.score,
+      },
+    });
+
+    return newRating;
+  });
+
+  return NextResponse.json(
+    {
+      data: {
+        id: rating.id,
+        roomId: rating.roomId,
+        revieweeId: rating.revieweeId,
+        score: rating.score,
+        comment: rating.comment,
+        createdAt: rating.createdAt,
+        expiresAt: rating.expiresAt,
+      },
+    },
+    { status: 201 }
+  );
+}

--- a/app/api/v1/rooms/[roomId]/ratings/route.ts
+++ b/app/api/v1/rooms/[roomId]/ratings/route.ts
@@ -70,31 +70,34 @@ export async function POST(request: Request, { params }: RouteParams) {
     );
   }
 
-  if (!room.closedAt) {
-    return NextResponse.json(
-      { error: { code: "ROOM_NOT_CLOSED", message: "部屋がまだ解散されていません" } },
-      { status: 400 }
-    );
-  }
-
-  const expiresAt = new Date(room.closedAt.getTime() + 24 * 60 * 60 * 1000);
-  const now = new Date();
-
-  if (now > expiresAt) {
-    return NextResponse.json(
-      { error: { code: "RATING_EXPIRED", message: "評価期限が切れています" } },
-      { status: 400 }
-    );
-  }
-
   const reviewerParticipant = await prisma.roomParticipant.findFirst({
     where: { roomId, userId: reviewerId },
+    select: { leftAt: true },
   });
 
   if (!reviewerParticipant) {
     return NextResponse.json(
       { error: { code: "NOT_PARTICIPATED", message: "この部屋に参加していません" } },
       { status: 403 }
+    );
+  }
+
+  const baseTime = reviewerParticipant.leftAt ?? room.closedAt;
+
+  if (!baseTime) {
+    return NextResponse.json(
+      { error: { code: "NOT_LEFT", message: "まだ部屋に参加中です" } },
+      { status: 400 }
+    );
+  }
+
+  const expiresAt = new Date(baseTime.getTime() + 24 * 60 * 60 * 1000);
+  const now = new Date();
+
+  if (now > expiresAt) {
+    return NextResponse.json(
+      { error: { code: "RATING_EXPIRED", message: "評価期限が切れています" } },
+      { status: 400 }
     );
   }
 

--- a/app/rooms/[roomId]/ratings/RatingForm.tsx
+++ b/app/rooms/[roomId]/ratings/RatingForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
 import { CheckCircle2 } from "lucide-react";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { StarRating, RatingDisplay } from "@/components/ui/StarRating";
@@ -19,18 +20,45 @@ type Props = {
   roomId: string;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function RatingForm({ user, roomId: _roomId }: Props) {
+type RatingPayload = {
+  revieweeId: string;
+  score: number;
+  comment?: string;
+};
+
+async function postRating(roomId: string, payload: RatingPayload) {
+  const res = await fetch(`/api/v1/rooms/${roomId}/ratings`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { error?: { message?: string } }).error?.message ?? "評価の送信に失敗しました"
+    );
+  }
+  return res.json();
+}
+
+export function RatingForm({ user, roomId }: Props) {
   const [score, setScore] = useState<number | null>(null);
   const [comment, setComment] = useState("");
-  const [submitted, setSubmitted] = useState(false);
+
+  const mutation = useMutation({
+    mutationFn: (payload: RatingPayload) => postRating(roomId, payload),
+  });
 
   const handleSubmit = () => {
     if (!score) return;
-    setSubmitted(true);
+    mutation.mutate({
+      revieweeId: user.userId,
+      score,
+      comment: comment || undefined,
+    });
   };
 
-  if (submitted) {
+  if (mutation.isSuccess) {
     return (
       <div
         className="flex items-center gap-4 rounded-2xl border p-5 opacity-60"
@@ -95,20 +123,27 @@ export function RatingForm({ user, roomId: _roomId }: Props) {
         />
       </div>
 
+      {mutation.isError && (
+        <p className="mb-3 text-xs text-red-400">
+          {mutation.error instanceof Error ? mutation.error.message : "評価の送信に失敗しました"}
+        </p>
+      )}
+
       <button
         onClick={handleSubmit}
-        disabled={!score}
+        disabled={!score || mutation.isPending}
         className={clsx(
           "w-full rounded-xl py-2.5 text-sm font-semibold text-white transition-all",
-          score ? "hover:opacity-90" : "opacity-40 cursor-not-allowed"
+          score && !mutation.isPending ? "hover:opacity-90" : "opacity-40 cursor-not-allowed"
         )}
         style={{
-          background: score
-            ? "linear-gradient(135deg, var(--accent), #6d28d9)"
-            : "var(--border)",
+          background:
+            score && !mutation.isPending
+              ? "linear-gradient(135deg, var(--accent), #6d28d9)"
+              : "var(--border)",
         }}
       >
-        評価を送信
+        {mutation.isPending ? "送信中..." : "評価を送信"}
       </button>
     </div>
   );

--- a/app/rooms/[roomId]/ratings/page.tsx
+++ b/app/rooms/[roomId]/ratings/page.tsx
@@ -16,8 +16,12 @@ export default async function RatingsPage({ params }: Props) {
   const currentUserId = session?.user?.id;
   if (!currentUserId) redirect("/login");
 
-  const [room, participants, submittedRatings] = await Promise.all([
+  const [room, myParticipant, participants, submittedRatings] = await Promise.all([
     prisma.room.findUnique({ where: { id: roomId }, select: { closedAt: true } }),
+    prisma.roomParticipant.findFirst({
+      where: { roomId, userId: currentUserId },
+      select: { leftAt: true },
+    }),
     prisma.roomParticipant.findMany({
       where: { roomId, userId: { not: currentUserId } },
       select: {
@@ -34,8 +38,9 @@ export default async function RatingsPage({ params }: Props) {
 
   const ratedIds = new Set(submittedRatings.map((r) => r.revieweeId));
   const now = new Date();
-  const expiresAt = room.closedAt
-    ? new Date(room.closedAt.getTime() + 24 * 60 * 60 * 1000)
+  const baseTime = myParticipant?.leftAt ?? room.closedAt;
+  const expiresAt = baseTime
+    ? new Date(baseTime.getTime() + 24 * 60 * 60 * 1000)
     : new Date(now.getTime() + 24 * 60 * 60 * 1000);
 
   const pendingUsers = participants


### PR DESCRIPTION
## Summary

- `POST /api/v1/rooms/[roomId]/ratings` 実装: 認証・バリデーション・期限チェック・参加者確認・重複チェック・トランザクションによるrating作成とユーザー統計更新
- `GET /api/v1/rooms/[roomId]/pending-ratings` 実装: 自分以外の参加者から評価済みを除いた未評価ユーザー一覧
- `RatingForm.tsx` API連携: `useMutation` (TanStack Query v5) でPOST接続、isPending/isError状態のUI対応

## Test plan

- [ ] `pnpm test ratings` — 16件すべてパスすること
- [ ] `pnpm lint` — ESLintエラーなし
- [ ] closed ルームの評価ページを開き、スター評価→送信でDBに保存される
- [ ] 24時間超過ルームで 400 RATING_EXPIRED が返る
- [ ] 同一ペアで2回目の評価が 409 ALREADY_RATED になる

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)