### PR TITLE
feat: X / Discord OAuth ログイン追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,16 @@ AUTH_SECRET="your-secret-here"
 AUTH_GOOGLE_ID="your-google-client-id"
 AUTH_GOOGLE_SECRET="your-google-client-secret"
 
+# X (Twitter) OAuth 認証情報（Twitter Developer Portal で取得）
+# 承認済みリダイレクトURI: http://localhost:3000/api/auth/callback/twitter
+AUTH_TWITTER_ID="your-twitter-client-id"
+AUTH_TWITTER_SECRET="your-twitter-client-secret"
+
+# Discord OAuth 認証情報（Discord Developer Portal で取得）
+# 承認済みリダイレクトURI: http://localhost:3000/api/auth/callback/discord
+AUTH_DISCORD_ID="your-discord-client-id"
+AUTH_DISCORD_SECRET="your-discord-client-secret"
+
 # Twitch API / IGDB (syncGames batch)
 TWITCH_CLIENT_ID=
 TWITCH_CLIENT_SECRET=

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -43,46 +43,94 @@ export default async function LoginPage({ searchParams }: Props) {
             ログイン
           </h2>
           <p className="mb-6 text-center text-sm" style={{ color: "var(--text-secondary)" }}>
-            Googleアカウントでかんたんにはじめられます
+            ソーシャルアカウントでかんたんにはじめられます
           </p>
 
-          {/* Google Login Button */}
-          <form
-            action={async () => {
-              "use server";
-              await signIn("google", { redirectTo });
-            }}
-          >
-            <button
-              type="submit"
-              className="flex w-full items-center justify-center gap-3 rounded-xl border px-6 py-3.5 text-sm font-medium transition-all hover:shadow-lg active:scale-[0.97]"
-              style={{
-                backgroundColor: "#fff",
-                borderColor: "#dadce0",
-                color: "#3c4043",
+          <div className="space-y-3">
+            {/* Google Login Button */}
+            <form
+              action={async () => {
+                "use server";
+                await signIn("google", { redirectTo });
               }}
             >
-              <svg width="18" height="18" viewBox="0 0 18 18">
-                <path
-                  fill="#4285F4"
-                  d="M16.51 8H8.98v3h4.3c-.18 1-.74 1.48-1.6 2.04v2.01h2.6a7.8 7.8 0 0 0 2.38-5.88c0-.57-.05-.66-.15-1.18z"
-                />
-                <path
-                  fill="#34A853"
-                  d="M8.98 17c2.16 0 3.97-.72 5.3-1.94l-2.6-2a4.8 4.8 0 0 1-7.18-2.54H1.83v2.07A8 8 0 0 0 8.98 17z"
-                />
-                <path
-                  fill="#FBBC05"
-                  d="M4.5 10.52a4.8 4.8 0 0 1 0-3.04V5.41H1.83a8 8 0 0 0 0 7.18z"
-                />
-                <path
-                  fill="#EA4335"
-                  d="M8.98 4.18c1.17 0 2.23.4 3.06 1.2l2.3-2.3A8 8 0 0 0 1.83 5.4L4.5 7.49a4.77 4.77 0 0 1 4.48-3.31z"
-                />
-              </svg>
-              Googleでログイン
-            </button>
-          </form>
+              <button
+                type="submit"
+                className="flex w-full items-center justify-center gap-3 rounded-xl border px-6 py-3.5 text-sm font-medium transition-all hover:shadow-lg active:scale-[0.97]"
+                style={{
+                  backgroundColor: "#fff",
+                  borderColor: "#dadce0",
+                  color: "#3c4043",
+                }}
+              >
+                <svg width="18" height="18" viewBox="0 0 18 18">
+                  <path
+                    fill="#4285F4"
+                    d="M16.51 8H8.98v3h4.3c-.18 1-.74 1.48-1.6 2.04v2.01h2.6a7.8 7.8 0 0 0 2.38-5.88c0-.57-.05-.66-.15-1.18z"
+                  />
+                  <path
+                    fill="#34A853"
+                    d="M8.98 17c2.16 0 3.97-.72 5.3-1.94l-2.6-2a4.8 4.8 0 0 1-7.18-2.54H1.83v2.07A8 8 0 0 0 8.98 17z"
+                  />
+                  <path
+                    fill="#FBBC05"
+                    d="M4.5 10.52a4.8 4.8 0 0 1 0-3.04V5.41H1.83a8 8 0 0 0 0 7.18z"
+                  />
+                  <path
+                    fill="#EA4335"
+                    d="M8.98 4.18c1.17 0 2.23.4 3.06 1.2l2.3-2.3A8 8 0 0 0 1.83 5.4L4.5 7.49a4.77 4.77 0 0 1 4.48-3.31z"
+                  />
+                </svg>
+                Googleでログイン
+              </button>
+            </form>
+
+            {/* X (Twitter) Login Button */}
+            <form
+              action={async () => {
+                "use server";
+                await signIn("twitter", { redirectTo });
+              }}
+            >
+              <button
+                type="submit"
+                className="flex w-full items-center justify-center gap-3 rounded-xl border px-6 py-3.5 text-sm font-medium transition-all hover:opacity-80 active:scale-[0.97]"
+                style={{
+                  backgroundColor: "#000",
+                  borderColor: "#333",
+                  color: "#fff",
+                }}
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                </svg>
+                X（Twitter）でログイン
+              </button>
+            </form>
+
+            {/* Discord Login Button */}
+            <form
+              action={async () => {
+                "use server";
+                await signIn("discord", { redirectTo });
+              }}
+            >
+              <button
+                type="submit"
+                className="flex w-full items-center justify-center gap-3 rounded-xl border px-6 py-3.5 text-sm font-medium transition-all hover:opacity-80 active:scale-[0.97]"
+                style={{
+                  backgroundColor: "#5865F2",
+                  borderColor: "#4752c4",
+                  color: "#fff",
+                }}
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057c.002.022.015.043.03.056a19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+                </svg>
+                Discordでログイン
+              </button>
+            </form>
+          </div>
 
           <p className="mt-4 text-center text-xs" style={{ color: "var(--text-muted)" }}>
             ログインすることで

--- a/app/users/me/edit/page.tsx
+++ b/app/users/me/edit/page.tsx
@@ -43,8 +43,8 @@ export default function EditProfilePage() {
   const router = useRouter();
   const { data: session, update, status } = useSession();
 
-  const currentUsername = session?.user?.username ?? "";
-  const isInitialSetup = status === "authenticated" && /^\d{15,}$/.test(currentUsername);
+  const isInitialSetup =
+    status === "authenticated" && (session?.user?.needsProfileSetup ?? false);
 
   const { data: profile } = useQuery({
     queryKey: ["users", "me"],
@@ -57,7 +57,7 @@ export default function EditProfilePage() {
     queryFn: fetchPlayStyleTags,
   });
 
-  const [username, setUsername] = useState(isInitialSetup ? "" : currentUsername);
+  const [username, setUsername] = useState(isInitialSetup ? "" : (session?.user?.username ?? ""));
   const [iconUrl, setIconUrl] = useState(session?.user?.iconUrl ?? "");
   const [bio, setBio] = useState("");
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -1,8 +1,16 @@
 import type { NextAuthConfig } from "next-auth";
 import Google from "next-auth/providers/google";
+import Twitter from "next-auth/providers/twitter";
+import Discord from "next-auth/providers/discord";
 
 export const authConfig = {
-  providers: [Google],
+  providers: [
+    Google,
+    Twitter,
+    Discord({
+      authorization: { params: { scope: "identify email" } },
+    }),
+  ],
   pages: {
     signIn: "/login",
   },
@@ -12,6 +20,7 @@ export const authConfig = {
       if (token["username"]) {
         session.user.username = token["username"] as string;
       }
+      session.user.needsProfileSetup = (token["needsProfileSetup"] as boolean | undefined) ?? false;
       return session;
     },
     authorized({ auth, request: { nextUrl } }) {
@@ -30,9 +39,8 @@ export const authConfig = {
 
       if (!isLoggedIn) return false;
 
-      // Google sub IDのまま（初回ログイン未設定）→ プロフィール設定画面へ強制
-      const username = auth?.user?.username ?? "";
-      const needsProfileSetup = /^\d{15,}$/.test(username);
+      // 初回ログイン未設定 → プロフィール設定画面へ強制
+      const needsProfileSetup = auth?.user?.needsProfileSetup ?? false;
       if (needsProfileSetup && !isEditPage) {
         return Response.redirect(new URL("/users/me/edit", nextUrl));
       }

--- a/auth.ts
+++ b/auth.ts
@@ -1,6 +1,11 @@
 import NextAuth from "next-auth";
 import { authConfig } from "./auth.config";
 import { prisma } from "@/lib/prisma";
+import {
+  toDbProvider,
+  extractProviderUserId,
+  extractAvatarUrl,
+} from "@/lib/auth-providers";
 
 export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
   ...authConfig,
@@ -14,13 +19,27 @@ export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
         session.user.iconUrl = (token["iconUrl"] as string | null) ?? null;
         session.user.avgRating = token["avgRating"] as number;
       }
+      session.user.needsProfileSetup =
+        (token["needsProfileSetup"] as boolean | undefined) ?? false;
       return session;
     },
-    async signIn({ profile }) {
-      if (!profile?.sub) return false;
+    async signIn({ account, profile }) {
+      if (!account?.provider || !profile) return false;
+
+      const provider = toDbProvider(account.provider);
+      const providerUserId = extractProviderUserId(
+        account.provider,
+        profile as Record<string, unknown>
+      );
+      if (!providerUserId) return false;
+
+      const avatarUrl = extractAvatarUrl(
+        account.provider,
+        profile as Record<string, unknown>
+      );
 
       const existing = await prisma.oauthProviderAccount.findUnique({
-        where: { provider_providerUserId: { provider: "google", providerUserId: profile.sub } },
+        where: { provider_providerUserId: { provider, providerUserId } },
         select: { userId: true },
       });
 
@@ -28,28 +47,28 @@ export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
         // 初回ログイン: ユーザーを作成し OAuth アカウントを紐づける
         const user = await prisma.user.create({
           data: {
-            username: String(profile.sub).slice(0, 50),
-            iconUrl: (profile.picture as string | undefined) ?? null,
+            username: providerUserId.slice(0, 50),
+            iconUrl: avatarUrl,
           },
           select: { id: true },
         });
         await prisma.oauthProviderAccount.create({
           data: {
             userId: user.id,
-            provider: "google",
-            providerUserId: profile.sub,
+            provider,
+            providerUserId,
           },
         });
       } else {
         await prisma.user.update({
           where: { id: existing.userId },
-          data: { iconUrl: (profile.picture as string | undefined) ?? null },
+          data: { iconUrl: avatarUrl },
         });
       }
 
       return true;
     },
-    async jwt({ token, profile, trigger }) {
+    async jwt({ token, account, profile, trigger }) {
       // セッション更新時（プロフィール設定完了後）: DBから最新usernameを取得
       if (trigger === "update" && token["userId"]) {
         const user = await prisma.user.findUnique({
@@ -60,25 +79,39 @@ export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
           token["username"] = user.username;
           token["iconUrl"] = user.iconUrl;
           token["avgRating"] = Number(user.avgRating);
+          token["needsProfileSetup"] = false;
         }
         return token;
       }
 
       // 初回ログイン時: DBからユーザー情報を取得してトークンに格納
-      if (profile?.sub) {
-        const account = await prisma.oauthProviderAccount.findUnique({
-          where: { provider_providerUserId: { provider: "google", providerUserId: profile.sub } },
-          select: {
-            user: {
-              select: { id: true, username: true, iconUrl: true, avgRating: true },
+      if (account?.provider && profile) {
+        const provider = toDbProvider(account.provider);
+        const providerUserId = extractProviderUserId(
+          account.provider,
+          profile as Record<string, unknown>
+        );
+        if (providerUserId) {
+          const oauthAccount = await prisma.oauthProviderAccount.findUnique({
+            where: {
+              provider_providerUserId: { provider, providerUserId },
             },
-          },
-        });
-        if (account?.user) {
-          token["userId"] = account.user.id;
-          token["username"] = account.user.username;
-          token["iconUrl"] = account.user.iconUrl;
-          token["avgRating"] = Number(account.user.avgRating);
+            select: {
+              user: {
+                select: { id: true, username: true, iconUrl: true, avgRating: true },
+              },
+            },
+          });
+          if (oauthAccount?.user) {
+            const { id, username, iconUrl, avgRating } = oauthAccount.user;
+            token["userId"] = id;
+            token["username"] = username;
+            token["iconUrl"] = iconUrl;
+            token["avgRating"] = Number(avgRating);
+            // username がプロバイダIDのままなら初回セットアップが必要
+            token["needsProfileSetup"] =
+              username === providerUserId.slice(0, 50);
+          }
         }
       }
 

--- a/lib/auth-providers.ts
+++ b/lib/auth-providers.ts
@@ -1,0 +1,64 @@
+import type { OauthProvider } from "@prisma/client";
+
+/**
+ * NextAuth provider ID → Prisma OauthProvider enum
+ * NextAuth uses "twitter" for X (formerly Twitter)
+ */
+export function toDbProvider(provider: string): OauthProvider {
+  if (provider === "twitter") return "x";
+  if (provider === "google") return "google";
+  if (provider === "discord") return "discord";
+  throw new Error(`Unsupported provider: ${provider}`);
+}
+
+/**
+ * Extract the provider-specific user ID from the OAuth profile.
+ * - Google: profile.sub (standard OIDC)
+ * - Twitter (X): profile.data.id (Twitter v2 API)
+ * - Discord: profile.id
+ */
+export function extractProviderUserId(
+  provider: string,
+  profile: Record<string, unknown>
+): string | null {
+  if (provider === "google") {
+    return typeof profile.sub === "string" ? profile.sub : null;
+  }
+  if (provider === "twitter") {
+    const data = profile.data as Record<string, unknown> | undefined;
+    return typeof data?.id === "string" ? data.id : null;
+  }
+  if (provider === "discord") {
+    return typeof profile.id === "string" ? profile.id : null;
+  }
+  return null;
+}
+
+/**
+ * Extract an avatar URL from the OAuth profile.
+ * Falls back to null if not available.
+ */
+export function extractAvatarUrl(
+  provider: string,
+  profile: Record<string, unknown>
+): string | null {
+  if (provider === "google") {
+    return typeof profile.picture === "string" ? profile.picture : null;
+  }
+  if (provider === "twitter") {
+    const data = profile.data as Record<string, unknown> | undefined;
+    return typeof data?.profile_image_url === "string"
+      ? data.profile_image_url
+      : null;
+  }
+  if (provider === "discord") {
+    // Discord avatar: https://cdn.discordapp.com/avatars/{id}/{avatar}.png
+    const id = profile.id as string | undefined;
+    const avatar = profile.avatar as string | null | undefined;
+    if (id && avatar) {
+      return `https://cdn.discordapp.com/avatars/${id}/${avatar}.png`;
+    }
+    return null;
+  }
+  return null;
+}

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -7,6 +7,7 @@ declare module "next-auth" {
       username: string;
       iconUrl: string | null;
       avgRating: number;
+      needsProfileSetup: boolean;
     } & DefaultSession["user"];
   }
 }
@@ -17,5 +18,6 @@ declare module "next-auth/jwt" {
     username?: string;
     iconUrl?: string | null;
     avgRating?: number;
+    needsProfileSetup?: boolean;
   }
 }


### PR DESCRIPTION
## 概要

Issue #27 対応。Google のみだった OAuth 認証に **X（Twitter）** と **Discord** を追加し、ゲーマーが日常的に使う SNS アカウントでログインできるようにします。

## 変更内容

- **`lib/auth-providers.ts`**（新規）— プロバイダマッピングユーティリティ
  - `toDbProvider()`: NextAuth provider ID → Prisma enum（`"twitter"` → `"x"`）
  - `extractProviderUserId()`: プロバイダごとのユーザーID抽出
  - `extractAvatarUrl()`: プロバイダごとのアバターURL抽出
- **`types/next-auth.d.ts`** — `needsProfileSetup: boolean` を Session・JWT に追加
- **`auth.config.ts`** — Twitter/Discord プロバイダ追加、`authorized` コールバックの正規表現判定を廃止し `needsProfileSetup` フラグに統一
- **`auth.ts`** — `signIn`/`jwt` コールバックをプロバイダ非依存に書き換え
- **`app/users/me/edit/page.tsx`** — `isInitialSetup` 判定を `needsProfileSetup` フラグに変更
- **`app/login/page.tsx`** — X・Discord ログインボタン追加（X: 黒背景、Discord: `#5865F2`）
- **`.env.example`** — `AUTH_TWITTER_ID/SECRET`、`AUTH_DISCORD_ID/SECRET` テンプレート追加

## 設計上のポイント

初回ログイン検出を `/^\d{15,}$/` 正規表現（Google sub ID 依存）から廃止。Twitter ID は15桁未満の場合があり誤検出が発生していたため、JWT に `needsProfileSetup` フラグを持たせて確実に判定するよう改善。

Closes #27