### PR TITLE
feat: /rooms/current へのサーバーサイドリダイレクト実装 (#63)

### DIFF
--- a/app/rooms/[roomId]/RoomDetailView.tsx
+++ b/app/rooms/[roomId]/RoomDetailView.tsx
@@ -55,7 +55,12 @@ export function RoomDetailView({ roomId }: Props) {
   }
 
   const room = data.data;
-  const status = statusConfig[room.status];
+  const status = statusConfig[room.status as keyof typeof statusConfig] ?? {
+    label: room.status,
+    bg: "rgba(100,100,120,0.15)",
+    color: "#8888aa",
+    border: "rgba(100,100,120,0.3)",
+  };
   const isParticipant = room.participants.some((p) => p.userId === currentUserId);
   const isHost = room.host.id === currentUserId;
 

--- a/app/rooms/current/chat/page.tsx
+++ b/app/rooms/current/chat/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+export default async function CurrentRoomChatPage() {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) redirect("/login");
+
+  const participant = await prisma.roomParticipant.findFirst({
+    where: { userId, leftAt: null, room: { status: { not: "closed" } } },
+    select: { roomId: true },
+  });
+
+  if (!participant) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen gap-4 text-center">
+        <p className="text-gray-400 text-lg">参加中の部屋がありません</p>
+        <Link
+          href="/rooms"
+          className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors"
+        >
+          部屋を探す
+        </Link>
+      </div>
+    );
+  }
+
+  redirect(`/rooms/${participant.roomId}/chat`);
+}

--- a/app/rooms/current/page.tsx
+++ b/app/rooms/current/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+export default async function CurrentRoomPage() {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) redirect("/login");
+
+  const participant = await prisma.roomParticipant.findFirst({
+    where: { userId, leftAt: null, room: { status: { not: "closed" } } },
+    select: { roomId: true },
+  });
+
+  if (!participant) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen gap-4 text-center">
+        <p className="text-gray-400 text-lg">参加中の部屋がありません</p>
+        <Link
+          href="/rooms"
+          className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors"
+        >
+          部屋を探す
+        </Link>
+      </div>
+    );
+  }
+
+  redirect(`/rooms/${participant.roomId}`);
+}


### PR DESCRIPTION
## Summary

- `/rooms/current` および `/rooms/current/chat` にアクセスした際、ログイン済みかつ参加中ルームがあれば `/rooms/{roomId}` / `/rooms/{roomId}/chat` へサーバーサイドリダイレクト
- 参加中ルームがない場合は「参加中の部屋がありません」画面を表示
- 未ログイン時は既存 middleware により `/login` へリダイレクト（変更なし）
- `RoomDetailView` で `status` が `undefined` のときに発生していた TypeError を修正
- `docs/06_sitemap.md` に `/rooms/current` ルートを追記

## 受け入れ基準

- [x] ログイン済み・参加中 → `/rooms/current` で `/rooms/{roomId}` へリダイレクト
- [x] ログイン済み・参加中 → `/rooms/current/chat` で `/rooms/{roomId}/chat` へリダイレクト
- [x] ログイン済み・未参加 → 「参加中の部屋がありません」画面表示（`/rooms/current`）
- [x] ログイン済み・未参加 → 「参加中の部屋がありません」画面表示（`/rooms/current/chat`）
- [x] 未ログイン → middleware により `/login` へリダイレクト

## Test plan

- [x] 開発サーバー起動: `pnpm dev`
- [x] ログイン済み・参加中ルームあり状態で `/rooms/current` にアクセス → `/rooms/{roomId}` にリダイレクトされること
- [x] ログイン済み・参加中ルームあり状態で `/rooms/current/chat` にアクセス → `/rooms/{roomId}/chat` にリダイレクトされること
- [x] ログイン済み・参加中ルームなし状態で `/rooms/current` にアクセス → 「参加中の部屋がありません」画面が表示されること
- [x] 未ログイン状態で `/rooms/current` にアクセス → `/login` にリダイレクトされること
- [x] ルーム詳細ページで status が undefined のルームを表示しても TypeError が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)