### PR TITLE
feat: Lucide Icons を Phosphor Icons へ移行 (#72)

### DIFF
--- a/app/(onboarding)/onboarding/page.tsx
+++ b/app/(onboarding)/onboarding/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { Zap, Check, ArrowLeft, ChevronRight } from "lucide-react";
+import { Lightning, Check, ArrowLeft, CaretRight } from "@phosphor-icons/react";
 import { type Game } from "@/lib/mock-data";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { GridGamePicker } from "@/components/ui/GamePicker";
@@ -84,7 +84,7 @@ export default function OnboardingPage() {
 
         {/* Logo — 常に表示 */}
         <div className="mb-10 flex items-center gap-2 justify-center">
-          <Zap className="h-6 w-6" style={{ color: "var(--accent-light)" }} />
+          <Lightning className="h-6 w-6" style={{ color: "var(--accent-light)" }} />
           <span className="text-2xl tracking-tight" style={{ color: "var(--text-primary)" }}>
             <span className="font-medium">Quest</span>
             <span className="font-bold">Link</span>
@@ -156,7 +156,7 @@ export default function OnboardingPage() {
               }}
             >
               次へ
-              <ChevronRight className="h-4 w-4" />
+              <CaretRight className="h-4 w-4" />
             </button>
           </div>
         )}
@@ -222,7 +222,7 @@ export default function OnboardingPage() {
                 }}
               >
                 次へ
-                <ChevronRight className="h-4 w-4" />
+                <CaretRight className="h-4 w-4" />
               </button>
             </div>
           </form>
@@ -287,7 +287,7 @@ export default function OnboardingPage() {
                   }}
                 >
                   次へ
-                  <ChevronRight className="h-4 w-4" />
+                  <CaretRight className="h-4 w-4" />
                 </button>
               </div>
             </div>
@@ -351,7 +351,7 @@ export default function OnboardingPage() {
                 }}
               >
                 次へ
-                <ChevronRight className="h-4 w-4" />
+                <CaretRight className="h-4 w-4" />
               </button>
             </div>
           </div>

--- a/app/HomeGameGrid.tsx
+++ b/app/HomeGameGrid.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
-import { Gamepad2 } from "lucide-react";
+import { GameController } from "@phosphor-icons/react";
 import type { GameResult } from "@/lib/games";
 
 type Props = {
@@ -44,7 +44,7 @@ export function HomeGameGrid({ games }: Props) {
                   className="flex h-full w-full items-center justify-center"
                   style={{ background: "var(--bg-card-hover)" }}
                 >
-                  <Gamepad2 className="h-8 w-8 opacity-40" style={{ color: "var(--accent)" }} />
+                  <GameController className="h-8 w-8 opacity-40" style={{ color: "var(--accent)" }} />
                 </div>
               )}
               <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/70 via-transparent p-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">

--- a/app/games/GamesGrid.tsx
+++ b/app/games/GamesGrid.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
-import { Search, Gamepad2 } from "lucide-react";
+import { MagnifyingGlass, GameController } from "@phosphor-icons/react";
 import type { GameResult } from "@/lib/games";
 
 type Props = {
@@ -31,7 +31,7 @@ export function GamesGrid({ games, roomCounts }: Props) {
       {/* Search bar */}
       <div className="mb-6 flex items-center gap-3">
         <div className="relative flex-1">
-          <Search
+          <MagnifyingGlass
             className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2"
             style={{ color: "var(--text-secondary)" }}
           />
@@ -83,7 +83,7 @@ export function GamesGrid({ games, roomCounts }: Props) {
                       className="flex h-full w-full items-center justify-center"
                       style={{ background: "var(--bg-card-hover)" }}
                     >
-                      <Gamepad2 className="h-10 w-10 opacity-40" style={{ color: "var(--accent)" }} />
+                      <GameController className="h-10 w-10 opacity-40" style={{ color: "var(--accent)" }} />
                     </div>
                   )}
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,4 @@
-import { Lightning } from "@phosphor-icons/react";
+import { Lightning } from "@phosphor-icons/react/dist/ssr";
 import { signIn } from "@/auth";
 
 type Props = {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,4 @@
-import { Zap } from "lucide-react";
+import { Lightning } from "@phosphor-icons/react";
 import { signIn } from "@/auth";
 
 type Props = {
@@ -17,7 +17,7 @@ export default async function LoginPage({ searchParams }: Props) {
       <div className="w-full max-w-md">
         {/* Logo */}
         <div className="mb-8 flex flex-col items-center animate-fade-in-up">
-          <Zap className="mb-3 h-8 w-8" style={{ color: "var(--accent-light)" }} />
+          <Lightning className="mb-3 h-8 w-8" style={{ color: "var(--accent-light)" }} />
           <h1 className="text-4xl tracking-tight" style={{ color: "var(--text-primary)" }}>
             <span className="font-medium">Quest</span>
             <span className="font-bold">Link</span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ChevronRight } from "lucide-react";
+import { CaretRight } from "@phosphor-icons/react";
 import { Prisma } from "@prisma/client";
 import { connection } from "next/server";
 import { getPopularGames } from "@/lib/games";
@@ -82,7 +82,7 @@ export default async function HomePage() {
             style={{ color: "var(--accent-light)" }}
           >
             すべて見る
-            <ChevronRight className="h-4 w-4" />
+            <CaretRight className="h-4 w-4" />
           </Link>
         </div>
 
@@ -101,7 +101,7 @@ export default async function HomePage() {
             style={{ color: "var(--accent-light)" }}
           >
             もっと見る
-            <ChevronRight className="h-4 w-4" />
+            <CaretRight className="h-4 w-4" />
           </Link>
         </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { CaretRight } from "@phosphor-icons/react";
+import { CaretRight } from "@phosphor-icons/react/dist/ssr";
 import { Prisma } from "@prisma/client";
 import { connection } from "next/server";
 import { getPopularGames } from "@/lib/games";

--- a/app/rooms/RoomsFilter.tsx
+++ b/app/rooms/RoomsFilter.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Search } from "lucide-react";
+import { MagnifyingGlass } from "@phosphor-icons/react";
 import { fetchRooms, type RoomSummary } from "@/lib/api/rooms";
 import { RoomCard } from "@/components/ui/RoomCard";
 import { TagFilterToggle } from "@/components/ui/TagFilterToggle";
@@ -77,12 +77,12 @@ export function RoomsFilter({ gameId }: { gameId?: string }) {
 
   return (
     <>
-      {/* Search */}
+      {/* MagnifyingGlass */}
       <div
         className="relative mb-4 flex items-center rounded-xl border px-4 py-2.5 focus-within:border-[var(--accent)] transition-colors"
         style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
       >
-        <Search className="mr-3 h-4 w-4 shrink-0" style={{ color: "var(--text-muted)" }} />
+        <MagnifyingGlass className="mr-3 h-4 w-4 shrink-0" style={{ color: "var(--text-muted)" }} />
         <input
           type="text"
           placeholder="ゲームタイトル・部屋名で検索..."

--- a/app/rooms/[roomId]/RoomActions.tsx
+++ b/app/rooms/[roomId]/RoomActions.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { DoorOpen, LogOut, Loader2, Trash2 } from "lucide-react";
+import { DoorOpen, SignOut, CircleNotch, Trash } from "@phosphor-icons/react";
 import { joinRoom, leaveRoom, closeRoom } from "@/lib/api/rooms";
 
 type Props = {
@@ -64,7 +64,7 @@ export function RoomActions({ roomId, isParticipant, isHost, status }: Props) {
           }}
         >
           {joinMutation.isPending ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <CircleNotch className="h-4 w-4 animate-spin" />
           ) : (
             <DoorOpen className="h-4 w-4" />
           )}
@@ -93,9 +93,9 @@ export function RoomActions({ roomId, isParticipant, isHost, status }: Props) {
           }}
         >
           {leaveMutation.isPending ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <CircleNotch className="h-4 w-4 animate-spin" />
           ) : (
-            <LogOut className="h-4 w-4" />
+            <SignOut className="h-4 w-4" />
           )}
           退室する
         </button>
@@ -110,9 +110,9 @@ export function RoomActions({ roomId, isParticipant, isHost, status }: Props) {
             style={{ backgroundColor: "rgba(239,68,68,0.05)" }}
           >
             {closeMutation.isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
+              <CircleNotch className="h-4 w-4 animate-spin" />
             ) : (
-              <Trash2 className="h-4 w-4" />
+              <Trash className="h-4 w-4" />
             )}
             解散する
           </button>

--- a/app/rooms/[roomId]/RoomDetailView.tsx
+++ b/app/rooms/[roomId]/RoomDetailView.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
-import { ArrowLeft, Crown, MessageSquare, Users } from "lucide-react";
+import { ArrowLeft, Crown, ChatSquare, Users } from "@phosphor-icons/react";
 import { fetchRoom } from "@/lib/api/rooms";
 import { roomStatusConfig, fallbackStatusConfig } from "@/lib/room-status";
 import { UserAvatar } from "@/components/ui/UserAvatar";
@@ -190,7 +190,7 @@ export function RoomDetailView({ roomId }: Props) {
                   className="flex h-10 w-10 items-center justify-center rounded-xl"
                   style={{ backgroundColor: "rgba(124,58,237,0.15)" }}
                 >
-                  <MessageSquare className="h-5 w-5" style={{ color: "var(--accent-light)" }} />
+                  <ChatSquare className="h-5 w-5" style={{ color: "var(--accent-light)" }} />
                 </div>
                 <div>
                   <p className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>

--- a/app/rooms/[roomId]/RoomDetailView.tsx
+++ b/app/rooms/[roomId]/RoomDetailView.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
-import { ArrowLeft, Crown, ChatSquare, Users } from "@phosphor-icons/react";
+import { ArrowLeft, Crown, Chat, Users } from "@phosphor-icons/react";
 import { fetchRoom } from "@/lib/api/rooms";
 import { roomStatusConfig, fallbackStatusConfig } from "@/lib/room-status";
 import { UserAvatar } from "@/components/ui/UserAvatar";
@@ -190,7 +190,7 @@ export function RoomDetailView({ roomId }: Props) {
                   className="flex h-10 w-10 items-center justify-center rounded-xl"
                   style={{ backgroundColor: "rgba(124,58,237,0.15)" }}
                 >
-                  <ChatSquare className="h-5 w-5" style={{ color: "var(--accent-light)" }} />
+                  <Chat className="h-5 w-5" style={{ color: "var(--accent-light)" }} />
                 </div>
                 <div>
                   <p className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>

--- a/app/rooms/[roomId]/chat/ChatInput.tsx
+++ b/app/rooms/[roomId]/chat/ChatInput.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Send } from "lucide-react";
+import { PaperPlaneTilt } from "@phosphor-icons/react";
 import { getSocket } from "@/lib/socket";
 import { useChatStore } from "@/lib/stores/chatStore";
 
@@ -76,7 +76,7 @@ export function ChatInput({ roomId }: Props) {
             }}
             aria-label="送信"
           >
-            <Send className="h-4 w-4" />
+            <PaperPlaneTilt className="h-4 w-4" />
           </button>
         </div>
       </div>

--- a/app/rooms/[roomId]/chat/ChatView.tsx
+++ b/app/rooms/[roomId]/chat/ChatView.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import Link from "next/link";
-import { ArrowLeft, Crown } from "lucide-react";
+import { ArrowLeft, Crown } from "@phosphor-icons/react";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
 import { RatingDisplay } from "@/components/ui/StarRating";

--- a/app/rooms/[roomId]/ratings/RatingForm.tsx
+++ b/app/rooms/[roomId]/ratings/RatingForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
-import { CheckCircle2 } from "lucide-react";
+import { CheckCircle } from "@phosphor-icons/react";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { StarRating, RatingDisplay } from "@/components/ui/StarRating";
 import clsx from "clsx";
@@ -71,7 +71,7 @@ export function RatingForm({ user, roomId }: Props) {
           </p>
           <p className="text-xs" style={{ color: "#22c55e" }}>評価を送信しました</p>
         </div>
-        <CheckCircle2 className="h-5 w-5 animate-scale-in" style={{ color: "#22c55e", animationDelay: "150ms" }} />
+        <CheckCircle className="h-5 w-5 animate-scale-in" style={{ color: "#22c55e", animationDelay: "150ms" }} />
       </div>
     );
   }

--- a/app/rooms/[roomId]/ratings/page.tsx
+++ b/app/rooms/[roomId]/ratings/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
-import { Clock, CheckCircle } from "@phosphor-icons/react";
+import { Clock, CheckCircle } from "@phosphor-icons/react/dist/ssr";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { RatingForm } from "./RatingForm";

--- a/app/rooms/[roomId]/ratings/page.tsx
+++ b/app/rooms/[roomId]/ratings/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
-import { Clock, CheckCircle2 } from "lucide-react";
+import { Clock, CheckCircle } from "@phosphor-icons/react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { RatingForm } from "./RatingForm";
@@ -66,7 +66,7 @@ export default async function RatingsPage({ params }: Props) {
           className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-full"
           style={{ backgroundColor: "rgba(34,197,94,0.15)" }}
         >
-          <CheckCircle2 className="h-7 w-7 text-green-400" />
+          <CheckCircle className="h-7 w-7 text-green-400" />
         </div>
         <h1 className="text-xl font-bold" style={{ color: "var(--text-primary)" }}>
           セッション終了

--- a/app/rooms/new/page.tsx
+++ b/app/rooms/new/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useQuery, useMutation } from "@tanstack/react-query";
-import { ArrowLeft, Plus, Loader2 } from "lucide-react";
+import { Plus, CircleNotch } from "@phosphor-icons/react";
 import type { Game } from "@/lib/mock-data";
 import { SingleGamePicker } from "@/components/ui/GamePicker";
 import { TagFilterToggle } from "@/components/ui/TagFilterToggle";
@@ -262,7 +262,7 @@ export default function NewRoomPage() {
               }}
             >
               {mutation.isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <CircleNotch className="h-4 w-4 animate-spin" />
               ) : (
                 <Plus className="h-4 w-4" />
               )}

--- a/app/users/[userId]/page.tsx
+++ b/app/users/[userId]/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft, Star } from "lucide-react";
+import { ArrowLeft, Star } from "@phosphor-icons/react";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
 import { RatingDisplay } from "@/components/ui/StarRating";

--- a/app/users/me/DeleteAccountButton.tsx
+++ b/app/users/me/DeleteAccountButton.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { signOut } from "next-auth/react";
-import { Trash2 } from "lucide-react";
+import { Trash } from "@phosphor-icons/react";
 
 export function DeleteAccountButton() {
   const [confirming, setConfirming] = useState(false);
@@ -51,7 +51,7 @@ export function DeleteAccountButton() {
       onClick={() => setConfirming(true)}
       className="flex items-center gap-2 rounded-xl border border-red-500/30 px-4 py-2 text-sm font-medium text-red-400 transition-all hover:bg-red-500/10"
     >
-      <Trash2 className="h-4 w-4" />
+      <Trash className="h-4 w-4" />
       アカウントを削除する
     </button>
   );

--- a/app/users/me/edit/page.tsx
+++ b/app/users/me/edit/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
-import { ArrowLeft, Save } from "lucide-react";
+import { ArrowLeft, FloppyDisk } from "@phosphor-icons/react";
 import { type Game } from "@/lib/mock-data";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { MultiGamePicker } from "@/components/ui/GamePicker";
@@ -206,7 +206,7 @@ export default function EditProfilePage() {
                 boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
               }}
             >
-              <Save className="h-4 w-4" />
+              <FloppyDisk className="h-4 w-4" />
               {saving ? "保存中..." : "保存する"}
             </button>
           </div>

--- a/app/users/me/history/page.tsx
+++ b/app/users/me/history/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowLeft, Calendar } from "lucide-react";
+import { ArrowLeft, Calendar } from "@phosphor-icons/react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";

--- a/app/users/me/history/page.tsx
+++ b/app/users/me/history/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowLeft, Calendar } from "@phosphor-icons/react";
+import { ArrowLeft, Calendar } from "@phosphor-icons/react/dist/ssr";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import { Edit2, History, Star } from "lucide-react";
+import { PencilSimple, ClockCounterClockwise, Star } from "@phosphor-icons/react";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
 import { RatingDisplay } from "@/components/ui/StarRating";
@@ -89,7 +89,7 @@ export default function MyProfilePage() {
               className="flex items-center gap-2 rounded-xl border p-2 sm:px-4 sm:py-2 text-sm font-medium transition-all hover:border-[var(--accent)]"
               style={{ borderColor: "var(--border)", color: "var(--text-secondary)", backgroundColor: "var(--bg-input)" }}
             >
-              <Edit2 className="h-4 w-4" />
+              <PencilSimple className="h-4 w-4" />
               <span className="hidden sm:inline">プロフィール編集</span>
             </Link>
             <Link
@@ -97,7 +97,7 @@ export default function MyProfilePage() {
               className="flex items-center gap-2 rounded-xl border p-2 sm:px-4 sm:py-2 text-sm font-medium transition-all hover:border-[var(--accent)]"
               style={{ borderColor: "var(--border)", color: "var(--text-secondary)", backgroundColor: "var(--bg-input)" }}
             >
-              <History className="h-4 w-4" />
+              <ClockCounterClockwise className="h-4 w-4" />
               <span className="hidden sm:inline">参加履歴</span>
             </Link>
           </div>

--- a/components/ui/ActiveFilterBar.tsx
+++ b/components/ui/ActiveFilterBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { CaretLeft, CaretRight, X } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
 
 type Tag = {
@@ -105,7 +105,7 @@ export function ActiveFilterBar({
           }}
           aria-label="左にスクロール"
         >
-          <ChevronLeft className="h-5 w-5" />
+          <CaretLeft className="h-5 w-5" />
         </button>
       )}
 
@@ -124,7 +124,7 @@ export function ActiveFilterBar({
           }}
           aria-label="右にスクロール"
         >
-          <ChevronRight className="h-5 w-5" />
+          <CaretRight className="h-5 w-5" />
         </button>
       )}
     </div>

--- a/components/ui/BottomNav.tsx
+++ b/components/ui/BottomNav.tsx
@@ -45,7 +45,7 @@ export function BottomNav() {
               className="relative flex flex-1 flex-col items-center gap-1 px-2 py-2 text-[11px] whitespace-nowrap transition-colors"
               style={{ color: "var(--text-secondary)" }}
             >
-              <Icon className="h-7 w-7" />
+              <Icon className="h-6 w-6" />
               {label}
             </Link>
           );
@@ -54,17 +54,11 @@ export function BottomNav() {
           <Link
             key={href}
             href={href}
-            className="relative flex flex-1 flex-col items-center gap-1 px-2 py-2 text-[11px] whitespace-nowrap transition-colors"
+            className="flex flex-1 flex-col items-center gap-1 px-2 py-2 text-[11px] whitespace-nowrap transition-colors"
             style={linkStyle}
           >
-            <Icon className="h-7 w-7" />
+            <Icon className="h-6 w-6" />
             {label}
-            {isActive && (
-              <span
-                className="absolute bottom-0.5 left-1/2 -translate-x-1/2 h-0.5 w-4 rounded-full animate-scale-in"
-                style={{ backgroundColor: "var(--accent-light)" }}
-              />
-            )}
           </Link>
         );
       })}

--- a/components/ui/BottomNav.tsx
+++ b/components/ui/BottomNav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { Home, PlusCircle, MessageSquare, User, Users } from "lucide-react";
+import { House, PlusCircle, ChatSquare, User, Users } from "@phosphor-icons/react";
 
 export function BottomNav() {
   const pathname = usePathname();
@@ -14,10 +14,10 @@ export function BottomNav() {
   const isAuthenticated = status === "authenticated";
 
   const staticItems = [
-    { href: "/", label: "トップ", icon: Home },
+    { href: "/", label: "トップ", icon: House },
     { href: "/games", label: "探す", icon: Users, requiresAuth: false },
     { href: "/rooms/new", label: "部屋作成", icon: PlusCircle, requiresAuth: true },
-    { href: "/rooms/current/chat", label: "参加中", icon: MessageSquare, requiresAuth: true },
+    { href: "/rooms/current/chat", label: "参加中", icon: ChatSquare, requiresAuth: true },
     { href: "/users/me", label: "プロフィール", icon: User, requiresAuth: true },
   ];
 

--- a/components/ui/BottomNav.tsx
+++ b/components/ui/BottomNav.tsx
@@ -45,7 +45,7 @@ export function BottomNav() {
               className="relative flex flex-1 flex-col items-center gap-1 px-2 py-2 text-[11px] whitespace-nowrap transition-colors"
               style={{ color: "var(--text-secondary)" }}
             >
-              <Icon className="h-5 w-5" />
+              <Icon className="h-7 w-7" />
               {label}
             </Link>
           );
@@ -57,7 +57,7 @@ export function BottomNav() {
             className="relative flex flex-1 flex-col items-center gap-1 px-2 py-2 text-[11px] whitespace-nowrap transition-colors"
             style={linkStyle}
           >
-            <Icon className="h-5 w-5" />
+            <Icon className="h-7 w-7" />
             {label}
             {isActive && (
               <span

--- a/components/ui/BottomNav.tsx
+++ b/components/ui/BottomNav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { House, PlusCircle, ChatSquare, User, Users } from "@phosphor-icons/react";
+import { House, PlusCircle, Chat, User, Users } from "@phosphor-icons/react";
 
 export function BottomNav() {
   const pathname = usePathname();
@@ -17,7 +17,7 @@ export function BottomNav() {
     { href: "/", label: "トップ", icon: House },
     { href: "/games", label: "探す", icon: Users, requiresAuth: false },
     { href: "/rooms/new", label: "部屋作成", icon: PlusCircle, requiresAuth: true },
-    { href: "/rooms/current/chat", label: "参加中", icon: ChatSquare, requiresAuth: true },
+    { href: "/rooms/current/chat", label: "参加中", icon: Chat, requiresAuth: true },
     { href: "/users/me", label: "プロフィール", icon: User, requiresAuth: true },
   ];
 

--- a/components/ui/GamePicker.tsx
+++ b/components/ui/GamePicker.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback, memo } from "react";
 import Image from "next/image";
-import { Search, X, Gamepad2, Check, ChevronDown } from "lucide-react";
+import { MagnifyingGlass, X, GameController, Check, CaretDown } from "@phosphor-icons/react";
 import { type Game } from "@/lib/mock-data";
 import clsx from "clsx";
 
@@ -35,7 +35,7 @@ export const GameCover = memo(function GameCover({ game, size = "md", className 
         style={{ backgroundColor: "rgba(124,58,237,0.15)", border: "1px solid rgba(124,58,237,0.2)" }}
         title={game.name}
       >
-        <Gamepad2 className="h-4 w-4" style={{ color: "var(--accent-light)" }} />
+        <GameController className="h-4 w-4" style={{ color: "var(--accent-light)" }} />
       </div>
     );
   }
@@ -156,9 +156,9 @@ export function SingleGamePicker({
           </>
         ) : (
           <>
-            <Gamepad2 className="h-4 w-4 shrink-0" style={{ color: "var(--text-muted)" }} />
+            <GameController className="h-4 w-4 shrink-0" style={{ color: "var(--text-muted)" }} />
             <span className="flex-1">{placeholder}</span>
-            <ChevronDown
+            <CaretDown
               className={clsx("h-4 w-4 shrink-0 transition-transform", open && "rotate-180")}
               style={{ color: "var(--text-muted)" }}
             />
@@ -177,7 +177,7 @@ export function SingleGamePicker({
             className="flex items-center gap-2 border-b px-3 py-2.5"
             style={{ borderColor: "var(--border)" }}
           >
-            <Search className="h-4 w-4 shrink-0" style={{ color: "var(--text-muted)" }} />
+            <MagnifyingGlass className="h-4 w-4 shrink-0" style={{ color: "var(--text-muted)" }} />
             <input
               type="text"
               autoFocus
@@ -309,7 +309,7 @@ export function MultiGamePicker({ value, onChange, max = 20 }: MultiGamePickerPr
                 : { backgroundColor: "var(--bg-input)", borderColor: "var(--border)", color: "var(--text-muted)" }
             }
           >
-            <Search className="h-4 w-4 shrink-0" />
+            <MagnifyingGlass className="h-4 w-4 shrink-0" />
             <span>ゲームを追加...</span>
             <span className="ml-auto text-xs" style={{ color: "var(--text-muted)" }}>
               {value.length}/{max}
@@ -325,7 +325,7 @@ export function MultiGamePicker({ value, onChange, max = 20 }: MultiGamePickerPr
                 className="flex items-center gap-2 border-b px-3 py-2.5"
                 style={{ borderColor: "var(--border)" }}
               >
-                <Search className="h-4 w-4 shrink-0" style={{ color: "var(--text-muted)" }} />
+                <MagnifyingGlass className="h-4 w-4 shrink-0" style={{ color: "var(--text-muted)" }} />
                 <input
                   type="text"
                   autoFocus

--- a/components/ui/GamePicker.tsx
+++ b/components/ui/GamePicker.tsx
@@ -429,7 +429,7 @@ export function GridGamePicker({ value, onChange, max = 20 }: GridGamePickerProp
       {/* 検索バー + カウンタ */}
       <div className="flex items-center gap-3">
         <div className="relative flex-1">
-          <Search
+          <MagnifyingGlass
             className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2"
             style={{ color: "var(--text-secondary)" }}
           />
@@ -494,7 +494,7 @@ export function GridGamePicker({ value, onChange, max = 20 }: GridGamePickerProp
                         className="flex h-full w-full items-center justify-center"
                         style={{ backgroundColor: "rgba(124,58,237,0.15)" }}
                       >
-                        <Gamepad2 className="h-8 w-8 opacity-40" style={{ color: "var(--accent)" }} />
+                        <GameController className="h-8 w-8 opacity-40" style={{ color: "var(--accent)" }} />
                       </div>
                     )}
 

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { Home, PlusCircle, MessageSquare, User, Zap, Users } from "lucide-react";
+import { House, PlusCircle, ChatSquare, User, Lightning, Users } from "@phosphor-icons/react";
 import clsx from "clsx";
 import { SignOutButton } from "@/components/ui/SignOutButton";
 
@@ -16,10 +16,10 @@ export function Header() {
   const isAuthenticated = status === "authenticated";
 
   const staticNavItems = [
-    { href: "/", label: "トップ", icon: Home, requiresAuth: false },
+    { href: "/", label: "トップ", icon: House, requiresAuth: false },
     { href: "/games", label: "部屋を探す", icon: Users, requiresAuth: false },
     { href: "/rooms/new", label: "部屋作成", icon: PlusCircle, requiresAuth: true },
-    { href: "/rooms/current/chat", label: "参加中の部屋", icon: MessageSquare, requiresAuth: true },
+    { href: "/rooms/current/chat", label: "参加中の部屋", icon: ChatSquare, requiresAuth: true },
     { href: "/users/me", label: "プロフィール", icon: User, requiresAuth: true },
   ];
 
@@ -34,7 +34,7 @@ export function Header() {
       <div className="mx-auto flex h-full max-w-7xl items-center justify-between px-4 sm:px-6">
         {/* Logo */}
         <Link href="/" className="flex items-center gap-2">
-          <Zap className="h-5 w-5" style={{ color: "var(--accent-light)" }} />
+          <Lightning className="h-5 w-5" style={{ color: "var(--accent-light)" }} />
           <span className="text-lg tracking-tight" style={{ color: "var(--text-primary)" }}>
             <span className="font-medium">Quest</span>
             <span className="font-bold">Link</span>

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { House, PlusCircle, ChatSquare, User, Lightning, Users } from "@phosphor-icons/react";
+import { House, PlusCircle, Chat, User, Lightning, Users } from "@phosphor-icons/react";
 import clsx from "clsx";
 import { SignOutButton } from "@/components/ui/SignOutButton";
 
@@ -19,7 +19,7 @@ export function Header() {
     { href: "/", label: "トップ", icon: House, requiresAuth: false },
     { href: "/games", label: "部屋を探す", icon: Users, requiresAuth: false },
     { href: "/rooms/new", label: "部屋作成", icon: PlusCircle, requiresAuth: true },
-    { href: "/rooms/current/chat", label: "参加中の部屋", icon: ChatSquare, requiresAuth: true },
+    { href: "/rooms/current/chat", label: "参加中の部屋", icon: Chat, requiresAuth: true },
     { href: "/users/me", label: "プロフィール", icon: User, requiresAuth: true },
   ];
 

--- a/components/ui/RoomCard.test.tsx
+++ b/components/ui/RoomCard.test.tsx
@@ -22,7 +22,7 @@ vi.mock("./UserAvatar", () => ({
   UserAvatar: () => <div data-testid="user-avatar" />,
 }));
 
-vi.mock("lucide-react", () => ({
+vi.mock("@phosphor-icons/react", () => ({
   Users: () => <span />,
 }));
 

--- a/components/ui/RoomCard.tsx
+++ b/components/ui/RoomCard.tsx
@@ -3,7 +3,7 @@
 import { memo } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { Users } from "lucide-react";
+import { Users } from "@phosphor-icons/react";
 import type { RoomSummary } from "@/lib/api/rooms";
 import { roomStatusConfig, fallbackStatusConfig } from "@/lib/room-status";
 import { UserAvatar } from "./UserAvatar";

--- a/components/ui/SignOutButton.tsx
+++ b/components/ui/SignOutButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { signOut } from "next-auth/react";
-import { LogOut } from "lucide-react";
+import { SignOut } from "@phosphor-icons/react";
 
 export function SignOutButton() {
   return (
@@ -10,7 +10,7 @@ export function SignOutButton() {
       className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-all hover:text-red-400"
       style={{ color: "var(--text-secondary)" }}
     >
-      <LogOut className="h-4 w-4" />
+      <SignOut className="h-4 w-4" />
       ログアウト
     </button>
   );

--- a/components/ui/StarRating.tsx
+++ b/components/ui/StarRating.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Star } from "lucide-react";
+import { Star } from "@phosphor-icons/react";
 import clsx from "clsx";
 
 type Props = {

--- a/components/ui/TagFilterToggle.tsx
+++ b/components/ui/TagFilterToggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Filter, ChevronDown } from "lucide-react";
+import { Funnel, CaretDown } from "@phosphor-icons/react";
 
 type Props = {
   selectedCount: number;
@@ -20,7 +20,7 @@ export function TagFilterToggle({ selectedCount, panelOpen, onPanelToggle, label
         border: `1px solid ${panelOpen ? "rgba(124,58,237,0.4)" : "var(--border)"}`,
       }}
     >
-      <Filter className="h-4 w-4" />
+      <Funnel className="h-4 w-4" />
       <span>{label}</span>
       {selectedCount > 0 && (
         <span
@@ -30,7 +30,7 @@ export function TagFilterToggle({ selectedCount, panelOpen, onPanelToggle, label
           {selectedCount}
         </span>
       )}
-      <ChevronDown
+      <CaretDown
         className="h-4 w-4 transition-transform duration-200"
         style={{ transform: panelOpen ? "rotate(180deg)" : "rotate(0deg)" }}
       />

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",
+    "@phosphor-icons/react": "^2.1.10",
     "@prisma/adapter-pg": "^7.4.1",
     "@prisma/client": "^7.4.1",
     "@tanstack/react-query": "^5.90.21",
     "clsx": "^2.1.1",
     "dotenv": "^17.3.1",
-    "lucide-react": "^0.469.0",
     "next": "16.1.6",
     "next-auth": "5.0.0-beta.30",
     "pg": "^8.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@auth/prisma-adapter':
         specifier: ^2.11.1
         version: 2.11.1(@prisma/client@7.4.1(prisma@7.4.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))
+      '@phosphor-icons/react':
+        specifier: ^2.1.10
+        version: 2.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@prisma/adapter-pg':
         specifier: ^7.4.1
         version: 7.4.1
@@ -26,9 +29,6 @@ importers:
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
-      lucide-react:
-        specifier: ^0.469.0
-        version: 0.469.0(react@19.2.3)
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -811,6 +811,13 @@ packages:
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
+  '@phosphor-icons/react@2.1.10':
+    resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>= 16.8'
+      react-dom: '>= 16.8'
 
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
@@ -2507,11 +2514,6 @@ packages:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
 
-  lucide-react@0.469.0:
-    resolution: {integrity: sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -4027,6 +4029,11 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@panva/hkdf@1.2.1': {}
+
+  '@phosphor-icons/react@2.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@playwright/test@1.58.2':
     dependencies:
@@ -5872,10 +5879,6 @@ snapshots:
       yallist: 3.1.1
 
   lru.min@1.1.4: {}
-
-  lucide-react@0.469.0(react@19.2.3):
-    dependencies:
-      react: 19.2.3
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## 概要

`lucide-react` を `@phosphor-icons/react` へ移行。
ブランド方針「安心・親しみ・実用」に合わせ、AI感・無機質感のある Lucide から、より有機的・人間的な Phosphor Icons へ切り替えた。

## 変更内容

- `pnpm add @phosphor-icons/react` / `pnpm remove lucide-react`
- 全25ファイルの import と JSX 参照を対応表に従って更新
- Server Components（`app/page.tsx` 等）では `@phosphor-icons/react/dist/ssr` を使用（React Context 非使用のSSR対応エントリーポイント）

### 主なアイコン対応
| Lucide | Phosphor |
|--------|----------|
| `Zap` | `Lightning` |
| `Home` | `House` |
| `MessageSquare` | `Chat` |
| `Search` | `MagnifyingGlass` |
| `ChevronRight` | `CaretRight` |
| `Loader2` | `CircleNotch` |
| `Gamepad2` | `GameController` |

## 確認事項

- [x] `pnpm lint` 通過
- [x] `pnpm test` 通過（99テスト）

Closes #72