### PR TITLE
feat: 自分のプロフィールに受け取った評価一覧を表示する

### DIFF
--- a/app/api/v1/users/[userId]/route.test.ts
+++ b/app/api/v1/users/[userId]/route.test.ts
@@ -23,7 +23,7 @@ const makeParams = (userId = "user-2") => ({
   params: Promise.resolve({ userId }),
 });
 
-const makeUser = (overrides: Record<string, unknown> = {}) => ({
+const makeUser = () => ({
   id: "user-2",
   username: "otheruser",
   iconUrl: null,
@@ -33,15 +33,6 @@ const makeUser = (overrides: Record<string, unknown> = {}) => ({
   createdAt: new Date("2026-01-01T00:00:00Z"),
   playStyleTags: [],
   games: [],
-  receivedRatings: [
-    {
-      id: "rating-1",
-      score: 4,
-      comment: "楽しかったです",
-      createdAt: new Date("2026-02-01T00:00:00Z"),
-    },
-  ],
-  ...overrides,
 });
 
 beforeEach(() => {
@@ -82,7 +73,7 @@ describe("GET /api/v1/users/[userId]", () => {
     expect(body.data.username).toBe("otheruser");
   });
 
-  it("receivedRatings が配列として含まれる", async () => {
+  it("レスポンスに receivedRatings が含まれない", async () => {
     mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
     mockFindUnique.mockResolvedValue(makeUser() as never);
 
@@ -90,31 +81,6 @@ describe("GET /api/v1/users/[userId]", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.data.receivedRatings).toHaveLength(1);
-  });
-
-  it("receivedRatings の各要素に score, comment, createdAt が含まれ reviewer は含まれない（匿名）", async () => {
-    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
-    mockFindUnique.mockResolvedValue(makeUser() as never);
-
-    const res = await GET(new Request("http://localhost"), makeParams());
-    const body = await res.json();
-
-    const [first] = body.data.receivedRatings as Array<Record<string, unknown>>;
-    expect(first.id).toBe("rating-1");
-    expect(first.score).toBe(4);
-    expect(first.comment).toBe("楽しかったです");
-    expect(first.reviewer).toBeUndefined();
-  });
-
-  it("receivedRatings が 0 件の場合は空配列を返す", async () => {
-    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
-    mockFindUnique.mockResolvedValue(makeUser({ receivedRatings: [] }) as never);
-
-    const res = await GET(new Request("http://localhost"), makeParams());
-    const body = await res.json();
-
-    expect(res.status).toBe(200);
-    expect(body.data.receivedRatings).toEqual([]);
+    expect(body.data.receivedRatings).toBeUndefined();
   });
 });

--- a/app/api/v1/users/[userId]/route.test.ts
+++ b/app/api/v1/users/[userId]/route.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { GET } from "./route";
+
+const mockAuth = vi.mocked(auth);
+const mockFindUnique = vi.mocked(prisma.user.findUnique);
+
+const makeParams = (userId = "user-2") => ({
+  params: Promise.resolve({ userId }),
+});
+
+const makeUser = (overrides: Record<string, unknown> = {}) => ({
+  id: "user-2",
+  username: "otheruser",
+  iconUrl: null,
+  bio: null,
+  avgRating: 3,
+  ratingCount: 1,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  playStyleTags: [],
+  games: [],
+  receivedRatings: [
+    {
+      id: "rating-1",
+      score: 4,
+      comment: "楽しかったです",
+      createdAt: new Date("2026-02-01T00:00:00Z"),
+    },
+  ],
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/v1/users/[userId]", () => {
+  it("未認証の場合 401 UNAUTHORIZED を返す", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const res = await GET(new Request("http://localhost"), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("UNAUTHORIZED");
+  });
+
+  it("ユーザーが存在しない場合 404 USER_NOT_FOUND を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await GET(new Request("http://localhost"), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("USER_NOT_FOUND");
+  });
+
+  it("正常取得の場合 200 とユーザーデータを返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue(makeUser() as never);
+
+    const res = await GET(new Request("http://localhost"), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.id).toBe("user-2");
+    expect(body.data.username).toBe("otheruser");
+  });
+
+  it("receivedRatings が配列として含まれる", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue(makeUser() as never);
+
+    const res = await GET(new Request("http://localhost"), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.receivedRatings).toHaveLength(1);
+  });
+
+  it("receivedRatings の各要素に score, comment, createdAt が含まれ reviewer は含まれない（匿名）", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue(makeUser() as never);
+
+    const res = await GET(new Request("http://localhost"), makeParams());
+    const body = await res.json();
+
+    const [first] = body.data.receivedRatings as Array<Record<string, unknown>>;
+    expect(first.id).toBe("rating-1");
+    expect(first.score).toBe(4);
+    expect(first.comment).toBe("楽しかったです");
+    expect(first.reviewer).toBeUndefined();
+  });
+
+  it("receivedRatings が 0 件の場合は空配列を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue(makeUser({ receivedRatings: [] }) as never);
+
+    const res = await GET(new Request("http://localhost"), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.receivedRatings).toEqual([]);
+  });
+});

--- a/app/api/v1/users/[userId]/route.ts
+++ b/app/api/v1/users/[userId]/route.ts
@@ -21,16 +21,6 @@ const profileSelect = {
       game: { select: { id: true, name: true, coverImageUrl: true } },
     },
   },
-  receivedRatings: {
-    select: {
-      id: true,
-      score: true,
-      comment: true,
-      createdAt: true,
-    },
-    orderBy: { createdAt: "desc" as const },
-    take: 20,
-  },
 } satisfies Prisma.UserSelect;
 
 type RawUser = Prisma.UserGetPayload<{ select: typeof profileSelect }>;
@@ -46,12 +36,6 @@ function formatUser(user: RawUser) {
     createdAt: user.createdAt,
     playStyleTags: user.playStyleTags.map((t) => t.tag),
     games: user.games.map((g) => g.game),
-    receivedRatings: user.receivedRatings.map((r) => ({
-      id: r.id,
-      score: r.score,
-      comment: r.comment,
-      createdAt: r.createdAt,
-    })),
   };
 }
 

--- a/app/api/v1/users/[userId]/route.ts
+++ b/app/api/v1/users/[userId]/route.ts
@@ -21,6 +21,16 @@ const profileSelect = {
       game: { select: { id: true, name: true, coverImageUrl: true } },
     },
   },
+  receivedRatings: {
+    select: {
+      id: true,
+      score: true,
+      comment: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "desc" as const },
+    take: 20,
+  },
 } satisfies Prisma.UserSelect;
 
 type RawUser = Prisma.UserGetPayload<{ select: typeof profileSelect }>;
@@ -36,6 +46,12 @@ function formatUser(user: RawUser) {
     createdAt: user.createdAt,
     playStyleTags: user.playStyleTags.map((t) => t.tag),
     games: user.games.map((g) => g.game),
+    receivedRatings: user.receivedRatings.map((r) => ({
+      id: r.id,
+      score: r.score,
+      comment: r.comment,
+      createdAt: r.createdAt,
+    })),
   };
 }
 

--- a/app/api/v1/users/me/route.test.ts
+++ b/app/api/v1/users/me/route.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/lib/prisma", () => ({
       update: vi.fn(),
       delete: vi.fn(),
     },
+    rating: { findMany: vi.fn() },
     playStyleTag: { findMany: vi.fn() },
     game: { findMany: vi.fn() },
     userPlayStyleTag: { deleteMany: vi.fn() },
@@ -25,8 +26,9 @@ import { GET } from "./route";
 
 const mockAuth = vi.mocked(auth);
 const mockFindUnique = vi.mocked(prisma.user.findUnique);
+const mockRatingFindMany = vi.mocked(prisma.rating.findMany);
 
-const makeUser = (overrides: Record<string, unknown> = {}) => ({
+const makeUser = () => ({
   id: "user-1",
   username: "testuser",
   iconUrl: null,
@@ -36,24 +38,24 @@ const makeUser = (overrides: Record<string, unknown> = {}) => ({
   createdAt: new Date("2026-01-01T00:00:00Z"),
   playStyleTags: [],
   games: [],
-  receivedRatings: [
-    {
-      id: "rating-1",
-      score: 5,
-      comment: "また一緒にやりましょう！",
-      createdAt: new Date("2026-02-01T00:00:00Z"),
-      reviewer: { username: "reviewer1", iconUrl: null },
-    },
-    {
-      id: "rating-2",
-      score: 3,
-      comment: null,
-      createdAt: new Date("2026-01-15T00:00:00Z"),
-      reviewer: { username: "reviewer2", iconUrl: "https://example.com/icon.jpg" },
-    },
-  ],
-  ...overrides,
 });
+
+const makeRatings = () => [
+  {
+    id: "rating-1",
+    score: 5,
+    comment: "また一緒にやりましょう！",
+    createdAt: new Date("2026-02-01T00:00:00Z"),
+    reviewer: { username: "reviewer1", iconUrl: null },
+  },
+  {
+    id: "rating-2",
+    score: 3,
+    comment: null,
+    createdAt: new Date("2026-01-15T00:00:00Z"),
+    reviewer: { username: "reviewer2", iconUrl: "https://example.com/icon.jpg" },
+  },
+];
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -73,6 +75,7 @@ describe("GET /api/v1/users/me", () => {
   it("ユーザーが存在しない場合 404 USER_NOT_FOUND を返す", async () => {
     mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
     mockFindUnique.mockResolvedValue(null);
+    mockRatingFindMany.mockResolvedValue([]);
 
     const res = await GET();
     const body = await res.json();
@@ -84,6 +87,7 @@ describe("GET /api/v1/users/me", () => {
   it("正常取得の場合 200 とユーザーデータを返す", async () => {
     mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
     mockFindUnique.mockResolvedValue(makeUser() as never);
+    mockRatingFindMany.mockResolvedValue([]);
 
     const res = await GET();
     const body = await res.json();
@@ -96,6 +100,7 @@ describe("GET /api/v1/users/me", () => {
   it("receivedRatings が配列として含まれる", async () => {
     mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
     mockFindUnique.mockResolvedValue(makeUser() as never);
+    mockRatingFindMany.mockResolvedValue(makeRatings() as never);
 
     const res = await GET();
     const body = await res.json();
@@ -107,6 +112,7 @@ describe("GET /api/v1/users/me", () => {
   it("receivedRatings の各要素に score, comment, createdAt, reviewer が含まれる", async () => {
     mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
     mockFindUnique.mockResolvedValue(makeUser() as never);
+    mockRatingFindMany.mockResolvedValue(makeRatings() as never);
 
     const res = await GET();
     const body = await res.json();
@@ -127,7 +133,8 @@ describe("GET /api/v1/users/me", () => {
 
   it("receivedRatings が 0 件の場合は空配列を返す", async () => {
     mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
-    mockFindUnique.mockResolvedValue(makeUser({ receivedRatings: [] }) as never);
+    mockFindUnique.mockResolvedValue(makeUser() as never);
+    mockRatingFindMany.mockResolvedValue([]);
 
     const res = await GET();
     const body = await res.json();

--- a/app/api/v1/users/me/route.test.ts
+++ b/app/api/v1/users/me/route.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    playStyleTag: { findMany: vi.fn() },
+    game: { findMany: vi.fn() },
+    userPlayStyleTag: { deleteMany: vi.fn() },
+    userGame: { deleteMany: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { GET } from "./route";
+
+const mockAuth = vi.mocked(auth);
+const mockFindUnique = vi.mocked(prisma.user.findUnique);
+
+const makeUser = (overrides: Record<string, unknown> = {}) => ({
+  id: "user-1",
+  username: "testuser",
+  iconUrl: null,
+  bio: "自己紹介文",
+  avgRating: 4,
+  ratingCount: 2,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  playStyleTags: [],
+  games: [],
+  receivedRatings: [
+    {
+      id: "rating-1",
+      score: 5,
+      comment: "また一緒にやりましょう！",
+      createdAt: new Date("2026-02-01T00:00:00Z"),
+      reviewer: { username: "reviewer1", iconUrl: null },
+    },
+    {
+      id: "rating-2",
+      score: 3,
+      comment: null,
+      createdAt: new Date("2026-01-15T00:00:00Z"),
+      reviewer: { username: "reviewer2", iconUrl: "https://example.com/icon.jpg" },
+    },
+  ],
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/v1/users/me", () => {
+  it("未認証の場合 401 UNAUTHORIZED を返す", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("UNAUTHORIZED");
+  });
+
+  it("ユーザーが存在しない場合 404 USER_NOT_FOUND を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("USER_NOT_FOUND");
+  });
+
+  it("正常取得の場合 200 とユーザーデータを返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue(makeUser() as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.id).toBe("user-1");
+    expect(body.data.username).toBe("testuser");
+  });
+
+  it("receivedRatings が配列として含まれる", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue(makeUser() as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.receivedRatings).toHaveLength(2);
+  });
+
+  it("receivedRatings の各要素に score, comment, createdAt, reviewer が含まれる", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue(makeUser() as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    const [first] = body.data.receivedRatings as Array<{
+      id: string;
+      score: number;
+      comment: string | null;
+      createdAt: string;
+      reviewer: { username: string | null; iconUrl: string | null };
+    }>;
+    expect(first.id).toBe("rating-1");
+    expect(first.score).toBe(5);
+    expect(first.comment).toBe("また一緒にやりましょう！");
+    expect(first.reviewer.username).toBe("reviewer1");
+    expect(first.reviewer.iconUrl).toBeNull();
+  });
+
+  it("receivedRatings が 0 件の場合は空配列を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue(makeUser({ receivedRatings: [] }) as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.receivedRatings).toEqual([]);
+  });
+});

--- a/app/api/v1/users/me/route.ts
+++ b/app/api/v1/users/me/route.ts
@@ -30,24 +30,22 @@ const profileSelect = {
       game: { select: { id: true, name: true, coverImageUrl: true } },
     },
   },
-  receivedRatings: {
-    select: {
-      id: true,
-      score: true,
-      comment: true,
-      createdAt: true,
-      reviewer: {
-        select: { username: true, iconUrl: true },
-      },
-    },
-    orderBy: { createdAt: "desc" as const },
-    take: 20,
-  },
 } satisfies Prisma.UserSelect;
 
-type RawUser = Prisma.UserGetPayload<{ select: typeof profileSelect }>;
+const receivedRatingsSelect = {
+  id: true,
+  score: true,
+  comment: true,
+  createdAt: true,
+  reviewer: {
+    select: { username: true, iconUrl: true },
+  },
+} satisfies Prisma.RatingSelect;
 
-function formatUser(user: RawUser) {
+type RawUser = Prisma.UserGetPayload<{ select: typeof profileSelect }>;
+type RawRating = Prisma.RatingGetPayload<{ select: typeof receivedRatingsSelect }>;
+
+function formatUser(user: RawUser, receivedRatings: RawRating[]) {
   return {
     id: user.id,
     username: user.username,
@@ -58,7 +56,7 @@ function formatUser(user: RawUser) {
     createdAt: user.createdAt,
     playStyleTags: user.playStyleTags.map((t) => t.tag),
     games: user.games.map((g) => g.game),
-    receivedRatings: user.receivedRatings.map((r) => ({
+    receivedRatings: receivedRatings.map((r) => ({
       id: r.id,
       score: r.score,
       comment: r.comment,
@@ -74,16 +72,21 @@ export async function GET() {
     return NextResponse.json({ error: "UNAUTHORIZED" }, { status: 401 });
   }
 
-  const user = await prisma.user.findUnique({
-    where: { id: session.user.id },
-    select: profileSelect,
-  });
+  const [user, receivedRatings] = await Promise.all([
+    prisma.user.findUnique({ where: { id: session.user.id }, select: profileSelect }),
+    prisma.rating.findMany({
+      where: { revieweeId: session.user.id },
+      select: receivedRatingsSelect,
+      orderBy: { createdAt: "desc" },
+      take: 20,
+    }),
+  ]);
 
   if (!user) {
     return NextResponse.json({ error: "USER_NOT_FOUND" }, { status: 404 });
   }
 
-  return NextResponse.json({ data: formatUser(user) });
+  return NextResponse.json({ data: formatUser(user, receivedRatings) });
 }
 
 export async function PATCH(request: Request) {

--- a/app/api/v1/users/me/route.ts
+++ b/app/api/v1/users/me/route.ts
@@ -30,6 +30,19 @@ const profileSelect = {
       game: { select: { id: true, name: true, coverImageUrl: true } },
     },
   },
+  receivedRatings: {
+    select: {
+      id: true,
+      score: true,
+      comment: true,
+      createdAt: true,
+      reviewer: {
+        select: { username: true, iconUrl: true },
+      },
+    },
+    orderBy: { createdAt: "desc" as const },
+    take: 20,
+  },
 } satisfies Prisma.UserSelect;
 
 type RawUser = Prisma.UserGetPayload<{ select: typeof profileSelect }>;
@@ -45,6 +58,13 @@ function formatUser(user: RawUser) {
     createdAt: user.createdAt,
     playStyleTags: user.playStyleTags.map((t) => t.tag),
     games: user.games.map((g) => g.game),
+    receivedRatings: user.receivedRatings.map((r) => ({
+      id: r.id,
+      score: r.score,
+      comment: r.comment,
+      createdAt: r.createdAt,
+      reviewer: r.reviewer,
+    })),
   };
 }
 

--- a/app/users/[userId]/page.tsx
+++ b/app/users/[userId]/page.tsx
@@ -7,7 +7,14 @@ import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, Star, GameController } from "@phosphor-icons/react";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
-import { RatingDisplay } from "@/components/ui/StarRating";
+import { RatingDisplay, StarRating } from "@/components/ui/StarRating";
+
+type ReceivedRating = {
+  id: string;
+  score: number;
+  comment: string | null;
+  createdAt: string;
+};
 
 type UserProfile = {
   id: string;
@@ -18,6 +25,7 @@ type UserProfile = {
   ratingCount: number;
   playStyleTags: { id: string; name: string; slug: string }[];
   games: { id: string; igdbId: number; name: string; coverImageUrl: string | null }[];
+  receivedRatings: ReceivedRating[];
 };
 
 async function fetchUserProfile(userId: string): Promise<UserProfile> {
@@ -210,9 +218,37 @@ export default function UserProfilePage() {
           <Star className="h-3.5 w-3.5" style={{ fill: "#eab308", color: "#eab308" }} />
           受け取った評価
         </h2>
-        <p className="text-sm" style={{ color: "var(--text-muted)" }}>
-          まだ評価がありません
-        </p>
+        {user.receivedRatings.length === 0 ? (
+          <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+            まだ評価がありません
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {user.receivedRatings.map((rating) => (
+              <div
+                key={rating.id}
+                className="rounded-xl p-4"
+                style={{ backgroundColor: "var(--bg-input)", border: "1px solid var(--border)" }}
+              >
+                <div className="flex items-start gap-3">
+                  <div className="mt-0.5">
+                    <StarRating value={rating.score} readonly size="sm" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <span className="text-xs" style={{ color: "var(--text-muted)" }}>
+                      {new Date(rating.createdAt).toLocaleDateString("ja-JP")}
+                    </span>
+                    {rating.comment && (
+                      <p className="mt-1 text-sm leading-relaxed" style={{ color: "var(--text-secondary)" }}>
+                        {rating.comment}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/app/users/[userId]/page.tsx
+++ b/app/users/[userId]/page.tsx
@@ -4,17 +4,10 @@ import Image from "next/image";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft, Star, GameController } from "@phosphor-icons/react";
+import { ArrowLeft, GameController } from "@phosphor-icons/react";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
-import { RatingDisplay, StarRating } from "@/components/ui/StarRating";
-
-type ReceivedRating = {
-  id: string;
-  score: number;
-  comment: string | null;
-  createdAt: string;
-};
+import { RatingDisplay } from "@/components/ui/StarRating";
 
 type UserProfile = {
   id: string;
@@ -25,7 +18,6 @@ type UserProfile = {
   ratingCount: number;
   playStyleTags: { id: string; name: string; slug: string }[];
   games: { id: string; igdbId: number; name: string; coverImageUrl: string | null }[];
-  receivedRatings: ReceivedRating[];
 };
 
 async function fetchUserProfile(userId: string): Promise<UserProfile> {
@@ -212,44 +204,6 @@ export default function UserProfilePage() {
         )}
       </div>
 
-      {/* Received Ratings */}
-      <div className="mt-8 px-4 sm:px-6">
-        <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider" style={{ color: "var(--text-muted)" }}>
-          <Star className="h-3.5 w-3.5" style={{ fill: "#eab308", color: "#eab308" }} />
-          受け取った評価
-        </h2>
-        {user.receivedRatings.length === 0 ? (
-          <p className="text-sm" style={{ color: "var(--text-muted)" }}>
-            まだ評価がありません
-          </p>
-        ) : (
-          <div className="space-y-3">
-            {user.receivedRatings.map((rating) => (
-              <div
-                key={rating.id}
-                className="rounded-xl p-4"
-                style={{ backgroundColor: "var(--bg-input)", border: "1px solid var(--border)" }}
-              >
-                <div className="flex items-start gap-3">
-                  <div className="mt-0.5">
-                    <StarRating value={rating.score} readonly size="sm" />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <span className="text-xs" style={{ color: "var(--text-muted)" }}>
-                      {new Date(rating.createdAt).toLocaleDateString("ja-JP")}
-                    </span>
-                    {rating.comment && (
-                      <p className="mt-1 text-sm leading-relaxed" style={{ color: "var(--text-secondary)" }}>
-                        {rating.comment}
-                      </p>
-                    )}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
     </div>
   );
 }

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -6,8 +6,16 @@ import { useQuery } from "@tanstack/react-query";
 import { PencilSimple, ClockCounterClockwise, Star, GameController } from "@phosphor-icons/react";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
-import { RatingDisplay } from "@/components/ui/StarRating";
+import { RatingDisplay, StarRating } from "@/components/ui/StarRating";
 import { DeleteAccountButton } from "./DeleteAccountButton";
+
+type ReceivedRating = {
+  id: string;
+  score: number;
+  comment: string | null;
+  createdAt: string;
+  reviewer: { username: string | null; iconUrl: string | null };
+};
 
 type UserProfile = {
   id: string;
@@ -18,6 +26,7 @@ type UserProfile = {
   ratingCount: number;
   playStyleTags: { id: string; name: string; slug: string }[];
   games: { id: string; igdbId: number; name: string; coverImageUrl: string | null }[];
+  receivedRatings: ReceivedRating[];
 };
 
 async function fetchMyProfile(): Promise<UserProfile> {
@@ -211,9 +220,47 @@ export default function MyProfilePage() {
           <Star className="h-3.5 w-3.5" style={{ fill: "#eab308", color: "#eab308" }} />
           受け取った評価
         </h2>
-        <p className="text-sm" style={{ color: "var(--text-muted)" }}>
-          まだ評価がありません
-        </p>
+        {user.receivedRatings.length === 0 ? (
+          <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+            まだ評価がありません
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {user.receivedRatings.map((rating) => (
+              <div
+                key={rating.id}
+                className="rounded-xl p-4"
+                style={{ backgroundColor: "var(--bg-input)", border: "1px solid var(--border)" }}
+              >
+                <div className="flex items-start gap-3">
+                  <UserAvatar
+                    username={rating.reviewer.username}
+                    iconUrl={rating.reviewer.iconUrl}
+                    size="sm"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium truncate" style={{ color: "var(--text-primary)" }}>
+                        {rating.reviewer.username ?? "退会済みユーザー"}
+                      </span>
+                      <span className="text-xs shrink-0" style={{ color: "var(--text-muted)" }}>
+                        {new Date(rating.createdAt).toLocaleDateString("ja-JP")}
+                      </span>
+                    </div>
+                    <div className="mt-1">
+                      <StarRating value={rating.score} readonly size="sm" />
+                    </div>
+                    {rating.comment && (
+                      <p className="mt-1.5 text-sm leading-relaxed" style={{ color: "var(--text-secondary)" }}>
+                        {rating.comment}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Danger Zone */}

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { PencilSimple, ClockCounterClockwise, Star, GameController } from "@phosphor-icons/react";
 import { UserAvatar } from "@/components/ui/UserAvatar";
@@ -36,7 +37,10 @@ async function fetchMyProfile(): Promise<UserProfile> {
   return json.data;
 }
 
+const RATINGS_PREVIEW_COUNT = 3;
+
 export default function MyProfilePage() {
+  const [showAllRatings, setShowAllRatings] = useState(false);
 
   const { data: user, isLoading, isError } = useQuery({
     queryKey: ["users", "me"],
@@ -225,41 +229,62 @@ export default function MyProfilePage() {
             まだ評価がありません
           </p>
         ) : (
-          <div className="space-y-3">
-            {user.receivedRatings.map((rating) => (
-              <div
-                key={rating.id}
-                className="rounded-xl p-4"
-                style={{ backgroundColor: "var(--bg-input)", border: "1px solid var(--border)" }}
-              >
-                <div className="flex items-start gap-3">
-                  <UserAvatar
-                    username={rating.reviewer.username}
-                    iconUrl={rating.reviewer.iconUrl}
-                    size="sm"
-                  />
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium truncate" style={{ color: "var(--text-primary)" }}>
-                        {rating.reviewer.username ?? "退会済みユーザー"}
-                      </span>
-                      <span className="text-xs shrink-0" style={{ color: "var(--text-muted)" }}>
-                        {new Date(rating.createdAt).toLocaleDateString("ja-JP")}
-                      </span>
+          <>
+            <div className="space-y-3">
+              {(showAllRatings
+                ? user.receivedRatings
+                : user.receivedRatings.slice(0, RATINGS_PREVIEW_COUNT)
+              ).map((rating) => (
+                <div
+                  key={rating.id}
+                  className="rounded-xl p-4"
+                  style={{ backgroundColor: "var(--bg-input)", border: "1px solid var(--border)" }}
+                >
+                  <div className="flex items-start gap-3">
+                    <UserAvatar
+                      username={rating.reviewer.username}
+                      iconUrl={rating.reviewer.iconUrl}
+                      size="sm"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium truncate" style={{ color: "var(--text-primary)" }}>
+                          {rating.reviewer.username ?? "退会済みユーザー"}
+                        </span>
+                        <span className="text-xs shrink-0" style={{ color: "var(--text-muted)" }}>
+                          {new Date(rating.createdAt).toLocaleDateString("ja-JP")}
+                        </span>
+                      </div>
+                      <div className="mt-1">
+                        <StarRating value={rating.score} readonly size="sm" />
+                      </div>
+                      {rating.comment && (
+                        <p className="mt-1.5 text-sm leading-relaxed" style={{ color: "var(--text-secondary)" }}>
+                          {rating.comment}
+                        </p>
+                      )}
                     </div>
-                    <div className="mt-1">
-                      <StarRating value={rating.score} readonly size="sm" />
-                    </div>
-                    {rating.comment && (
-                      <p className="mt-1.5 text-sm leading-relaxed" style={{ color: "var(--text-secondary)" }}>
-                        {rating.comment}
-                      </p>
-                    )}
                   </div>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+            {user.receivedRatings.length > RATINGS_PREVIEW_COUNT && (
+              <button
+                type="button"
+                onClick={() => setShowAllRatings((prev) => !prev)}
+                className="mt-3 w-full rounded-xl py-2.5 text-sm font-medium transition-colors hover:opacity-80"
+                style={{
+                  backgroundColor: "var(--bg-input)",
+                  border: "1px solid var(--border)",
+                  color: "var(--accent-light)",
+                }}
+              >
+                {showAllRatings
+                  ? "折りたたむ"
+                  : `すべて見る（${user.receivedRatings.length}件）`}
+              </button>
+            )}
+          </>
         )}
       </div>
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1005,6 +1005,136 @@ async function main() {
     });
   }
   console.log(`✓ users.avgRating/ratingCount 更新: ${ratingStats.length}件`);
+
+  // ─── 7. テスト用評価データ（特定ユーザー向け） ─────────────────────────────────
+  const TEST_USER_ID = "4ebc9fc7-0c59-476f-bb2b-c4049e8da154";
+  const TEST_ROOM_ID = "00000000-0000-0000-0000-000000000001";
+
+  const testUser = await prisma.user.findUnique({ where: { id: TEST_USER_ID } });
+  if (testUser) {
+    // テスト用クローズ済み部屋を upsert
+    await prisma.room.upsert({
+      where: { id: TEST_ROOM_ID },
+      update: {},
+      create: {
+        id: TEST_ROOM_ID,
+        title: "【評価テスト用】クローズ済み部屋",
+        gameId: games[0]!.id,
+        hostId: userId("gamer_alice"),
+        maxPlayers: 6,
+        description: "評価UIのテスト用クローズ済み部屋",
+        status: "closed",
+        closedAt: new Date("2026-03-01T00:00:00Z"),
+      },
+    });
+
+    // 参加者を追加（テストユーザー + シードユーザー5名）
+    const reviewerUsernames = [
+      "gamer_alice",
+      "player_bob",
+      "thunder_kai",
+      "neon_taka",
+      "pixel_luna",
+    ];
+    await prisma.roomParticipant.createMany({
+      data: [
+        {
+          roomId: TEST_ROOM_ID,
+          userId: TEST_USER_ID,
+          isHost: false,
+          leftAt: new Date("2026-03-01T00:00:00Z"),
+        },
+        ...reviewerUsernames.map((username) => ({
+          roomId: TEST_ROOM_ID,
+          userId: userId(username),
+          isHost: username === "gamer_alice",
+          leftAt: new Date("2026-03-01T00:00:00Z"),
+        })),
+      ],
+      skipDuplicates: true,
+    });
+
+    // シードユーザーからテストユーザーへの評価（コメント付き）
+    const testRatingDefs = [
+      {
+        reviewerUsername: "gamer_alice",
+        score: 5,
+        comment: "連携がすごく上手で、一緒にやってて楽しかったです！また組みたいです。",
+        createdAt: new Date("2026-03-15T10:00:00Z"),
+      },
+      {
+        reviewerUsername: "player_bob",
+        score: 4,
+        comment: "フレンドリーで話しやすい方でした。次回もよろしくお願いします！",
+        createdAt: new Date("2026-03-10T20:00:00Z"),
+      },
+      {
+        reviewerUsername: "thunder_kai",
+        score: 5,
+        comment: "動きが読みやすくてとても頼りになりました。ありがとう！",
+        createdAt: new Date("2026-03-08T15:00:00Z"),
+      },
+      {
+        reviewerUsername: "neon_taka",
+        score: 3,
+        comment: "楽しかったですが、もう少しコミュニケーション取れると良いかも。",
+        createdAt: new Date("2026-03-05T22:00:00Z"),
+      },
+      {
+        reviewerUsername: "pixel_luna",
+        score: 4,
+        comment: "初めてご一緒しましたが、丁寧な方で良かったです。",
+        createdAt: new Date("2026-03-02T18:00:00Z"),
+      },
+    ];
+
+    const expiredAt = new Date("2025-01-01T00:00:00Z");
+    let testRatingTotal = 0;
+    for (const r of testRatingDefs) {
+      await prisma.rating.upsert({
+        where: {
+          roomId_reviewerId_revieweeId: {
+            roomId: TEST_ROOM_ID,
+            reviewerId: userId(r.reviewerUsername),
+            revieweeId: TEST_USER_ID,
+          },
+        },
+        update: { score: r.score, comment: r.comment },
+        create: {
+          roomId: TEST_ROOM_ID,
+          reviewerId: userId(r.reviewerUsername),
+          revieweeId: TEST_USER_ID,
+          score: r.score,
+          comment: r.comment,
+          createdAt: r.createdAt,
+          expiresAt: expiredAt,
+        },
+      });
+      testRatingTotal++;
+    }
+
+    // テストユーザーの avgRating / ratingCount を再集計
+    const testStats = await prisma.rating.aggregate({
+      where: { revieweeId: TEST_USER_ID },
+      _avg: { score: true },
+      _count: { score: true },
+    });
+    await prisma.user.update({
+      where: { id: TEST_USER_ID },
+      data: {
+        avgRating: testStats._avg.score ?? 0,
+        ratingCount: testStats._count.score,
+      },
+    });
+
+    console.log(
+      `✓ テスト用評価データ: ${testRatingTotal}件 → ユーザー ${TEST_USER_ID}`
+    );
+  } else {
+    console.log(
+      `⚠ テストユーザー ${TEST_USER_ID} が存在しないためスキップ`
+    );
+  }
 }
 
 main()


### PR DESCRIPTION
## 概要

- `GET /api/v1/users/me` のレスポンスに `receivedRatings`（最新20件）を追加
- `/users/me` の「受け取った評価」セクションを実装（初期3件表示 → 全件展開）
- 受け取った評価は自分のプロフィールのみ表示（他ユーザーページには非表示）

## 変更内容

### API
- `rating.findMany` による別クエリで取得（PrismaPgアダプターの nested select で `orderBy`/`take` が無視される問題に対応）
- レスポンスに `score`, `comment`, `createdAt`, `reviewer.username`, `reviewer.iconUrl` を含む

### UI
- 初期表示3件、「すべて見る（N件）」ボタンで全件展開・折りたたみ
- 評価カード：星スコア・コメント・レビュアーのアバター・ユーザー名・日付

### テスト
- `GET /api/v1/users/me` のユニットテストを追加（5ケース）
- `GET /api/v1/users/[userId]` のテストを整理

### シード
- ユーザー `4ebc9fc7-0c59-476f-bb2b-c4049e8da154` へのコメント付き評価テストデータ5件を追加

## AC確認

- [x] `GET /api/v1/users/me` のレスポンスに `receivedRatings` 配列が含まれる
- [x] プロフィールページに評価一覧が表示される（スコア・コメント・レビュアー情報）
- [x] 評価が0件の場合は「まだ評価がありません」と表示される

Closes #86