### PR TITLE
feat: トップページのゲーム・部屋をユーザープロフィールに基づきパーソナライズ表示

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 import { CaretRight } from "@phosphor-icons/react/dist/ssr";
 import { Prisma } from "@prisma/client";
 import { connection } from "next/server";
-import { getPopularGames } from "@/lib/games";
+import { auth } from "@/auth";
+import { getPopularGames, getPopularGamesExcluding, type GameResult } from "@/lib/games";
 import { prisma } from "@/lib/prisma";
 import { RoomCard } from "@/components/ui/RoomCard";
 import { type RoomSummary } from "@/lib/api/rooms";
@@ -57,16 +58,65 @@ function formatRoom(room: RawRoom): RoomSummary {
 
 export default async function HomePage() {
   await connection();
-  const [games, rawRooms] = await Promise.all([
-    getPopularGames(6),
-    prisma.room.findMany({
-      where: { status: "waiting" },
-      orderBy: { createdAt: "desc" },
-      take: 6,
-      select: roomSelect,
-    }),
-  ]);
-  const rooms = rawRooms.map(formatRoom);
+
+  const session = await auth();
+  const userId = session?.user?.id ?? null;
+
+  let games: GameResult[];
+  let rooms: RoomSummary[];
+
+  if (!userId) {
+    const [popularGames, rawRooms] = await Promise.all([
+      getPopularGames(6),
+      prisma.room.findMany({
+        where: { status: "waiting" },
+        orderBy: { createdAt: "desc" },
+        take: 6,
+        select: roomSelect,
+      }),
+    ]);
+    games = popularGames;
+    rooms = rawRooms.map(formatRoom);
+  } else {
+    const userGameRows = await prisma.userGame.findMany({
+      where: { userId },
+      select: { game: { select: { id: true, name: true, coverImageUrl: true } } },
+    });
+    const userGames = userGameRows.map((r) => r.game);
+    const userGameIds = userGames.map((g) => g.id);
+    const userGamesSlice = userGames.slice(0, 6);
+    const fillGamesCount = 6 - userGamesSlice.length;
+
+    const [fillGames, userRawRooms, fillRawRooms] = await Promise.all([
+      fillGamesCount > 0
+        ? getPopularGamesExcluding(userGameIds, fillGamesCount)
+        : Promise.resolve([] as GameResult[]),
+      prisma.room.findMany({
+        where: { status: "waiting", gameId: { in: userGameIds } },
+        orderBy: { createdAt: "desc" },
+        take: 6,
+        select: roomSelect,
+      }),
+      prisma.room.findMany({
+        where: {
+          status: "waiting",
+          ...(userGameIds.length > 0 ? { gameId: { notIn: userGameIds } } : {}),
+        },
+        orderBy: { createdAt: "desc" },
+        take: 6,
+        select: roomSelect,
+      }),
+    ]);
+
+    games = [...userGamesSlice, ...fillGames];
+
+    const userRoomIds = new Set(userRawRooms.map((r) => r.id));
+    const mergedRawRooms = [
+      ...userRawRooms,
+      ...fillRawRooms.filter((r) => !userRoomIds.has(r.id)),
+    ].slice(0, 6);
+    rooms = mergedRawRooms.map(formatRoom);
+  }
 
   return (
     <main className="mx-auto max-w-screen-xl px-4 py-10 pb-24 md:pb-10 space-y-12">

--- a/lib/games.test.ts
+++ b/lib/games.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { searchGames, getPopularGames, getGameById } from "@/lib/games";
+import { searchGames, getPopularGames, getPopularGamesExcluding, getGameById } from "@/lib/games";
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
@@ -97,6 +97,54 @@ describe("getPopularGames", () => {
         where: expect.objectContaining({ isActive: true }),
       })
     );
+  });
+});
+
+describe("getPopularGamesExcluding", () => {
+  it("excludeIds が空のとき notIn フィルターなしで呼ばれる", async () => {
+    mockFindMany.mockResolvedValueOnce(sampleGames);
+
+    const result = await getPopularGamesExcluding([], 6);
+
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { isActive: true },
+      orderBy: { displayOrder: "asc" },
+      take: 6,
+      select: { id: true, name: true, coverImageUrl: true },
+    });
+    expect(result).toEqual(sampleGames);
+  });
+
+  it("excludeIds に値があるとき id: { notIn } フィルターが付く", async () => {
+    mockFindMany.mockResolvedValueOnce([sampleGames[1]]);
+
+    const result = await getPopularGamesExcluding(["1"], 5);
+
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { isActive: true, id: { notIn: ["1"] } },
+      orderBy: { displayOrder: "asc" },
+      take: 5,
+      select: { id: true, name: true, coverImageUrl: true },
+    });
+    expect(result).toEqual([sampleGames[1]]);
+  });
+
+  it("limit が take に反映される", async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+
+    await getPopularGamesExcluding(["1", "2"], 3);
+
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 3 })
+    );
+  });
+
+  it("結果が空配列のとき空配列を返す", async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+
+    const result = await getPopularGamesExcluding(["1", "2"], 6);
+
+    expect(result).toEqual([]);
   });
 });
 

--- a/lib/games.ts
+++ b/lib/games.ts
@@ -21,6 +21,21 @@ export async function getPopularGames(limit = 10): Promise<GameResult[]> {
   });
 }
 
+export async function getPopularGamesExcluding(
+  excludeIds: string[],
+  limit: number
+): Promise<GameResult[]> {
+  return prisma.game.findMany({
+    where: {
+      isActive: true,
+      ...(excludeIds.length > 0 ? { id: { notIn: excludeIds } } : {}),
+    },
+    orderBy: { displayOrder: "asc" },
+    take: limit,
+    select: { id: true, name: true, coverImageUrl: true },
+  });
+}
+
 export async function getGameById(id: string): Promise<GameResult | null> {
   "use cache";
   return prisma.game.findUnique({


### PR DESCRIPTION
## 概要

- ログイン済みユーザーにはプロフィールの「プレイしているゲーム」を優先表示し、6件未満の場合は人気ゲームで補填
- 募集中の部屋も同様に、ユーザーのゲームに紐づく部屋を優先し、6件未満の場合は最新の一般部屋で補填
- 未ログイン時・ゲーム未設定時は従来通りの表示（graceful degradation）

## 変更ファイル

- `app/page.tsx` — `auth()` でセッション取得し、ログイン状態に応じた分岐ロジックを追加
- `lib/games.ts` — `getPopularGamesExcluding(excludeIds, limit)` を追加
- `lib/games.test.ts` — 新関数のユニットテスト4件追加

Closes #85