### PR TITLE
feat: 招待URL発行機能（API + UI）

### DIFF
--- a/app/api/v1/rooms/[roomId]/invite/route.test.ts
+++ b/app/api/v1/rooms/[roomId]/invite/route.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    room: { findUnique: vi.fn(), update: vi.fn() },
+  },
+}));
+
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { POST, DELETE } from "./route";
+
+const mockAuth = vi.mocked(auth);
+const mockFindUnique = vi.mocked(prisma.room.findUnique);
+const mockUpdate = vi.mocked(prisma.room.update);
+
+const makePostRequest = () =>
+  new Request("http://localhost/api/v1/rooms/room-1/invite", { method: "POST" });
+const makeDeleteRequest = () =>
+  new Request("http://localhost/api/v1/rooms/room-1/invite", { method: "DELETE" });
+const makeParams = () => ({ params: Promise.resolve({ roomId: "room-1" }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/v1/rooms/[roomId]/invite", () => {
+  it("未認証の場合 401 UNAUTHORIZED を返す", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const res = await POST(makePostRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("room が存在しない場合 404 ROOM_NOT_FOUND を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await POST(makePostRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error.code).toBe("ROOM_NOT_FOUND");
+  });
+
+  it("ホスト以外のユーザーの場合 403 FORBIDDEN を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue({
+      id: "room-1",
+      hostId: "other-user",
+      status: "waiting",
+      inviteToken: null,
+    } as never);
+
+    const res = await POST(makePostRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("closed な部屋の場合 400 ROOM_CLOSED を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue({
+      id: "room-1",
+      hostId: "user-1",
+      status: "closed",
+      inviteToken: null,
+    } as never);
+
+    const res = await POST(makePostRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("ROOM_CLOSED");
+  });
+
+  it("既存トークンがある場合は新規生成せずそのまま返す（冪等）", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue({
+      id: "room-1",
+      hostId: "user-1",
+      status: "waiting",
+      inviteToken: "existing-token",
+    } as never);
+
+    const res = await POST(makePostRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.inviteToken).toBe("existing-token");
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("トークンが未生成の場合は新規生成して返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue({
+      id: "room-1",
+      hostId: "user-1",
+      status: "waiting",
+      inviteToken: null,
+    } as never);
+    mockUpdate.mockResolvedValue({ inviteToken: "a".repeat(64) } as never);
+
+    const res = await POST(makePostRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.inviteToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "room-1" },
+        data: expect.objectContaining({ inviteToken: expect.stringMatching(/^[0-9a-f]{64}$/) }),
+      })
+    );
+  });
+});
+
+describe("DELETE /api/v1/rooms/[roomId]/invite", () => {
+  it("未認証の場合 401 UNAUTHORIZED を返す", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const res = await DELETE(makeDeleteRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("room が存在しない場合 404 ROOM_NOT_FOUND を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await DELETE(makeDeleteRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error.code).toBe("ROOM_NOT_FOUND");
+  });
+
+  it("ホスト以外のユーザーの場合 403 FORBIDDEN を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue({
+      id: "room-1",
+      hostId: "other-user",
+      status: "waiting",
+    } as never);
+
+    const res = await DELETE(makeDeleteRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("closed な部屋の場合 400 ROOM_CLOSED を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue({
+      id: "room-1",
+      hostId: "user-1",
+      status: "closed",
+    } as never);
+
+    const res = await DELETE(makeDeleteRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("ROOM_CLOSED");
+  });
+
+  it("正常無効化の場合 204 を返しトークンを null にする", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue({
+      id: "room-1",
+      hostId: "user-1",
+      status: "waiting",
+    } as never);
+    mockUpdate.mockResolvedValue({} as never);
+
+    const res = await DELETE(makeDeleteRequest(), makeParams());
+
+    expect(res.status).toBe(204);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "room-1" },
+        data: { inviteToken: null },
+      })
+    );
+  });
+});

--- a/app/api/v1/rooms/[roomId]/invite/route.ts
+++ b/app/api/v1/rooms/[roomId]/invite/route.ts
@@ -1,0 +1,77 @@
+import { randomBytes } from "crypto";
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+type RouteParams = { params: Promise<{ roomId: string }> };
+
+export async function POST(_request: Request, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: { code: "UNAUTHORIZED", message: "認証が必要です" } }, { status: 401 });
+  }
+
+  const { roomId } = await params;
+
+  const room = await prisma.room.findUnique({
+    where: { id: roomId },
+    select: { id: true, hostId: true, status: true, inviteToken: true },
+  });
+
+  if (!room) {
+    return NextResponse.json({ error: { code: "ROOM_NOT_FOUND", message: "部屋が存在しません" } }, { status: 404 });
+  }
+
+  if (room.hostId !== session.user.id) {
+    return NextResponse.json({ error: { code: "FORBIDDEN", message: "ホストのみ招待リンクを発行できます" } }, { status: 403 });
+  }
+
+  if (room.status === "closed") {
+    return NextResponse.json({ error: { code: "ROOM_CLOSED", message: "解散済みの部屋には招待リンクを発行できません" } }, { status: 400 });
+  }
+
+  if (room.inviteToken) {
+    return NextResponse.json({ data: { inviteToken: room.inviteToken } });
+  }
+
+  const inviteToken = randomBytes(32).toString("hex");
+  await prisma.room.update({
+    where: { id: roomId },
+    data: { inviteToken },
+  });
+
+  return NextResponse.json({ data: { inviteToken } });
+}
+
+export async function DELETE(_request: Request, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: { code: "UNAUTHORIZED", message: "認証が必要です" } }, { status: 401 });
+  }
+
+  const { roomId } = await params;
+
+  const room = await prisma.room.findUnique({
+    where: { id: roomId },
+    select: { id: true, hostId: true, status: true },
+  });
+
+  if (!room) {
+    return NextResponse.json({ error: { code: "ROOM_NOT_FOUND", message: "部屋が存在しません" } }, { status: 404 });
+  }
+
+  if (room.hostId !== session.user.id) {
+    return NextResponse.json({ error: { code: "FORBIDDEN", message: "ホストのみ招待リンクを無効化できます" } }, { status: 403 });
+  }
+
+  if (room.status === "closed") {
+    return NextResponse.json({ error: { code: "ROOM_CLOSED", message: "解散済みの部屋です" } }, { status: 400 });
+  }
+
+  await prisma.room.update({
+    where: { id: roomId },
+    data: { inviteToken: null },
+  });
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/rooms/[roomId]/InvitePanel.test.tsx
+++ b/app/rooms/[roomId]/InvitePanel.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: vi.fn(),
+}));
+
+vi.mock("@phosphor-icons/react", () => ({
+  LinkSimple: () => <span data-testid="icon-link" />,
+  Copy: () => <span data-testid="icon-copy" />,
+  Prohibit: () => <span data-testid="icon-prohibit" />,
+  CircleNotch: () => <span data-testid="icon-spinner" />,
+  Check: () => <span data-testid="icon-check" />,
+}));
+
+vi.mock("@/lib/api/rooms", () => ({
+  generateInviteToken: vi.fn(),
+  invalidateInviteToken: vi.fn(),
+}));
+
+import { useMutation } from "@tanstack/react-query";
+import { InvitePanel } from "./InvitePanel";
+
+const mockUseMutation = vi.mocked(useMutation);
+
+type MutationConfig = {
+  mutationFn?: () => Promise<unknown>;
+  onSuccess?: (data: unknown) => void;
+};
+
+function makeMutation(overrides: Partial<ReturnType<typeof useMutation>> = {}) {
+  return {
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    ...overrides,
+  } as unknown as ReturnType<typeof useMutation>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseMutation.mockReturnValue(makeMutation());
+});
+
+describe("InvitePanel", () => {
+  it("初期状態では「招待リンクを生成」ボタンが表示される", () => {
+    render(<InvitePanel roomId="room-1" />);
+    expect(screen.getByText("招待リンクを生成")).toBeInTheDocument();
+  });
+
+  it("「招待リンクを生成」ボタンをクリックすると generateMutation.mutate が呼ばれる", () => {
+    const generateMutate = vi.fn();
+    mockUseMutation
+      .mockReturnValueOnce(makeMutation({ mutate: generateMutate }))
+      .mockReturnValueOnce(makeMutation());
+
+    render(<InvitePanel roomId="room-1" />);
+    fireEvent.click(screen.getByText("招待リンクを生成"));
+    expect(generateMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("生成中は「招待リンクを生成」ボタンが無効化される", () => {
+    mockUseMutation
+      .mockReturnValueOnce(makeMutation({ isPending: true }))
+      .mockReturnValueOnce(makeMutation());
+
+    render(<InvitePanel roomId="room-1" />);
+    expect(screen.getByText("招待リンクを生成").closest("button")).toBeDisabled();
+  });
+
+  it("生成エラー時にエラーメッセージが表示される", () => {
+    mockUseMutation
+      .mockReturnValueOnce(makeMutation({ isError: true, error: new Error("生成に失敗しました") }))
+      .mockReturnValueOnce(makeMutation());
+
+    render(<InvitePanel roomId="room-1" />);
+    expect(screen.getByText("生成に失敗しました")).toBeInTheDocument();
+  });
+
+  it("onSuccess でトークンがセットされると招待URLが表示される", async () => {
+    let capturedOnSuccess: ((data: unknown) => void) | undefined;
+    mockUseMutation.mockImplementation((config: MutationConfig) => {
+      if (!capturedOnSuccess && config.onSuccess) {
+        capturedOnSuccess = config.onSuccess;
+      }
+      return makeMutation();
+    });
+
+    render(<InvitePanel roomId="room-1" />);
+
+    capturedOnSuccess?.({ data: { inviteToken: "abc123" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/abc123/)).toBeInTheDocument();
+    });
+  });
+
+  it("「リンクを無効化」ボタンをクリックすると invalidateMutation.mutate が呼ばれる", async () => {
+    const invalidateMutate = vi.fn();
+    let capturedOnSuccess: ((data: unknown) => void) | undefined;
+
+    mockUseMutation.mockImplementation((config: MutationConfig) => {
+      if (!capturedOnSuccess && config.onSuccess) {
+        capturedOnSuccess = config.onSuccess;
+        return makeMutation();
+      }
+      return makeMutation({ mutate: invalidateMutate });
+    });
+
+    render(<InvitePanel roomId="room-1" />);
+    capturedOnSuccess?.({ data: { inviteToken: "abc123" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("リンクを無効化")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("リンクを無効化"));
+    expect(invalidateMutate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/rooms/[roomId]/InvitePanel.tsx
+++ b/app/rooms/[roomId]/InvitePanel.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { LinkSimple, Copy, Prohibit, CircleNotch, Check } from "@phosphor-icons/react";
+import { generateInviteToken, invalidateInviteToken } from "@/lib/api/rooms";
+
+type Props = { roomId: string };
+
+export function InvitePanel({ roomId }: Props) {
+  const [inviteToken, setInviteToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const inviteUrl = inviteToken
+    ? `${window.location.origin}/rooms/${roomId}?invite=${inviteToken}`
+    : null;
+
+  const generateMutation = useMutation({
+    mutationFn: () => generateInviteToken(roomId),
+    onSuccess: (res) => setInviteToken(res.data.inviteToken),
+  });
+
+  const invalidateMutation = useMutation({
+    mutationFn: () => invalidateInviteToken(roomId),
+    onSuccess: () => setInviteToken(null),
+  });
+
+  const handleCopy = () => {
+    if (!inviteUrl) return;
+    void navigator.clipboard.writeText(inviteUrl).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div
+      className="rounded-xl border px-5 py-4 space-y-3"
+      style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
+    >
+      <div className="flex items-center gap-2">
+        <LinkSimple className="h-4 w-4" style={{ color: "var(--text-muted)" }} />
+        <span className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+          招待リンク
+        </span>
+      </div>
+
+      {!inviteUrl ? (
+        <div className="flex flex-col gap-2">
+          <button
+            onClick={() => generateMutation.mutate()}
+            disabled={generateMutation.isPending}
+            className="flex w-full items-center justify-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition-all hover:opacity-80 active:scale-[0.97] disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{
+              borderColor: "var(--border)",
+              color: "var(--text-secondary)",
+              backgroundColor: "var(--bg-card)",
+            }}
+          >
+            {generateMutation.isPending ? (
+              <CircleNotch className="h-4 w-4 animate-spin" />
+            ) : (
+              <LinkSimple className="h-4 w-4" />
+            )}
+            招待リンクを生成
+          </button>
+          {generateMutation.isError && (
+            <p className="text-center text-xs animate-slide-in-bottom" style={{ color: "#f87171" }}>
+              {generateMutation.error.message}
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <div
+            className="flex items-center gap-2 rounded-lg border px-3 py-2"
+            style={{ borderColor: "var(--border)", backgroundColor: "rgba(124,58,237,0.06)" }}
+          >
+            <span
+              className="flex-1 truncate text-xs font-mono"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              {inviteUrl}
+            </span>
+            <button
+              onClick={handleCopy}
+              className="shrink-0 rounded p-1 transition-colors hover:opacity-80"
+              style={{ color: copied ? "var(--accent-light)" : "var(--text-muted)" }}
+              title="コピー"
+            >
+              {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            </button>
+          </div>
+          <div className="flex flex-col gap-2">
+            <button
+              onClick={() => invalidateMutation.mutate()}
+              disabled={invalidateMutation.isPending}
+              className="flex w-full items-center justify-center gap-2 rounded-lg border border-red-500/30 px-4 py-2 text-xs font-medium text-red-400 transition-all hover:bg-red-500/10 active:scale-[0.97] disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{ backgroundColor: "rgba(239,68,68,0.05)" }}
+            >
+              {invalidateMutation.isPending ? (
+                <CircleNotch className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Prohibit className="h-3.5 w-3.5" />
+              )}
+              リンクを無効化
+            </button>
+            {invalidateMutation.isError && (
+              <p className="text-center text-xs animate-slide-in-bottom" style={{ color: "#f87171" }}>
+                {invalidateMutation.error.message}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/rooms/[roomId]/RoomDetailView.tsx
+++ b/app/rooms/[roomId]/RoomDetailView.tsx
@@ -12,6 +12,7 @@ import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
 import { RatingDisplay } from "@/components/ui/StarRating";
 import { GameCover } from "@/components/ui/GamePicker";
 import { RoomActions } from "./RoomActions";
+import { InvitePanel } from "./InvitePanel";
 
 type Props = { roomId: string };
 
@@ -97,7 +98,7 @@ export function RoomDetailView({ roomId }: Props) {
 
       <div className="grid gap-4 sm:gap-6 md:grid-cols-[1fr_260px] lg:grid-cols-3">
         {/* Main content */}
-        <div className="lg:col-span-2 space-y-4 sm:space-y-6">
+        <div className="lg:col-span-2 flex flex-col gap-4 sm:gap-6">
           {/* Room Info */}
           <div
             className="rounded-2xl border overflow-hidden animate-fade-in-up"
@@ -168,22 +169,12 @@ export function RoomDetailView({ roomId }: Props) {
             </div>
           </div>
 
-          {/* Actions */}
-          <div className="animate-fade-in-up" style={{ animationDelay: "80ms" }}>
-          <RoomActions
-            roomId={room.id}
-            isParticipant={isParticipant}
-            isHost={isHost}
-            status={room.status}
-          />
-          </div>
-
           {/* Chat shortcut */}
           {isParticipant && (
             <Link
               href={`/rooms/${room.id}/chat`}
-              className="flex items-center justify-between rounded-xl border px-5 py-4 transition-all hover:border-[var(--accent)]"
-              style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
+              className="flex items-center justify-between rounded-xl border px-5 py-4 transition-all hover:border-[var(--accent)] animate-fade-in-up"
+              style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)", animationDelay: "80ms" }}
             >
               <div className="flex items-center gap-3">
                 <div
@@ -201,6 +192,23 @@ export function RoomDetailView({ roomId }: Props) {
               <ArrowLeft className="h-4 w-4 rotate-180" style={{ color: "var(--text-muted)" }} />
             </Link>
           )}
+
+          {/* Invite link */}
+          {isHost && room.status !== "closed" && (
+            <div className="animate-fade-in-up" style={{ animationDelay: "80ms" }}>
+              <InvitePanel roomId={room.id} />
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="animate-fade-in-up" style={{ animationDelay: "80ms" }}>
+            <RoomActions
+              roomId={room.id}
+              isParticipant={isParticipant}
+              isHost={isHost}
+              status={room.status}
+            />
+          </div>
         </div>
 
         {/* Sidebar: Participants */}

--- a/docs/02_database-design.md
+++ b/docs/02_database-design.md
@@ -81,6 +81,7 @@ Google / X / Discord の3プロバイダに対応するため、プロバイダ�
 | `max_players` | `SMALLINT` | NOT NULL | - | 最大参加人数（2〜16） |
 | `description` | `TEXT` | NULL | - | 補足説明 |
 | `status` | `room_status` | NOT NULL | `'waiting'` | 部屋ステータス（ENUM） |
+| `invite_token` | `VARCHAR(64)` | NULL | - | 招待URL用トークン（64文字hex）。NULL = 招待リンク未発行 |
 | `created_at` | `TIMESTAMPTZ` | NOT NULL | `NOW()` | - |
 | `updated_at` | `TIMESTAMPTZ` | NOT NULL | `NOW()` | - |
 | `closed_at` | `TIMESTAMPTZ` | NULL | - | 解散日時 |
@@ -97,6 +98,7 @@ Google / X / Discord の3プロバイダに対応するため、プロバイダ�
 - `FOREIGN KEY (host_id) REFERENCES users(id) ON DELETE SET NULL`
 - `FOREIGN KEY (game_id) REFERENCES games(id) ON DELETE RESTRICT`
 - `CHECK (max_players >= 2 AND max_players <= 16)`
+- `UNIQUE (invite_token)`
 
 ---
 

--- a/docs/05_03_api_rooms-chat.md
+++ b/docs/05_03_api_rooms-chat.md
@@ -19,6 +19,8 @@
 | POST | `/rooms/{roomId}/join` | 必要 | 部屋に参加 |
 | POST | `/rooms/{roomId}/leave` | 必要 | 部屋を退室 |
 | POST | `/rooms/{roomId}/close` | 必要（ホストのみ） | 部屋を解散 |
+| POST | `/rooms/{roomId}/invite` | 必要（ホストのみ） | 招待トークンを発行（冪等） |
+| DELETE | `/rooms/{roomId}/invite` | 必要（ホストのみ） | 招待トークンを無効化 |
 | POST | `/rooms/{roomId}/share` | 必要 | SNS シェア投稿 |
 | GET | `/rooms/{roomId}/messages` | 必要 | チャット履歴取得 |
 | GET | `/rooms/{roomId}/pending-ratings` | 必要 | 未評価の相手一覧（`04_ratings-tags.md` 参照） |
@@ -309,7 +311,61 @@ POST /rooms/{roomId}/close
 
 ---
 
-## 10. SNS シェア投稿
+## 10. 招待トークン発行
+
+ホストが招待URLのトークンを生成する。既にトークンが存在する場合はそのまま返す（冪等）。`closed` な部屋には発行不可。
+
+```
+POST /rooms/{roomId}/invite
+```
+
+**認証**: 必要（ホストのみ）
+
+### レスポンス `200 OK`
+
+```json
+{
+  "data": {
+    "inviteToken": "a3f8c2e1d4b7..."
+  }
+}
+```
+
+招待URLはフロントエンドで `{origin}/rooms/{roomId}?invite={inviteToken}` として構築する。
+
+### エラー
+
+| HTTP | エラーコード | 説明 |
+|------|------------|------|
+| 400 | `ROOM_CLOSED` | 解散済みの部屋 |
+| 403 | `FORBIDDEN` | ホストではない |
+| 404 | `ROOM_NOT_FOUND` | 部屋が存在しない |
+
+---
+
+## 10-1. 招待トークン無効化
+
+発行済みの招待トークンを削除する。以降、そのトークンを含むURLでは参加不可になる。
+
+```
+DELETE /rooms/{roomId}/invite
+```
+
+**認証**: 必要（ホストのみ）
+
+### レスポンス `204 No Content`
+
+### エラー
+
+| HTTP | エラーコード | 説明 |
+|------|------------|------|
+| 400 | `ROOM_CLOSED` | 解散済みの部屋 |
+| 403 | `FORBIDDEN` | ホストではない |
+| 404 | `ROOM_NOT_FOUND` | 部屋が存在しない |
+
+---
+
+## 11. SNS シェア投稿
 
 部屋の参加リンクを X または Discord に投稿する。1部屋・1時間あたり3回まで。
 
@@ -350,7 +406,7 @@ Discord 投稿はプロフィールに登録済みの `discordWebhookUrl` を使
 
 ---
 
-## 11. チャット履歴取得
+## 12. チャット履歴取得
 
 リアルタイム送受信は WebSocket で行い、REST は履歴参照専用。カーソルページネーション方式（`before` パラメータ）を採用。
 
@@ -390,7 +446,7 @@ GET /rooms/{roomId}/messages
 
 ---
 
-## 12. WebSocket イベント
+## 13. WebSocket イベント
 
 Socket.IO を使用。ログイン済み参加者およびゲスト参加者が利用可。
 

--- a/lib/api/rooms.ts
+++ b/lib/api/rooms.ts
@@ -166,3 +166,30 @@ export async function fetchCurrentRoom(): Promise<CurrentRoomResponse> {
   if (!res.ok) throw new Error("参加中の部屋の取得に失敗しました");
   return res.json() as Promise<CurrentRoomResponse>;
 }
+
+export type InviteTokenResponse = {
+  data: { inviteToken: string };
+};
+
+export async function generateInviteToken(roomId: string): Promise<InviteTokenResponse> {
+  const res = await fetch(`/api/v1/rooms/${roomId}/invite`, {
+    method: "POST",
+    credentials: "include",
+  });
+  if (!res.ok) {
+    const body = (await res.json()) as { error?: { code: string; message: string } };
+    throw new Error(body.error?.message ?? "招待リンクの生成に失敗しました");
+  }
+  return res.json() as Promise<InviteTokenResponse>;
+}
+
+export async function invalidateInviteToken(roomId: string): Promise<void> {
+  const res = await fetch(`/api/v1/rooms/${roomId}/invite`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+  if (!res.ok) {
+    const body = (await res.json()) as { error?: { code: string; message: string } };
+    throw new Error(body.error?.message ?? "招待リンクの無効化に失敗しました");
+  }
+}


### PR DESCRIPTION
## 概要

ホストが部屋の招待URLを生成・コピー・無効化できる機能を実装しました。

- **POST** `/api/v1/rooms/:roomId/invite` — 64文字hexトークンを生成（冪等：既存トークンがあればそのまま返す）
- **DELETE** `/api/v1/rooms/:roomId/invite` — トークンを無効化（null にセット）
- `InvitePanel` コンポーネント（ホスト専用）— 生成・コピー・無効化のUI
- `RoomDetailView` のレイアウト整理 — タイトル → チャットルームへ → 招待リンク → ボタングループ の順に統一

## テスト

- API route: 11ケース（認証・認可・冪等性・正常系）
- コンポーネント: 6ケース（初期表示・操作・エラー表示）

Closes #102