### PR TITLE
feat: 招待URLからのゲスト参加機能（#103）

### DIFF
--- a/app/api/v1/invite/[token]/join/route.test.ts
+++ b/app/api/v1/invite/[token]/join/route.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    room: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    roomParticipant: {
+      findFirst: vi.fn(),
+    },
+    chatMessage: {
+      create: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/socket-emitter", () => ({ emitToRoom: vi.fn() }));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+}));
+
+import { prisma } from "@/lib/prisma";
+import { emitToRoom } from "@/lib/socket-emitter";
+import { cookies } from "next/headers";
+import { POST } from "./route";
+
+const mockRoomFindUnique = vi.mocked(prisma.room.findUnique);
+const mockParticipantFindFirst = vi.mocked(prisma.roomParticipant.findFirst);
+const mockChatMessageCreate = vi.mocked(prisma.chatMessage.create);
+const mockTransaction = vi.mocked(prisma.$transaction);
+const mockEmitToRoom = vi.mocked(emitToRoom);
+const mockCookies = vi.mocked(cookies);
+
+type MockTx = {
+  $queryRaw: ReturnType<typeof vi.fn>;
+  roomParticipant: {
+    count: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  room: {
+    update: ReturnType<typeof vi.fn>;
+  };
+};
+
+let mockTx: MockTx;
+
+const makeRequest = (body: Record<string, unknown> = {}) =>
+  new Request("http://localhost/api/v1/invite/valid-token/join", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const makeParams = (token = "valid-token") => ({
+  params: Promise.resolve({ token }),
+});
+
+const mockRoom = { id: "room-1", status: "waiting", maxPlayers: 4 };
+const mockNow = new Date();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockTx = {
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    roomParticipant: {
+      count: vi.fn().mockResolvedValue(1),
+      create: vi.fn().mockResolvedValue({
+        roomId: "room-1",
+        guestSessionId: "guest_abc",
+        displayName: "TestGuest",
+        isHost: false,
+        joinedAt: mockNow,
+      }),
+    },
+    room: {
+      update: vi.fn().mockResolvedValue({}),
+    },
+  };
+
+  mockTransaction.mockImplementation(async (fn) => fn(mockTx as never));
+
+  mockCookies.mockResolvedValue({
+    get: vi.fn().mockReturnValue(undefined),
+  } as never);
+
+  mockChatMessageCreate.mockResolvedValue({
+    id: "msg-1",
+    roomId: "room-1",
+    content: "TestGuestさんが入室しました",
+    isSystem: true,
+    createdAt: mockNow,
+  } as never);
+});
+
+describe("POST /api/v1/invite/[token]/join", () => {
+  it("トークンが存在しない場合 404 INVITE_NOT_FOUND を返す", async () => {
+    mockRoomFindUnique.mockResolvedValue(null);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error.code).toBe("INVITE_NOT_FOUND");
+  });
+
+  it("room.status が closed の場合 400 ROOM_CLOSED を返す", async () => {
+    mockRoomFindUnique.mockResolvedValue({
+      ...mockRoom,
+      status: "closed",
+    } as never);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("ROOM_CLOSED");
+  });
+
+  it("Cookie に既存 guestSessionId が存在する場合 409 ALREADY_JOINED を返す", async () => {
+    mockRoomFindUnique.mockResolvedValue(mockRoom as never);
+    mockCookies.mockResolvedValue({
+      get: vi.fn().mockReturnValue({ value: "guest_existing" }),
+    } as never);
+    mockParticipantFindFirst.mockResolvedValue({ id: "participant-1" } as never);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("ALREADY_JOINED");
+  });
+
+  it("同じ Cookie でも別のルームなら参加できる（findFirst が null を返す）", async () => {
+    mockRoomFindUnique.mockResolvedValue(mockRoom as never);
+    mockCookies.mockResolvedValue({
+      get: vi.fn().mockReturnValue({ value: "guest_existing" }),
+    } as never);
+    mockParticipantFindFirst.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ displayName: "TestGuest" }), makeParams());
+
+    expect(res.status).toBe(200);
+  });
+
+  it("満員の場合 409 ROOM_FULL を返す", async () => {
+    mockRoomFindUnique.mockResolvedValue(mockRoom as never);
+    mockTx.roomParticipant.count.mockResolvedValue(4);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("ROOM_FULL");
+  });
+
+  it("正常参加（満員にならない）場合 200 と isGuest: true を返す", async () => {
+    mockRoomFindUnique.mockResolvedValue(mockRoom as never);
+    mockTx.roomParticipant.count.mockResolvedValue(1);
+
+    const res = await POST(makeRequest({ displayName: "TestGuest" }), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.roomId).toBe("room-1");
+    expect(body.data.isGuest).toBe(true);
+    expect(body.data.guestSessionId).toBeDefined();
+    expect(mockTx.room.update).not.toHaveBeenCalled();
+  });
+
+  it("正常参加（満員になる）場合 room.update({ status: 'full' }) が呼ばれる", async () => {
+    mockRoomFindUnique.mockResolvedValue(mockRoom as never);
+    mockTx.roomParticipant.count.mockResolvedValue(3);
+
+    const res = await POST(makeRequest({ displayName: "TestGuest" }), makeParams());
+
+    expect(res.status).toBe(200);
+    expect(mockTx.room.update).toHaveBeenCalledWith({
+      where: { id: "room-1" },
+      data: { status: "full" },
+    });
+  });
+
+  it("成功時に Cookie quest_link_guest_session が設定される", async () => {
+    mockRoomFindUnique.mockResolvedValue(mockRoom as never);
+
+    const res = await POST(makeRequest({ displayName: "TestGuest" }), makeParams());
+
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get("set-cookie");
+    expect(setCookie).toContain("quest_link_guest_session=");
+    expect(setCookie).toContain("HttpOnly");
+  });
+
+  it("成功時に emitToRoom が chat:message と room:user_joined で呼ばれる", async () => {
+    mockRoomFindUnique.mockResolvedValue(mockRoom as never);
+
+    await POST(makeRequest({ displayName: "TestGuest" }), makeParams());
+
+    expect(mockEmitToRoom).toHaveBeenCalledTimes(2);
+    expect(mockEmitToRoom).toHaveBeenCalledWith(
+      "chat:message",
+      "room-1",
+      expect.objectContaining({ isSystem: true })
+    );
+    expect(mockEmitToRoom).toHaveBeenCalledWith(
+      "room:user_joined",
+      "room-1",
+      expect.objectContaining({ isGuest: true })
+    );
+  });
+
+  it("displayName が空の場合、自動生成名が使われる", async () => {
+    mockRoomFindUnique.mockResolvedValue(mockRoom as never);
+
+    await POST(makeRequest({ displayName: "" }), makeParams());
+
+    expect(mockTx.roomParticipant.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          displayName: expect.stringMatching(/^Guest\d+$/),
+        }),
+      })
+    );
+  });
+
+  it("displayName が 51 文字の場合 400 VALIDATION_ERROR を返す", async () => {
+    mockRoomFindUnique.mockResolvedValue(mockRoom as never);
+
+    const res = await POST(
+      makeRequest({ displayName: "a".repeat(51) }),
+      makeParams()
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+  });
+});

--- a/app/api/v1/invite/[token]/join/route.ts
+++ b/app/api/v1/invite/[token]/join/route.ts
@@ -1,0 +1,152 @@
+import { randomBytes } from "crypto";
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { emitToRoom } from "@/lib/socket-emitter";
+import { Prisma } from "@prisma/client";
+
+const bodySchema = z.object({
+  displayName: z
+    .string()
+    .max(50)
+    .optional()
+    .transform((v) => v?.trim() ?? ""),
+});
+
+type RouteParams = { params: Promise<{ token: string }> };
+
+export async function POST(request: Request, { params }: RouteParams) {
+  const { token } = await params;
+
+  const parsed = bodySchema.safeParse(
+    await request.json().catch(() => ({}))
+  );
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "入力値が不正です" } },
+      { status: 400 }
+    );
+  }
+  const rawName = parsed.data.displayName;
+
+  const room = await prisma.room.findUnique({
+    where: { inviteToken: token },
+    select: { id: true, status: true, maxPlayers: true },
+  });
+
+  if (!room) {
+    return NextResponse.json(
+      { error: { code: "INVITE_NOT_FOUND", message: "招待リンクが無効です" } },
+      { status: 404 }
+    );
+  }
+
+  if (room.status === "closed") {
+    return NextResponse.json(
+      { error: { code: "ROOM_CLOSED", message: "この部屋はすでに終了しています" } },
+      { status: 400 }
+    );
+  }
+
+  const cookieStore = await cookies();
+  const existingSession = cookieStore.get("quest_link_guest_session")?.value ?? null;
+  if (existingSession) {
+    const existing = await prisma.roomParticipant.findFirst({
+      where: { roomId: room.id, guestSessionId: existingSession, leftAt: null },
+    });
+    if (existing) {
+      return NextResponse.json(
+        { error: { code: "ALREADY_JOINED", message: "すでにこの部屋に参加しています" } },
+        { status: 409 }
+      );
+    }
+  }
+
+  const guestSessionId = "guest_" + randomBytes(16).toString("hex");
+  const displayName =
+    rawName.length > 0 ? rawName : `Guest${randomBytes(2).readUInt16BE(0)}`;
+
+  try {
+    const participant = await prisma.$transaction(
+      async (tx) => {
+        await tx.$queryRaw`SELECT id FROM rooms WHERE id = ${room.id}::uuid FOR UPDATE`;
+
+        const currentCount = await tx.roomParticipant.count({
+          where: { roomId: room.id, leftAt: null },
+        });
+
+        if (currentCount >= room.maxPlayers) {
+          throw new Error("ROOM_FULL");
+        }
+
+        const p = await tx.roomParticipant.create({
+          data: { roomId: room.id, guestSessionId, displayName, isHost: false },
+        });
+
+        if (currentCount + 1 >= room.maxPlayers) {
+          await tx.room.update({
+            where: { id: room.id },
+            data: { status: "full" },
+          });
+        }
+
+        return p;
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
+
+    const systemMsg = await prisma.chatMessage.create({
+      data: {
+        roomId: room.id,
+        content: `${displayName}さんが入室しました`,
+        isSystem: true,
+      },
+    });
+
+    await emitToRoom("chat:message", room.id, {
+      id: systemMsg.id,
+      roomId: room.id,
+      user: null,
+      content: systemMsg.content,
+      isSystem: true,
+      createdAt: systemMsg.createdAt,
+    });
+
+    await emitToRoom("room:user_joined", room.id, {
+      userId: guestSessionId,
+      username: displayName,
+      iconUrl: null,
+      avgRating: 0,
+      isGuest: true,
+      joinedAt: participant.joinedAt,
+    });
+
+    const response = NextResponse.json({
+      data: {
+        roomId: room.id,
+        guestSessionId,
+        isGuest: true,
+        joinedAt: participant.joinedAt,
+      },
+    });
+
+    response.cookies.set("quest_link_guest_session", guestSessionId, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      maxAge: 86400,
+      path: "/",
+      sameSite: "lax",
+    });
+
+    return response;
+  } catch (error) {
+    if (error instanceof Error && error.message === "ROOM_FULL") {
+      return NextResponse.json(
+        { error: { code: "ROOM_FULL", message: "この部屋は満員です" } },
+        { status: 409 }
+      );
+    }
+    throw error;
+  }
+}

--- a/app/api/v1/rooms/[roomId]/route.ts
+++ b/app/api/v1/rooms/[roomId]/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 
@@ -20,6 +19,8 @@ const roomSelect = {
     where: { leftAt: null },
     select: {
       userId: true,
+      guestSessionId: true,
+      displayName: true,
       isHost: true,
       joinedAt: true,
       user: { select: { username: true, iconUrl: true, avgRating: true } },
@@ -49,9 +50,13 @@ function formatRoom(room: RawRoom) {
     playStyleTags: room.playStyleTags.map((t) => t.tag),
     participants: room.participants.map((p) => ({
       userId: p.userId,
-      username: p.user?.username ?? "",
+      guestSessionId: p.guestSessionId,
+      username: p.user?.username ?? p.displayName ?? "ゲスト",
       iconUrl: p.user?.iconUrl ?? null,
-      avgRating: p.user?.avgRating !== null && p.user?.avgRating !== undefined ? Number(p.user.avgRating) : null,
+      avgRating:
+        p.user?.avgRating !== null && p.user?.avgRating !== undefined
+          ? Number(p.user.avgRating)
+          : null,
       isHost: p.isHost,
       joinedAt: p.joinedAt,
     })),
@@ -61,11 +66,6 @@ function formatRoom(room: RawRoom) {
 type RouteParams = { params: Promise<{ roomId: string }> };
 
 export async function GET(_request: Request, { params }: RouteParams) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: { code: "UNAUTHORIZED", message: "認証が必要です" } }, { status: 401 });
-  }
-
   const { roomId } = await params;
 
   const room = await prisma.room.findUnique({
@@ -74,7 +74,10 @@ export async function GET(_request: Request, { params }: RouteParams) {
   });
 
   if (!room) {
-    return NextResponse.json({ error: { code: "ROOM_NOT_FOUND", message: "部屋が存在しません" } }, { status: 404 });
+    return NextResponse.json(
+      { error: { code: "ROOM_NOT_FOUND", message: "部屋が存在しません" } },
+      { status: 404 }
+    );
   }
 
   return NextResponse.json({ data: formatRoom(room) });

--- a/app/rooms/[roomId]/InvitePanel.tsx
+++ b/app/rooms/[roomId]/InvitePanel.tsx
@@ -12,7 +12,7 @@ export function InvitePanel({ roomId }: Props) {
   const [copied, setCopied] = useState(false);
 
   const inviteUrl = inviteToken
-    ? `${window.location.origin}/rooms/${roomId}?invite=${inviteToken}`
+    ? `${window.location.origin}/rooms/${roomId}?inviteToken=${inviteToken}`
     : null;
 
   const generateMutation = useMutation({

--- a/app/rooms/[roomId]/RoomDetailView.tsx
+++ b/app/rooms/[roomId]/RoomDetailView.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
+import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 import { ArrowLeft, Crown, Chat, Users } from "@phosphor-icons/react";
@@ -11,6 +12,7 @@ import { UserAvatar } from "@/components/ui/UserAvatar";
 import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
 import { RatingDisplay } from "@/components/ui/StarRating";
 import { GameCover } from "@/components/ui/GamePicker";
+import { GuestJoinModal } from "@/components/rooms/GuestJoinModal";
 import { RoomActions } from "./RoomActions";
 import { InvitePanel } from "./InvitePanel";
 
@@ -18,12 +20,14 @@ type Props = { roomId: string };
 
 export function RoomDetailView({ roomId }: Props) {
   const { data: session } = useSession();
-  const currentUserId = session?.user?.id;
+  const currentUserId = session?.user?.id ?? null;
+  const searchParams = useSearchParams();
+  const inviteToken = searchParams.get("inviteToken");
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["room", roomId],
     queryFn: () => fetchRoom(roomId),
-    enabled: !!currentUserId,
+    enabled: !!roomId,
   });
 
   if (isLoading) {
@@ -81,8 +85,10 @@ export function RoomDetailView({ roomId }: Props) {
 
   const room = data.data;
   const status = roomStatusConfig[room.status as keyof typeof roomStatusConfig] ?? fallbackStatusConfig;
-  const isParticipant = room.participants.some((p) => p.userId === currentUserId);
-  const isHost = room.host.id === currentUserId;
+  const isParticipant =
+    currentUserId != null &&
+    room.participants.some((p) => p.userId === currentUserId);
+  const isHost = currentUserId != null && room.host.id === currentUserId;
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-4 sm:py-8 sm:px-6">
@@ -244,33 +250,51 @@ export function RoomDetailView({ roomId }: Props) {
             </div>
 
             <ul className="space-y-3">
-              {room.participants.map((p) => (
-                <li key={p.userId} className="flex items-center gap-3">
-                  <Link
-                    href={p.userId === currentUserId ? "/users/me" : `/users/${p.userId}`}
-                    className="shrink-0"
-                  >
-                    <UserAvatar username={p.username} iconUrl={p.iconUrl} size="md" />
-                  </Link>
+              {room.participants.map((p, idx) => (
+                <li key={p.userId ?? p.guestSessionId ?? `participant-${idx}`} className="flex items-center gap-3">
+                  {p.userId != null ? (
+                    <Link
+                      href={p.userId === currentUserId ? "/users/me" : `/users/${p.userId}`}
+                      className="shrink-0"
+                    >
+                      <UserAvatar username={p.username} iconUrl={p.iconUrl} size="md" />
+                    </Link>
+                  ) : (
+                    <span className="shrink-0">
+                      <UserAvatar username={p.username} iconUrl={p.iconUrl} size="md" />
+                    </span>
+                  )}
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1.5">
                       {p.isHost && (
                         <Crown className="h-3.5 w-3.5 shrink-0" style={{ color: "#eab308" }} />
                       )}
-                      <Link
-                        href={p.userId === currentUserId ? "/users/me" : `/users/${p.userId}`}
-                        className="truncate text-sm font-medium hover:underline"
-                        style={{
-                          color: p.userId === currentUserId ? "var(--accent-light)" : "var(--text-primary)",
-                        }}
-                      >
-                        {p.username}
-                        {p.userId === currentUserId && (
+                      {p.userId != null ? (
+                        <Link
+                          href={p.userId === currentUserId ? "/users/me" : `/users/${p.userId}`}
+                          className="truncate text-sm font-medium hover:underline"
+                          style={{
+                            color: p.userId === currentUserId ? "var(--accent-light)" : "var(--text-primary)",
+                          }}
+                        >
+                          {p.username}
+                          {p.userId === currentUserId && (
+                            <span className="ml-1 text-xs" style={{ color: "var(--text-muted)" }}>
+                              (あなた)
+                            </span>
+                          )}
+                        </Link>
+                      ) : (
+                        <span
+                          className="truncate text-sm font-medium"
+                          style={{ color: "var(--text-primary)" }}
+                        >
+                          {p.username}
                           <span className="ml-1 text-xs" style={{ color: "var(--text-muted)" }}>
-                            (あなた)
+                            (ゲスト)
                           </span>
-                        )}
-                      </Link>
+                        </span>
+                      )}
                     </div>
                     <RatingDisplay
                       avgRating={p.avgRating}
@@ -299,6 +323,11 @@ export function RoomDetailView({ roomId }: Props) {
           </div>
         </div>
       </div>
+
+      {/* Guest join modal — shown when accessing via invite URL without login */}
+      {!!inviteToken && currentUserId === null && !!data && (
+        <GuestJoinModal roomId={roomId} inviteToken={inviteToken} />
+      )}
     </div>
   );
 }

--- a/app/rooms/[roomId]/chat/ChatView.tsx
+++ b/app/rooms/[roomId]/chat/ChatView.tsx
@@ -82,7 +82,10 @@ export function ChatView({
 
     socket.on("room:host_changed", ({ newHostId }: { newHostId: string }) => {
       useChatStore.setState((state) => ({
-        participants: state.participants.map((p) => ({ ...p, isHost: p.userId === newHostId })),
+        participants: state.participants.map((p) => ({
+          ...p,
+          isHost: p.userId != null && p.userId === newHostId,
+        })),
       }));
     });
 
@@ -156,11 +159,11 @@ export function ChatView({
             参加者 {currentPlayers}/{roomInfo.maxPlayers}
           </p>
           <ul className="space-y-2.5">
-            {participants.map((p) => {
+            {participants.map((p, idx) => {
               if (!p.user) return null;
               const { username, iconUrl, avgRating } = p.user;
               return (
-                <li key={p.userId} className="flex items-center gap-2.5">
+                <li key={p.userId ?? `guest-${idx}`} className="flex items-center gap-2.5">
                   <div className="relative">
                     <UserAvatar username={username} iconUrl={iconUrl} size="sm" />
                     <span
@@ -175,7 +178,7 @@ export function ChatView({
                         className="truncate text-xs font-medium"
                         style={{
                           color:
-                            p.userId === currentUserId
+                            p.userId != null && p.userId === currentUserId
                               ? "var(--accent-light)"
                               : "var(--text-primary)",
                         }}

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -34,7 +34,10 @@ export const authConfig = {
         return true;
       }
 
-      const isPublicPage = pathname === "/" || pathname === "/rooms";
+      const isPublicPage =
+        pathname === "/" ||
+        pathname === "/rooms" ||
+        pathname.startsWith("/rooms/");
       if (!isLoggedIn && isPublicPage) return true;
 
       if (!isLoggedIn) return false;

--- a/components/rooms/GuestJoinModal.test.tsx
+++ b/components/rooms/GuestJoinModal.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import { GuestJoinModal } from "./GuestJoinModal";
+
+const defaultProps = { roomId: "room-1", inviteToken: "valid-token" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+describe("GuestJoinModal", () => {
+  it("入力フィールドと参加ボタンが表示される", () => {
+    render(<GuestJoinModal {...defaultProps} />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "参加する" })).toBeInTheDocument();
+  });
+
+  it("51文字入力時は fetch を呼ばずバリデーションエラーを表示する", async () => {
+    render(<GuestJoinModal {...defaultProps} />);
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "a".repeat(51) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "参加する" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("表示名は50文字以内で入力してください")).toBeInTheDocument();
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("成功時に router.push が /rooms/room-1/chat で呼ばれる", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { roomId: "room-1", guestSessionId: "guest_abc", isGuest: true } }),
+    } as Response);
+
+    render(<GuestJoinModal {...defaultProps} />);
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "テストユーザー" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "参加する" }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/rooms/room-1/chat");
+    });
+  });
+
+  it("ROOM_CLOSED エラーコードで正しいメッセージを表示する", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: { code: "ROOM_CLOSED" } }),
+    } as Response);
+
+    render(<GuestJoinModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "参加する" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("この部屋はすでに終了しています")).toBeInTheDocument();
+    });
+  });
+
+  it("ROOM_FULL エラーコードで正しいメッセージを表示する", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: { code: "ROOM_FULL" } }),
+    } as Response);
+
+    render(<GuestJoinModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "参加する" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("この部屋は満員です")).toBeInTheDocument();
+    });
+  });
+
+  it("INVITE_NOT_FOUND エラーコードで正しいメッセージを表示する", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: { code: "INVITE_NOT_FOUND" } }),
+    } as Response);
+
+    render(<GuestJoinModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "参加する" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("招待リンクが無効です")).toBeInTheDocument();
+    });
+  });
+
+  it("ALREADY_JOINED エラーコードで正しいメッセージを表示する", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: { code: "ALREADY_JOINED" } }),
+    } as Response);
+
+    render(<GuestJoinModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "参加する" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("すでにこの部屋に参加しています")).toBeInTheDocument();
+    });
+  });
+
+  it("fetch 中はボタンが disabled になる", async () => {
+    let resolveFetch!: () => void;
+    vi.mocked(fetch).mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveFetch = () =>
+          resolve({
+            ok: true,
+            json: async () => ({ data: {} }),
+          } as Response);
+      })
+    );
+
+    render(<GuestJoinModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "参加する" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "参加中..." })).toBeDisabled();
+    });
+
+    resolveFetch();
+  });
+
+  it("正しい URL とボディで fetch が呼ばれる", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { roomId: "room-1", guestSessionId: "guest_abc", isGuest: true } }),
+    } as Response);
+
+    render(<GuestJoinModal {...defaultProps} />);
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Taro" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "参加する" }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/v1/invite/valid-token/join",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ displayName: "Taro" }),
+        })
+      );
+    });
+  });
+});

--- a/components/rooms/GuestJoinModal.tsx
+++ b/components/rooms/GuestJoinModal.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+const ERROR_MESSAGES: Record<string, string> = {
+  ROOM_CLOSED: "この部屋はすでに終了しています",
+  ROOM_FULL: "この部屋は満員です",
+  INVITE_NOT_FOUND: "招待リンクが無効です",
+  ALREADY_JOINED: "すでにこの部屋に参加しています",
+};
+
+type Props = {
+  roomId: string;
+  inviteToken: string;
+};
+
+export function GuestJoinModal({ roomId, inviteToken }: Props) {
+  const router = useRouter();
+  const [displayName, setDisplayName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (displayName.length > 50) {
+      setError("表示名は50文字以内で入力してください");
+      return;
+    }
+    setIsPending(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/invite/${inviteToken}/join`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ displayName }),
+      });
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: { code: string } };
+        setError(ERROR_MESSAGES[body.error?.code ?? ""] ?? "参加に失敗しました");
+        return;
+      }
+      router.push(`/rooms/${roomId}/chat`);
+    } catch {
+      setError("ネットワークエラーが発生しました");
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div
+        className="w-full max-w-sm rounded-2xl border p-6 space-y-5"
+        style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
+      >
+        <h2 className="text-lg font-bold" style={{ color: "var(--text-primary)" }}>
+          ゲストとして参加
+        </h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <label className="text-sm" style={{ color: "var(--text-secondary)" }}>
+              表示名（任意・最大50文字）
+            </label>
+            <input
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="表示名（空白の場合は自動設定）"
+              maxLength={50}
+              className="w-full rounded-lg border px-3 py-2 text-sm outline-none focus:border-[var(--accent)]"
+              style={{
+                backgroundColor: "var(--bg-input)",
+                borderColor: "var(--border)",
+                color: "var(--text-primary)",
+              }}
+            />
+          </div>
+          {error && <p className="text-sm text-red-400">{error}</p>}
+          <button
+            type="submit"
+            disabled={isPending}
+            className="w-full rounded-lg px-4 py-2.5 text-sm font-medium transition-all hover:opacity-90 active:scale-[0.97] disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{ backgroundColor: "var(--accent)", color: "white" }}
+          >
+            {isPending ? "参加中..." : "参加する"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/lib/api/rooms.ts
+++ b/lib/api/rooms.ts
@@ -21,7 +21,8 @@ export type RoomTag = {
 };
 
 export type RoomParticipant = {
-  userId: string;
+  userId: string | null;
+  guestSessionId: string | null;
   username: string;
   iconUrl: string | null;
   avgRating: number | null;

--- a/lib/stores/chatStore.ts
+++ b/lib/stores/chatStore.ts
@@ -11,7 +11,7 @@ export type ChatMessage = {
 };
 
 export type Participant = {
-  userId: string;
+  userId: string | null;
   isHost: boolean;
   user: { username: string; iconUrl: string | null; avgRating: number | null } | null;
 };


### PR DESCRIPTION
## 概要

招待URLを受け取った未ログインユーザーが表示名を入力してルームに参加できる機能を実装しました。

- 招待URL（`?inviteToken=xxx`）にアクセスした未認証ユーザーに `GuestJoinModal` を表示
- 表示名入力 → `POST /api/v1/invite/:token/join` → チャット画面へリダイレクト
- `quest_link_guest_session` Cookie（HttpOnly、24h TTL）で同一セッションの重複参加を防止

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `app/api/v1/invite/[token]/join/route.ts` | **新規** ゲスト参加 API |
| `app/api/v1/invite/[token]/join/route.test.ts` | **新規** API テスト |
| `components/rooms/GuestJoinModal.tsx` | **新規** ゲスト参加モーダル |
| `components/rooms/GuestJoinModal.test.tsx` | **新規** モーダルテスト |
| `auth.config.ts` | `/rooms/*` を公開パスに追加 |
| `app/api/v1/rooms/[roomId]/route.ts` | 認証不要化・ゲスト参加者対応 |
| `lib/api/rooms.ts` | `RoomParticipant` 型を `userId: string \| null` に更新 |
| `lib/stores/chatStore.ts` | `Participant` 型を `userId: string \| null` に更新 |
| `app/rooms/[roomId]/RoomDetailView.tsx` | `GuestJoinModal` 組み込み・null ガード追加 |
| `app/rooms/[roomId]/chat/ChatView.tsx` | ゲスト参加者の null ガード追加 |
| `app/rooms/[roomId]/InvitePanel.tsx` | `?invite=` → `?inviteToken=` に修正 |

Closes #103