### PR TITLE
feat: DBスキーマ変更 - 招待tokenとゲストチャット表示名フィールドの追加

### DIFF
--- a/prisma/migrations/20260403000000_add_invite_token_and_guest_display_name/migration.sql
+++ b/prisma/migrations/20260403000000_add_invite_token_and_guest_display_name/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "rooms" ADD COLUMN "invite_token" VARCHAR(64);
+
+-- AlterTable
+ALTER TABLE "chat_messages" ADD COLUMN "display_name" VARCHAR(50);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rooms_invite_token_key" ON "rooms"("invite_token");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,6 +74,7 @@ model Room {
   createdAt   DateTime   @default(now()) @map("created_at") @db.Timestamptz
   updatedAt   DateTime   @updatedAt @map("updated_at") @db.Timestamptz
   closedAt    DateTime?  @map("closed_at") @db.Timestamptz
+  inviteToken String?    @unique @map("invite_token") @db.VarChar(64)
 
   host          User               @relation("RoomHost", fields: [hostId], references: [id], onDelete: Restrict)
   game          Game               @relation(fields: [gameId], references: [id])
@@ -114,8 +115,9 @@ model ChatMessage {
   roomId    String   @map("room_id") @db.Uuid
   userId    String?  @map("user_id") @db.Uuid
   content   String
-  isSystem  Boolean  @default(false) @map("is_system")
-  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  isSystem    Boolean  @default(false) @map("is_system")
+  displayName String?  @map("display_name") @db.VarChar(50)
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
 
   room Room  @relation(fields: [roomId], references: [id], onDelete: Cascade)
   user User? @relation(fields: [userId], references: [id], onDelete: SetNull)


### PR DESCRIPTION
## 概要

招待URL機能とゲストチャット機能の基盤となるDBスキーマ変更。

## 変更内容

- `rooms` テーブルに `invite_token VARCHAR(64) UNIQUE NULL` を追加
- `chat_messages` テーブルに `display_name VARCHAR(50) NULL` を追加
- マイグレーション適用済み

Closes #94