### PR TITLE
feat: プロフィール画像をアップロード方式に変更 (#78)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,8 @@ TWITCH_CLIENT_SECRET=
 
 # Redis（ローカル Docker: docker compose up -d）
 REDIS_URL="redis://localhost:6379"
+
+# Supabase Storage（プロフィール画像アップロード用）
+# Supabase Dashboard > Settings > API から取得
+SUPABASE_URL="https://xxxx.supabase.co"
+SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"

--- a/app/(onboarding)/onboarding/page.tsx
+++ b/app/(onboarding)/onboarding/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { Lightning, Check, ArrowLeft, CaretRight } from "@phosphor-icons/react";
+import { Lightning, Check, ArrowLeft, CaretRight, Camera } from "@phosphor-icons/react";
 import { type Game } from "@/lib/mock-data";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { GridGamePicker } from "@/components/ui/GamePicker";
@@ -16,13 +16,23 @@ export default function OnboardingPage() {
   const callbackUrl = searchParams.get("callbackUrl");
   const { data: session, update, status } = useSession();
 
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   const [currentStep, setCurrentStep] = useState(1);
   const [username, setUsername] = useState("");
-  const [iconUrl, setIconUrl] = useState("");
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const [bio, setBio] = useState("");
   const [selectedGames, setSelectedGames] = useState<Game[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!avatarFile) return;
+    const url = URL.createObjectURL(avatarFile);
+    setAvatarPreview(url);
+    return () => URL.revokeObjectURL(url);
+  }, [avatarFile]);
 
   useEffect(() => {
     if (status === "authenticated" && !session?.user?.needsProfileSetup) {
@@ -35,13 +45,25 @@ export default function OnboardingPage() {
     setError(null);
 
     try {
+      if (avatarFile) {
+        const formData = new FormData();
+        formData.append("file", avatarFile);
+        const uploadRes = await fetch("/api/v1/users/me/avatar", {
+          method: "POST",
+          body: formData,
+        });
+        if (!uploadRes.ok) {
+          setError("画像のアップロードに失敗しました");
+          return;
+        }
+      }
+
       const res = await fetch("/api/v1/users/me", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           username: username.trim(),
           bio: bio || null,
-          iconUrl: iconUrl || null,
           gameIds: selectedGames.map((g) => g.id),
         }),
       });
@@ -303,31 +325,30 @@ export default function OnboardingPage() {
                   プロフィール画像を設定
                 </h1>
                 <p className="mt-2 text-sm" style={{ color: "var(--text-secondary)" }}>
-                  アイコンとして表示される画像のURLを入力してください。後から変更できます。
+                  アイコン画像を設定してください。後から変更できます。
                 </p>
               </div>
 
-              <div className="flex items-center gap-4">
-                <UserAvatar username={username || "?"} iconUrl={iconUrl || null} size="xl" />
-                <div className="flex-1">
-                  <label
-                    className="mb-1.5 block text-sm font-medium"
-                    style={{ color: "var(--text-primary)" }}
-                  >
-                    画像 URL{" "}
-                    <span className="text-xs font-normal" style={{ color: "var(--text-muted)" }}>
-                      （任意）
-                    </span>
-                  </label>
-                  <input
-                    type="url"
-                    placeholder="https://example.com/icon.png"
-                    value={iconUrl}
-                    onChange={(e) => setIconUrl(e.target.value)}
-                    className="w-full rounded-xl border px-4 py-2.5 text-sm outline-none focus:border-[var(--accent)] transition-colors"
-                    style={inputStyle}
-                  />
-                </div>
+              <div className="flex justify-center">
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  className="group relative flex-shrink-0"
+                  aria-label="アイコン画像を選択"
+                >
+                  <UserAvatar username={username || "?"} iconUrl={avatarPreview} size="xl" />
+                  <div className="absolute inset-0 rounded-full bg-black/50 opacity-0 transition-opacity group-hover:opacity-100" />
+                  <div className="absolute bottom-0 right-0 flex h-6 w-6 items-center justify-center rounded-full bg-black/80">
+                    <Camera className="h-3.5 w-3.5 text-white" />
+                  </div>
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp,image/gif"
+                  onChange={(e) => { const f = e.target.files?.[0]; if (f) setAvatarFile(f); }}
+                  className="hidden"
+                />
               </div>
             </div>
 

--- a/app/api/v1/users/me/avatar/route.test.ts
+++ b/app/api/v1/users/me/avatar/route.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: { update: vi.fn() },
+  },
+}));
+
+const { mockUpload, mockGetPublicUrl, mockFrom } = vi.hoisted(() => ({
+  mockUpload: vi.fn(),
+  mockGetPublicUrl: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    storage: { from: mockFrom },
+  },
+  AVATAR_BUCKET: "avatar_images",
+}));
+
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { POST } from "./route";
+
+const mockAuth = vi.mocked(auth);
+const mockUserUpdate = vi.mocked(prisma.user.update);
+
+const makeFile = (name = "avatar.png", type = "image/png", sizeBytes = 1024) =>
+  new File([new Uint8Array(sizeBytes)], name, { type });
+
+// request.formData() を直接モックして jsdom のマルチパート解析を回避する
+const makeRequest = (file?: File) => {
+  const formData = new FormData();
+  if (file) formData.append("file", file);
+  return {
+    formData: () => Promise.resolve(formData),
+  } as unknown as Request;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFrom.mockReturnValue({
+    upload: mockUpload,
+    getPublicUrl: mockGetPublicUrl,
+  });
+});
+
+describe("POST /api/v1/users/me/avatar", () => {
+  it("未認証の場合 401 UNAUTHORIZED を返す", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const res = await POST(makeRequest(makeFile()));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("UNAUTHORIZED");
+  });
+
+  it("ファイルが含まれない場合 400 FILE_REQUIRED を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+
+    const res = await POST(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("FILE_REQUIRED");
+  });
+
+  it("許可されていない MIME タイプの場合 400 INVALID_FILE_TYPE を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+
+    const res = await POST(makeRequest(makeFile("doc.pdf", "application/pdf")));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("INVALID_FILE_TYPE");
+  });
+
+  it("5MB 超のファイルの場合 400 FILE_TOO_LARGE を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    const oversizedFile = makeFile("big.png", "image/png", 5 * 1024 * 1024 + 1);
+
+    const res = await POST(makeRequest(oversizedFile));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("FILE_TOO_LARGE");
+  });
+
+  it("Supabase アップロード失敗の場合 500 UPLOAD_FAILED を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockUpload.mockResolvedValue({ error: { message: "Bucket not found" } });
+
+    const res = await POST(makeRequest(makeFile()));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe("UPLOAD_FAILED");
+  });
+
+  it("正常アップロードの場合 200 と iconUrl を返し DB を更新する", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockUpload.mockResolvedValue({ error: null });
+    mockGetPublicUrl.mockReturnValue({
+      data: { publicUrl: "https://example.supabase.co/storage/v1/object/public/avatar_images/user-1/avatar.png" },
+    });
+    mockUserUpdate.mockResolvedValue({ id: "user-1" } as never);
+
+    const res = await POST(makeRequest(makeFile()));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.iconUrl).toContain("user-1/avatar.png");
+    expect(mockUserUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "user-1" },
+        data: { iconUrl: expect.stringContaining("user-1/avatar.png") },
+      })
+    );
+  });
+
+  it("アップロード時にユーザー ID をパスに含める", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "abc-123" } } as never);
+    mockUpload.mockResolvedValue({ error: null });
+    mockGetPublicUrl.mockReturnValue({
+      data: { publicUrl: "https://example.supabase.co/storage/v1/object/public/avatar_images/abc-123/avatar.png" },
+    });
+    mockUserUpdate.mockResolvedValue({ id: "abc-123" } as never);
+
+    await POST(makeRequest(makeFile("photo.png", "image/png")));
+
+    expect(mockFrom).toHaveBeenCalledWith("avatar_images");
+    expect(mockUpload).toHaveBeenCalledWith(
+      "abc-123/avatar.png",
+      expect.any(Uint8Array),
+      expect.objectContaining({ contentType: "image/png", upsert: true })
+    );
+  });
+});

--- a/app/api/v1/users/me/avatar/route.ts
+++ b/app/api/v1/users/me/avatar/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { supabase, AVATAR_BUCKET } from "@/lib/supabase";
+
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "UNAUTHORIZED" }, { status: 401 });
+  }
+
+  const formData = await request.formData();
+  const file = formData.get("file");
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "FILE_REQUIRED" }, { status: 400 });
+  }
+
+  if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+    return NextResponse.json({ error: "INVALID_FILE_TYPE" }, { status: 400 });
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json({ error: "FILE_TOO_LARGE" }, { status: 400 });
+  }
+
+  const ext = file.name.split(".").pop() ?? "jpg";
+  const path = `${session.user.id}/avatar.${ext}`;
+
+  const arrayBuffer = await file.arrayBuffer();
+  const buffer = new Uint8Array(arrayBuffer);
+
+  const { error: uploadError } = await supabase.storage
+    .from(AVATAR_BUCKET)
+    .upload(path, buffer, {
+      contentType: file.type,
+      upsert: true,
+    });
+
+  if (uploadError) {
+    console.error("[avatar upload] Supabase error:", uploadError);
+    return NextResponse.json(
+      { error: "UPLOAD_FAILED", detail: uploadError.message },
+      { status: 500 }
+    );
+  }
+
+  const {
+    data: { publicUrl },
+  } = supabase.storage.from(AVATAR_BUCKET).getPublicUrl(path);
+
+  await prisma.user.update({
+    where: { id: session.user.id },
+    data: { iconUrl: publicUrl },
+  });
+
+  return NextResponse.json({ data: { iconUrl: publicUrl } });
+}

--- a/app/api/v1/users/me/route.test.ts
+++ b/app/api/v1/users/me/route.test.ts
@@ -22,11 +22,13 @@ vi.mock("@/lib/prisma", () => ({
 
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { GET } from "./route";
+import { Prisma } from "@prisma/client";
+import { GET, PATCH } from "./route";
 
 const mockAuth = vi.mocked(auth);
 const mockFindUnique = vi.mocked(prisma.user.findUnique);
 const mockRatingFindMany = vi.mocked(prisma.rating.findMany);
+const mockTransaction = prisma.$transaction as ReturnType<typeof vi.fn>;
 
 const makeUser = () => ({
   id: "user-1",
@@ -141,5 +143,71 @@ describe("GET /api/v1/users/me", () => {
 
     expect(res.status).toBe(200);
     expect(body.data.receivedRatings).toEqual([]);
+  });
+});
+
+const makePatchRequest = (body: Record<string, unknown>) =>
+  new Request("http://localhost/api/v1/users/me", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+describe("PATCH /api/v1/users/me", () => {
+  it("未認証の場合 401 UNAUTHORIZED を返す", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const res = await PATCH(makePatchRequest({ username: "newname" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("UNAUTHORIZED");
+  });
+
+  it("username が空文字の場合 400 BAD_REQUEST を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+
+    const res = await PATCH(makePatchRequest({ username: "" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("BAD_REQUEST");
+  });
+
+  it("正常更新の場合 200 とユーザーデータを返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockTransaction.mockImplementation(async (fn: (tx: typeof prisma) => Promise<unknown>) =>
+      fn({
+        ...prisma,
+        user: {
+          ...prisma.user,
+          update: vi.fn().mockResolvedValue({
+            ...makeUser(),
+            username: "updatedname",
+          }),
+        },
+      } as never)
+    );
+
+    const res = await PATCH(makePatchRequest({ username: "updatedname" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.username).toBe("updatedname");
+  });
+
+  it("ユーザー名重複の場合 409 USERNAME_TAKEN を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint", {
+      code: "P2002",
+      clientVersion: "5.0.0",
+    });
+    mockTransaction.mockRejectedValue(prismaError);
+
+    const res = await PATCH(makePatchRequest({ username: "takenname" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.error).toBe("USERNAME_TAKEN");
   });
 });

--- a/app/api/v1/users/me/route.ts
+++ b/app/api/v1/users/me/route.ts
@@ -163,7 +163,7 @@ export async function PATCH(request: Request) {
       });
     });
 
-    return NextResponse.json({ data: formatUser(user) });
+    return NextResponse.json({ data: formatUser(user, []) });
   } catch (error) {
     if (
       error instanceof Prisma.PrismaClientKnownRequestError &&

--- a/app/users/me/edit/page.tsx
+++ b/app/users/me/edit/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
-import { ArrowLeft, FloppyDisk } from "@phosphor-icons/react";
+import { ArrowLeft, FloppyDisk, Camera } from "@phosphor-icons/react";
 import { type Game } from "@/lib/mock-data";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { MultiGamePicker } from "@/components/ui/GamePicker";
@@ -27,6 +27,7 @@ async function fetchMyProfile(): Promise<UserProfile> {
 export default function EditProfilePage() {
   const router = useRouter();
   const { data: session, update, status } = useSession();
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { data: profile } = useQuery({
     queryKey: ["users", "me"],
@@ -35,7 +36,9 @@ export default function EditProfilePage() {
   });
 
   const [username, setUsername] = useState(session?.user?.username ?? "");
-  const [iconUrl, setIconUrl] = useState(session?.user?.iconUrl ?? "");
+  const [iconUrl, setIconUrl] = useState<string | null>(session?.user?.iconUrl ?? null);
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const [bio, setBio] = useState("");
   const [selectedGames, setSelectedGames] = useState<Game[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -45,12 +48,25 @@ export default function EditProfilePage() {
   useEffect(() => {
     if (profile && !initialized) {
       setUsername(profile.username);
-      setIconUrl(profile.iconUrl ?? "");
+      setIconUrl(profile.iconUrl);
       setBio(profile.bio ?? "");
       setSelectedGames(profile.games);
       setInitialized(true);
     }
   }, [profile, initialized]);
+
+  useEffect(() => {
+    if (!avatarFile) return;
+    const url = URL.createObjectURL(avatarFile);
+    setAvatarPreview(url);
+    return () => URL.revokeObjectURL(url);
+  }, [avatarFile]);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setAvatarFile(file);
+  };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -58,13 +74,43 @@ export default function EditProfilePage() {
     setSaving(true);
 
     try {
+      // アバター画像のアップロード
+      if (avatarFile) {
+        const formData = new FormData();
+        formData.append("file", avatarFile);
+
+        const uploadRes = await fetch("/api/v1/users/me/avatar", {
+          method: "POST",
+          body: formData,
+        });
+
+        const uploadJson = (await uploadRes.json()) as {
+          data?: { iconUrl: string };
+          error?: string;
+        };
+
+        if (!uploadRes.ok) {
+          const msgMap: Record<string, string> = {
+            FILE_TOO_LARGE: "画像サイズは5MB以内にしてください",
+            INVALID_FILE_TYPE: "JPEG / PNG / WebP / GIF のみアップロード可能です",
+            UPLOAD_FAILED: "画像のアップロードに失敗しました",
+          };
+          setError(msgMap[uploadJson.error ?? ""] ?? "画像のアップロードに失敗しました");
+          return;
+        }
+
+        if (uploadJson.data) {
+          setIconUrl(uploadJson.data.iconUrl);
+        }
+      }
+
+      // プロフィール更新
       const res = await fetch("/api/v1/users/me", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           username: username.trim(),
           bio: bio || null,
-          iconUrl: iconUrl || null,
           gameIds: selectedGames.map((g) => g.id),
         }),
       });
@@ -91,55 +137,45 @@ export default function EditProfilePage() {
     color: "var(--text-primary)",
   };
 
+  const displayIconUrl = avatarPreview ?? iconUrl;
+
   return (
     <div className="mx-auto max-w-2xl px-4 py-4 sm:px-6 sm:py-8">
       <Link
         href="/users/me"
-        className="mb-3 flex items-center gap-2 text-sm transition-colors hover:text-white sm:mb-6"
-        style={{ color: "var(--text-secondary)" }}
-      >
-        <ArrowLeft className="h-4 w-4" />
-        プロフィールに戻る
-      </Link>
-
-      <h1
-        className="mb-2 text-xl font-bold sm:text-2xl"
+        className="mb-6 flex items-center gap-2 text-xl font-bold transition-colors hover:opacity-80 sm:text-2xl"
         style={{ color: "var(--text-primary)" }}
       >
+        <ArrowLeft className="h-5 w-5" />
         プロフィール編集
-      </h1>
+      </Link>
 
       <form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col gap-6 sm:gap-8">
         {/* Avatar section */}
-        <div>
-          <p
-            className="mb-4 text-sm font-medium"
-            style={{ color: "var(--text-secondary)" }}
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="group relative flex-shrink-0"
+            aria-label="アイコン画像を変更"
           >
-            アイコン
-          </p>
-          <div className="flex items-center gap-4">
-            <UserAvatar username={username || "?"} iconUrl={iconUrl || null} size="xl" />
-            <div className="flex-1">
-              <label
-                className="mb-1.5 block text-sm font-medium"
-                style={{ color: "var(--text-primary)" }}
-              >
-                アイコン URL{" "}
-                <span className="text-xs font-normal" style={{ color: "var(--text-muted)" }}>
-                  （任意）
-                </span>
-              </label>
-              <input
-                type="url"
-                placeholder="https://example.com/icon.png"
-                value={iconUrl}
-                onChange={(e) => setIconUrl(e.target.value)}
-                className="w-full rounded-xl border px-4 py-2.5 text-sm outline-none transition-colors focus:border-[var(--accent)]"
-                style={inputStyle}
-              />
+            <UserAvatar
+              username={username || "?"}
+              iconUrl={displayIconUrl}
+              size="xl"
+            />
+            <div className="absolute inset-0 rounded-full bg-black/50 opacity-0 transition-opacity group-hover:opacity-100" />
+            <div className="absolute bottom-0 right-0 flex h-6 w-6 items-center justify-center rounded-full bg-black/80">
+              <Camera className="h-3.5 w-3.5 text-white" />
             </div>
-          </div>
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp,image/gif"
+            onChange={handleFileChange}
+            className="hidden"
+          />
         </div>
 
         {/* Username section */}
@@ -159,9 +195,6 @@ export default function EditProfilePage() {
             className="w-full rounded-xl border px-4 py-2.5 text-sm outline-none transition-colors focus:border-[var(--accent)]"
             style={inputStyle}
           />
-          <p className="mt-1.5 text-xs" style={{ color: "var(--text-muted)" }}>
-            必須 · 50文字以内
-          </p>
         </div>
 
         {/* Bio section */}
@@ -170,10 +203,7 @@ export default function EditProfilePage() {
             className="mb-3 block text-sm font-medium"
             style={{ color: "var(--text-secondary)" }}
           >
-            自己紹介{" "}
-            <span className="text-xs font-normal" style={{ color: "var(--text-muted)" }}>
-              （任意）
-            </span>
+            自己紹介
           </label>
           <textarea
             rows={3}
@@ -184,9 +214,6 @@ export default function EditProfilePage() {
             className="w-full resize-none rounded-xl border px-4 py-2.5 text-sm outline-none transition-colors focus:border-[var(--accent)]"
             style={inputStyle}
           />
-          <p className="mt-1.5 text-xs" style={{ color: "var(--text-muted)" }}>
-            500文字以内
-          </p>
         </div>
 
         {/* Games section */}
@@ -195,15 +222,9 @@ export default function EditProfilePage() {
             className="mb-3 block text-sm font-medium"
             style={{ color: "var(--text-secondary)" }}
           >
-            プレイしているゲーム{" "}
-            <span className="text-xs font-normal" style={{ color: "var(--text-muted)" }}>
-              （最大20件）
-            </span>
+            プレイしているゲーム
           </label>
           <MultiGamePicker value={selectedGames} onChange={setSelectedGames} max={20} />
-          <p className="mt-1.5 text-xs" style={{ color: "var(--text-muted)" }}>
-            ゲーム名を入力して検索し、プレイしているゲームを登録できます
-          </p>
         </div>
 
         {/* Error */}

--- a/docs/05_02_api_users.md
+++ b/docs/05_02_api_users.md
@@ -13,6 +13,7 @@
 |---------|------|------|------|
 | GET | `/users/me` | 必要 | 自分のプロフィール取得 |
 | PATCH | `/users/me` | 必要 | 自分のプロフィール更新 |
+| POST | `/users/me/avatar` | 必要 | プロフィール画像アップロード |
 | DELETE | `/users/me` | 必要 | アカウント削除 |
 | GET | `/users/{userId}` | 不要 | ユーザープロフィール取得 |
 | GET | `/users/me/rooms` | 必要 | 自分の部屋参加履歴取得 |
@@ -93,7 +94,45 @@ PATCH /users/me
 
 ---
 
-## 4. アカウント削除
+## 4. プロフィール画像アップロード
+
+画像ファイルをアップロードし、Supabase Storage に保存した上で `iconUrl` を更新する。
+
+```
+POST /users/me/avatar
+```
+
+**認証**: 必要
+**Content-Type**: `multipart/form-data`
+
+### リクエストボディ
+
+| フィールド | 型 | 制約 | 説明 |
+|-----------|-----|------|------|
+| `file` | File | JPEG / PNG / WebP / GIF、5MB 以内 | アップロードする画像ファイル |
+
+### レスポンス `200 OK`
+
+```json
+{
+  "data": {
+    "iconUrl": "https://xxxx.supabase.co/storage/v1/object/public/avatar_images/user-id/avatar.png"
+  }
+}
+```
+
+### エラー
+
+| HTTP | エラーコード | 説明 |
+|------|------------|------|
+| 400 | `FILE_REQUIRED` | ファイルが含まれていない |
+| 400 | `INVALID_FILE_TYPE` | 許可されていない MIME タイプ |
+| 400 | `FILE_TOO_LARGE` | ファイルサイズが 5MB 超 |
+| 500 | `UPLOAD_FAILED` | Supabase Storage へのアップロード失敗 |
+
+---
+
+## 5. アカウント削除
 
 アカウントおよびすべての関連データを物理削除する。
 
@@ -107,7 +146,7 @@ DELETE /users/me
 
 ---
 
-## 5. ユーザープロフィール取得
+## 6. ユーザープロフィール取得
 
 ```
 GET /users/{userId}
@@ -144,7 +183,7 @@ GET /users/{userId}
 
 ---
 
-## 6. 自分の参加履歴取得
+## 7. 自分の参加履歴取得
 
 新しい順（`joined_at` 降順）で返却される。
 

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,12 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseServiceRoleKey) {
+  throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+}
+
+export const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
+
+export const AVATAR_BUCKET = "avatar_images";

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "lh3.googleusercontent.com",
       },
+      {
+        protocol: "https",
+        hostname: "*.supabase.co",
+      },
     ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "@prisma/adapter-pg": "^7.4.1",
     "@prisma/client": "^7.4.1",
+    "@supabase/supabase-js": "^2.100.1",
     "@tanstack/react-query": "^5.90.21",
     "clsx": "^2.1.1",
     "dotenv": "^17.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@prisma/client':
         specifier: ^7.4.1
         version: 7.4.1(prisma@7.4.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
+      '@supabase/supabase-js':
+        specifier: ^2.100.1
+        version: 2.100.1
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.3)
@@ -1032,6 +1035,33 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@supabase/auth-js@2.100.1':
+    resolution: {integrity: sha512-c5FB4nrG7cs1mLSzFGuIVl2iR2YO5XkSJ96uF4zubYm8YDn71XOi2emE9sBm/avfGCj61jaRBLOvxEAVnpys0Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.100.1':
+    resolution: {integrity: sha512-mo8QheoV4KR+wSubtyEWhZUxWnCM7YZ23TncccMAlbWAHb8YTDqRGRm9IalWCAswniKyud6buZCk9snRqI86KA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.0':
+    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+
+  '@supabase/postgrest-js@2.100.1':
+    resolution: {integrity: sha512-OIh4mOSo2LdqF2kox76OAPDtcSs+PwKABJOjc6plUV4/LXhFEsI2uwdEEIs7K7fd141qehWEVl/Y+Ts0fNvYsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.100.1':
+    resolution: {integrity: sha512-FHuRWPX4qZQ4x+0Q+ZrKaBZnOiVGiwsgiAUJM98pYRib1yeaE/fOM1lZ1ozd+4gA8Udw23OyaD8SxKS5mT5NYw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.100.1':
+    resolution: {integrity: sha512-x9xpEIoWM4xKiAlwfWTgHPSN6N4Y0aS4FVU4F6ZPbq7Gayw08SrtC6/YH/gOr8CjXQr0HxXYXDop2xGTSjubYA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.100.1':
+    resolution: {integrity: sha512-CAeFm5sfX8sbTzxoxRafhohreIzl9a7R6qHTck3MrgTqm5M5g/u0IHfEKYzI9w/17r8NINl8UZrw2i08wrO7Iw==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1213,6 +1243,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.56.0':
     resolution: {integrity: sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==}
@@ -2177,6 +2210,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -4209,6 +4246,46 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@supabase/auth-js@2.100.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.100.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.0': {}
+
+  '@supabase/postgrest-js@2.100.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.100.1':
+    dependencies:
+      '@supabase/phoenix': 0.4.0
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.100.1':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.100.1':
+    dependencies:
+      '@supabase/auth-js': 2.100.1
+      '@supabase/functions-js': 2.100.1
+      '@supabase/postgrest-js': 2.100.1
+      '@supabase/realtime-js': 2.100.1
+      '@supabase/storage-js': 2.100.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -4385,6 +4462,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.33
 
   '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -5564,6 +5645,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.7.2:
     dependencies:


### PR DESCRIPTION
## 概要

- Supabase Storage を利用したプロフィール画像アップロード機能を実装
- プロフィール編集・オンボーディングの画像設定を URL 入力からファイルアップロードに変更

## 変更内容

- `POST /api/v1/users/me/avatar` エンドポイントを新規追加
  - JPEG / PNG / WebP / GIF、5MB 以内を受け付け
  - `upsert: true` でユーザーごとに上書き保存し、DB の `iconUrl` を更新
- プロフィール編集画面（`app/users/me/edit/page.tsx`）
  - URL 入力フィールドをファイル選択 UI に置き換え
  - アバタークリックで file input 起動、選択後プレビュー即時反映
  - カメラアイコンを右下に常時表示
- オンボーディング Step 4（`app/(onboarding)/onboarding/page.tsx`）
  - 同様にファイルアップロード方式へ変更
- `next.config.ts` に `*.supabase.co` を `remotePatterns` へ追加
- `PATCH /api/v1/users/me` の `formatUser` 第2引数欠落バグを修正
- `@supabase/supabase-js` を追加
- `.env.example` に `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` を追記

## 環境変数

`.env` に以下を追加してください（`.env.example` 参照）：

```
SUPABASE_URL=https://xxxx.supabase.co
SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
```

Supabase Storage に `avatar_images`（Public）バケットが必要です。

Closes #78