### PR TITLE
feat: ゲストユーザーのチャット機能を実装 (#104)

### DIFF
--- a/app/api/v1/invite/[token]/join/route.test.ts
+++ b/app/api/v1/invite/[token]/join/route.test.ts
@@ -40,6 +40,9 @@ type MockTx = {
     count: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
   };
+  guest: {
+    upsert: ReturnType<typeof vi.fn>;
+  };
   room: {
     update: ReturnType<typeof vi.fn>;
   };
@@ -71,10 +74,12 @@ beforeEach(() => {
       create: vi.fn().mockResolvedValue({
         roomId: "room-1",
         guestSessionId: "guest_abc",
-        displayName: "TestGuest",
         isHost: false,
         joinedAt: mockNow,
       }),
+    },
+    guest: {
+      upsert: vi.fn().mockResolvedValue({}),
     },
     room: {
       update: vi.fn().mockResolvedValue({}),
@@ -213,14 +218,14 @@ describe("POST /api/v1/invite/[token]/join", () => {
     );
   });
 
-  it("displayName が空の場合、自動生成名が使われる", async () => {
+  it("displayName が空の場合、自動生成名で guest.upsert が呼ばれる", async () => {
     mockRoomFindUnique.mockResolvedValue(mockRoom as never);
 
     await POST(makeRequest({ displayName: "" }), makeParams());
 
-    expect(mockTx.roomParticipant.create).toHaveBeenCalledWith(
+    expect(mockTx.guest.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({
+        create: expect.objectContaining({
           displayName: expect.stringMatching(/^Guest\d+$/),
         }),
       })

--- a/app/api/v1/invite/[token]/join/route.ts
+++ b/app/api/v1/invite/[token]/join/route.ts
@@ -80,8 +80,14 @@ export async function POST(request: Request, { params }: RouteParams) {
           throw new Error("ROOM_FULL");
         }
 
+        await tx.guest.upsert({
+          where: { guestSessionId },
+          create: { guestSessionId, displayName },
+          update: { displayName },
+        });
+
         const p = await tx.roomParticipant.create({
-          data: { roomId: room.id, guestSessionId, displayName, isHost: false },
+          data: { roomId: room.id, guestSessionId, isHost: false },
         });
 
         if (currentCount + 1 >= room.maxPlayers) {

--- a/app/api/v1/rooms/[roomId]/leave/route.test.ts
+++ b/app/api/v1/rooms/[roomId]/leave/route.test.ts
@@ -7,8 +7,10 @@ vi.mock("@/auth", () => ({
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     room: { findUnique: vi.fn() },
-    roomParticipant: { findFirst: vi.fn() },
+    roomParticipant: { findFirst: vi.fn(), update: vi.fn() },
     user: { findUnique: vi.fn() },
+    guest: { findUnique: vi.fn() },
+    chatMessage: { create: vi.fn() },
     $transaction: vi.fn(),
   },
 }));
@@ -23,7 +25,10 @@ import { POST } from "./route";
 const mockAuth = vi.mocked(auth);
 const mockFindUnique = vi.mocked(prisma.room.findUnique);
 const mockFindFirst = vi.mocked(prisma.roomParticipant.findFirst);
+const mockParticipantUpdate = vi.mocked(prisma.roomParticipant.update);
 const mockUserFindUnique = vi.mocked(prisma.user.findUnique);
+const mockGuestFindUnique = vi.mocked(prisma.guest.findUnique);
+const mockChatMessageCreate = vi.mocked(prisma.chatMessage.create);
 const mockTransaction = vi.mocked(prisma.$transaction);
 const mockEmitToRoom = vi.mocked(emitToRoom);
 
@@ -38,8 +43,11 @@ type MockTx = {
 
 let mockTx: MockTx;
 
-const makeRequest = () =>
-  new Request("http://localhost/api/v1/rooms/room-1/leave", { method: "POST" });
+const makeRequest = (cookie?: string) =>
+  new Request("http://localhost/api/v1/rooms/room-1/leave", {
+    method: "POST",
+    headers: cookie ? { cookie } : {},
+  });
 const makeParams = () => ({ params: Promise.resolve({ roomId: "room-1" }) });
 
 beforeEach(() => {
@@ -57,6 +65,8 @@ beforeEach(() => {
   mockTransaction.mockImplementation(async (fn) => fn(mockTx as never));
 
   mockUserFindUnique.mockResolvedValue({ username: "user-1-name" } as never);
+  mockParticipantUpdate.mockResolvedValue({} as never);
+  mockChatMessageCreate.mockResolvedValue({ id: "leave-msg-1", content: "ゲストさんが退室しました", createdAt: new Date() } as never);
 });
 
 describe("POST /api/v1/rooms/[roomId]/leave", () => {
@@ -174,6 +184,57 @@ describe("POST /api/v1/rooms/[roomId]/leave", () => {
       "room-1",
       expect.objectContaining({ roomId: "room-1", closedAt: expect.any(Date) })
     );
+  });
+
+  describe("ゲスト退室", () => {
+    it("クッキーなしの場合 401 UNAUTHORIZED を返す", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const res = await POST(makeRequest(), makeParams());
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("ゲストが部屋に参加していない場合 400 NOT_IN_ROOM を返す", async () => {
+      mockAuth.mockResolvedValue(null);
+      mockFindFirst.mockResolvedValue(null);
+
+      const res = await POST(makeRequest("quest_link_guest_session=guest_abc"), makeParams());
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error.code).toBe("NOT_IN_ROOM");
+    });
+
+    it("ゲストが正常退室した場合 204 を返し leftAt が更新される", async () => {
+      mockAuth.mockResolvedValue(null);
+      mockFindFirst.mockResolvedValue({ id: "participant-g1" } as never);
+      mockGuestFindUnique.mockResolvedValue({ displayName: "ゲストA" } as never);
+
+      const res = await POST(makeRequest("quest_link_guest_session=guest_abc"), makeParams());
+
+      expect(res.status).toBe(204);
+      expect(mockParticipantUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "participant-g1" },
+          data: expect.objectContaining({ leftAt: expect.any(Date) }),
+        })
+      );
+    });
+
+    it("ゲスト退室時に chat:message と room:user_left が emit される", async () => {
+      mockAuth.mockResolvedValue(null);
+      mockFindFirst.mockResolvedValue({ id: "participant-g1" } as never);
+      mockGuestFindUnique.mockResolvedValue({ displayName: "ゲストA" } as never);
+
+      await POST(makeRequest("quest_link_guest_session=guest_abc"), makeParams());
+
+      expect(mockEmitToRoom).toHaveBeenCalledTimes(2);
+      expect(mockEmitToRoom).toHaveBeenCalledWith("chat:message", "room-1", expect.objectContaining({ isSystem: true }));
+      expect(mockEmitToRoom).toHaveBeenCalledWith("room:user_left", "room-1", expect.objectContaining({ userId: "guest_abc" }));
+    });
   });
 
   it("ホスト引き継ぎ時に emitToRoom の引数が正しい", async () => {

--- a/app/api/v1/rooms/[roomId]/leave/route.ts
+++ b/app/api/v1/rooms/[roomId]/leave/route.ts
@@ -5,16 +5,64 @@ import { emitToRoom } from "@/lib/socket-emitter";
 
 type RouteParams = { params: Promise<{ roomId: string }> };
 
-export async function POST(_request: Request, { params }: RouteParams) {
+export async function POST(request: Request, { params }: RouteParams) {
   const session = await auth();
+  const { roomId } = await params;
+
+  // ゲスト退室
   if (!session?.user?.id) {
-    return NextResponse.json(
-      { error: { code: "UNAUTHORIZED", message: "認証が必要です" } },
-      { status: 401 }
-    );
+    const cookieHeader = request.headers.get("cookie") ?? "";
+    const match = cookieHeader.match(/quest_link_guest_session=([^;]+)/);
+    const guestSessionId = match?.[1] ?? null;
+    if (!guestSessionId) {
+      return NextResponse.json(
+        { error: { code: "UNAUTHORIZED", message: "認証が必要です" } },
+        { status: 401 }
+      );
+    }
+
+    const guestParticipant = await prisma.roomParticipant.findFirst({
+      where: { roomId, guestSessionId, leftAt: null },
+    });
+    if (!guestParticipant) {
+      return NextResponse.json(
+        { error: { code: "NOT_IN_ROOM", message: "この部屋に参加していません" } },
+        { status: 400 }
+      );
+    }
+
+    const guest = await prisma.guest.findUnique({
+      where: { guestSessionId },
+      select: { displayName: true },
+    });
+    const displayName = guest?.displayName ?? "ゲスト";
+    const now = new Date();
+
+    await prisma.roomParticipant.update({
+      where: { id: guestParticipant.id },
+      data: { leftAt: now },
+    });
+
+    const leaveMsg = await prisma.chatMessage.create({
+      data: { roomId, content: `${displayName}さんが退室しました`, isSystem: true },
+    });
+    await emitToRoom("chat:message", roomId, {
+      id: leaveMsg.id,
+      roomId,
+      user: null,
+      content: leaveMsg.content,
+      isSystem: true,
+      createdAt: leaveMsg.createdAt,
+    });
+    await emitToRoom("room:user_left", roomId, {
+      userId: guestSessionId,
+      username: displayName,
+      leftAt: now,
+    });
+
+    return new NextResponse(null, { status: 204 });
   }
 
-  const { roomId } = await params;
   const userId = session.user.id;
 
   const room = await prisma.room.findUnique({

--- a/app/api/v1/rooms/[roomId]/route.test.ts
+++ b/app/api/v1/rooms/[roomId]/route.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/auth", () => ({
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     room: { findUnique: vi.fn() },
+    guest: { findMany: vi.fn() },
   },
 }));
 
@@ -58,19 +59,24 @@ const makeRoom = () => ({
   ],
 });
 
+const mockGuestFindMany = vi.mocked(prisma.guest.findMany);
+
 beforeEach(() => {
   vi.clearAllMocks();
+  mockGuestFindMany.mockResolvedValue([]);
 });
 
 describe("GET /api/v1/rooms/[roomId]", () => {
-  it("未認証の場合 401 UNAUTHORIZED を返す", async () => {
+  it("未認証でも部屋情報を取得できる（isCurrentGuestParticipant: false）", async () => {
     mockAuth.mockResolvedValue(null);
+    mockFindUnique.mockResolvedValue(makeRoom() as never);
 
     const res = await GET(makeRequest(), makeParams());
     const body = await res.json();
 
-    expect(res.status).toBe(401);
-    expect(body.error.code).toBe("UNAUTHORIZED");
+    expect(res.status).toBe(200);
+    expect(body.data.isCurrentGuestParticipant).toBe(false);
+    expect(body.data.currentGuestSessionId).toBeNull();
   });
 
   it("room が存在しない場合 404 ROOM_NOT_FOUND を返す", async () => {

--- a/app/api/v1/rooms/[roomId]/route.ts
+++ b/app/api/v1/rooms/[roomId]/route.ts
@@ -20,7 +20,6 @@ const roomSelect = {
     select: {
       userId: true,
       guestSessionId: true,
-      displayName: true,
       isHost: true,
       joinedAt: true,
       user: { select: { username: true, iconUrl: true, avgRating: true } },
@@ -30,7 +29,7 @@ const roomSelect = {
 
 type RawRoom = Prisma.RoomGetPayload<{ select: typeof roomSelect }>;
 
-function formatRoom(room: RawRoom) {
+function formatRoom(room: RawRoom, guestMap: Map<string, string>) {
   return {
     id: room.id,
     title: room.title,
@@ -51,7 +50,9 @@ function formatRoom(room: RawRoom) {
     participants: room.participants.map((p) => ({
       userId: p.userId,
       guestSessionId: p.guestSessionId,
-      username: p.user?.username ?? p.displayName ?? "ゲスト",
+      username:
+        p.user?.username ??
+        (p.guestSessionId ? (guestMap.get(p.guestSessionId) ?? "ゲスト") : "ゲスト"),
       iconUrl: p.user?.iconUrl ?? null,
       avgRating:
         p.user?.avgRating !== null && p.user?.avgRating !== undefined
@@ -65,7 +66,7 @@ function formatRoom(room: RawRoom) {
 
 type RouteParams = { params: Promise<{ roomId: string }> };
 
-export async function GET(_request: Request, { params }: RouteParams) {
+export async function GET(request: Request, { params }: RouteParams) {
   const { roomId } = await params;
 
   const room = await prisma.room.findUnique({
@@ -80,5 +81,32 @@ export async function GET(_request: Request, { params }: RouteParams) {
     );
   }
 
-  return NextResponse.json({ data: formatRoom(room) });
+  // ゲスト参加者の displayName を Guest テーブルから取得
+  const guestSessionIds = room.participants
+    .map((p) => p.guestSessionId)
+    .filter((id): id is string => id !== null);
+  const guestRecords =
+    guestSessionIds.length > 0
+      ? await prisma.guest.findMany({
+          where: { guestSessionId: { in: guestSessionIds } },
+          select: { guestSessionId: true, displayName: true },
+        })
+      : [];
+  const guestMap = new Map(guestRecords.map((g) => [g.guestSessionId, g.displayName]));
+
+  // リクエストの Cookie からゲストセッションを確認
+  const cookieHeader = request.headers.get("cookie") ?? "";
+  const guestSessionCookieMatch = cookieHeader.match(/quest_link_guest_session=([^;]+)/);
+  const currentGuestSessionId = guestSessionCookieMatch?.[1] ?? null;
+  const isCurrentGuestParticipant =
+    currentGuestSessionId !== null &&
+    guestSessionIds.includes(currentGuestSessionId);
+
+  return NextResponse.json({
+    data: {
+      ...formatRoom(room, guestMap),
+      isCurrentGuestParticipant,
+      currentGuestSessionId: isCurrentGuestParticipant ? currentGuestSessionId : null,
+    },
+  });
 }

--- a/app/rooms/[roomId]/RoomActions.tsx
+++ b/app/rooms/[roomId]/RoomActions.tsx
@@ -9,10 +9,11 @@ type Props = {
   roomId: string;
   isParticipant: boolean;
   isHost: boolean;
+  isGuest: boolean;
   status: "waiting" | "playing" | "closed";
 };
 
-export function RoomActions({ roomId, isParticipant, isHost, status }: Props) {
+export function RoomActions({ roomId, isParticipant, isHost, isGuest, status }: Props) {
   const router = useRouter();
   const queryClient = useQueryClient();
 
@@ -27,7 +28,11 @@ export function RoomActions({ roomId, isParticipant, isHost, status }: Props) {
   const leaveMutation = useMutation({
     mutationFn: () => leaveRoom(roomId),
     onSuccess: () => {
-      router.push(`/rooms/${roomId}/ratings`);
+      if (isGuest) {
+        router.push(`/rooms/${roomId}/guest-leave`);
+      } else {
+        router.push(`/rooms/${roomId}/ratings`);
+      }
     },
   });
 

--- a/app/rooms/[roomId]/RoomDetailView.tsx
+++ b/app/rooms/[roomId]/RoomDetailView.tsx
@@ -85,10 +85,12 @@ export function RoomDetailView({ roomId }: Props) {
 
   const room = data.data;
   const status = roomStatusConfig[room.status as keyof typeof roomStatusConfig] ?? fallbackStatusConfig;
+  const currentGuestSessionId = room.currentGuestSessionId ?? null;
   const isParticipant =
-    currentUserId != null &&
-    room.participants.some((p) => p.userId === currentUserId);
+    (currentUserId != null && room.participants.some((p) => p.userId === currentUserId)) ||
+    room.isCurrentGuestParticipant;
   const isHost = currentUserId != null && room.host.id === currentUserId;
+  const isGuest = currentUserId === null && isParticipant;
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-4 sm:py-8 sm:px-6">
@@ -212,6 +214,7 @@ export function RoomDetailView({ roomId }: Props) {
               roomId={room.id}
               isParticipant={isParticipant}
               isHost={isHost}
+              isGuest={isGuest}
               status={room.status}
             />
           </div>
@@ -287,12 +290,27 @@ export function RoomDetailView({ roomId }: Props) {
                       ) : (
                         <span
                           className="truncate text-sm font-medium"
-                          style={{ color: "var(--text-primary)" }}
+                          style={{
+                            color:
+                              currentGuestSessionId !== null &&
+                              p.guestSessionId === currentGuestSessionId
+                                ? "var(--accent-light)"
+                                : "var(--text-primary)",
+                          }}
                         >
                           {p.username}
-                          <span className="ml-1 text-xs" style={{ color: "var(--text-muted)" }}>
-                            (ゲスト)
-                          </span>
+                        </span>
+                      )}
+                      {p.userId == null && (
+                        <span
+                          className="shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none"
+                          style={{
+                            backgroundColor: "rgba(34, 197, 94, 0.15)",
+                            color: "#4ade80",
+                            border: "1px solid rgba(34, 197, 94, 0.3)",
+                          }}
+                        >
+                          ゲスト
                         </span>
                       )}
                     </div>
@@ -325,7 +343,7 @@ export function RoomDetailView({ roomId }: Props) {
       </div>
 
       {/* Guest join modal — shown when accessing via invite URL without login */}
-      {!!inviteToken && currentUserId === null && !!data && (
+      {!!inviteToken && currentUserId === null && !!data && !isParticipant && (
         <GuestJoinModal roomId={roomId} inviteToken={inviteToken} />
       )}
     </div>

--- a/app/rooms/[roomId]/chat/ChatView.tsx
+++ b/app/rooms/[roomId]/chat/ChatView.tsx
@@ -15,6 +15,7 @@ type Tag = { id: string; name: string; slug: string };
 type Props = {
   roomId: string;
   currentUserId: string | null;
+  currentGuestSessionId: string | null;
   initialMessages: ChatMessage[];
   initialParticipants: Participant[];
   roomInfo: {
@@ -28,6 +29,7 @@ type Props = {
 export function ChatView({
   roomId,
   currentUserId,
+  currentGuestSessionId,
   initialMessages,
   initialParticipants,
   roomInfo,
@@ -160,31 +162,45 @@ export function ChatView({
           </p>
           <ul className="space-y-2.5">
             {participants.map((p, idx) => {
-              if (!p.user) return null;
-              const { username, iconUrl, avgRating } = p.user;
+              const name = p.user?.username ?? p.displayName ?? "ゲスト";
+              const iconUrl = p.user?.iconUrl ?? null;
+              const avgRating = p.user?.avgRating ?? null;
+              const isMe =
+                (p.userId != null && p.userId === currentUserId) ||
+                (currentGuestSessionId !== null && p.guestSessionId === currentGuestSessionId);
+              const isGuest = p.user === null;
               return (
                 <li key={p.userId ?? `guest-${idx}`} className="flex items-center gap-2.5">
                   <div className="relative">
-                    <UserAvatar username={username} iconUrl={iconUrl} size="sm" />
-                    <span
-                      className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2"
-                      style={{ backgroundColor: "#22c55e", borderColor: "var(--bg-card)" }}
-                    />
+                    <UserAvatar username={name} iconUrl={iconUrl} size="sm" />
+                    {!isGuest && (
+                      <span
+                        className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2"
+                        style={{ backgroundColor: "#22c55e", borderColor: "var(--bg-card)" }}
+                      />
+                    )}
                   </div>
                   <div className="min-w-0">
                     <div className="flex items-center gap-1">
                       {p.isHost && <Crown className="h-3 w-3" style={{ color: "#eab308" }} />}
                       <span
                         className="truncate text-xs font-medium"
-                        style={{
-                          color:
-                            p.userId != null && p.userId === currentUserId
-                              ? "var(--accent-light)"
-                              : "var(--text-primary)",
-                        }}
+                        style={{ color: isMe ? "var(--accent-light)" : "var(--text-primary)" }}
                       >
-                        {username}
+                        {name}
                       </span>
+                      {isGuest && (
+                        <span
+                          className="shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none"
+                          style={{
+                            backgroundColor: "rgba(34, 197, 94, 0.15)",
+                            color: "#4ade80",
+                            border: "1px solid rgba(34, 197, 94, 0.3)",
+                          }}
+                        >
+                          ゲスト
+                        </span>
+                      )}
                     </div>
                     <RatingDisplay
                       avgRating={avgRating !== null ? Number(avgRating) : null}
@@ -258,14 +274,18 @@ export function ChatView({
               );
             }
 
-            const isMe = msg.user?.id === currentUserId;
+            const isMe =
+              (currentUserId !== null && msg.user?.id === currentUserId) ||
+              (currentGuestSessionId !== null && msg.guestSessionId === currentGuestSessionId);
+            const isGuest = msg.user === null && !msg.isSystem;
+            const senderName = isGuest ? (msg.displayName ?? "ゲスト") : (msg.user?.username ?? "");
             return (
               <div
                 key={msg.id}
                 className={`flex flex-col gap-1 ${isMe ? "items-end" : "items-start"} ${msg.isNew ? "animate-slide-in-bottom" : ""}`}
               >
                 <div className={`flex items-end gap-2 max-w-[70%] ${isMe ? "flex-row-reverse" : "flex-row"}`}>
-                  {!isMe && msg.user && (
+                  {!isMe && !isGuest && msg.user && (
                     <UserAvatar
                       username={msg.user.username}
                       iconUrl={msg.user.iconUrl}
@@ -275,9 +295,21 @@ export function ChatView({
                   <div
                     className={`min-w-0 ${isMe ? "items-end" : "items-start"} flex flex-col gap-1`}
                   >
-                    {!isMe && msg.user && (
-                      <span className="truncate text-xs" style={{ color: "var(--text-muted)" }}>
-                        {msg.user.username}
+                    {!isMe && (isGuest || msg.user) && (
+                      <span className="flex items-center gap-1 truncate text-xs" style={{ color: "var(--text-muted)" }}>
+                        {senderName}
+                        {isGuest && (
+                          <span
+                            className="inline-block rounded px-1 text-[10px] font-semibold leading-4"
+                            style={{
+                              backgroundColor: "rgba(139, 92, 246, 0.15)",
+                              color: "#a78bfa",
+                              border: "1px solid rgba(139, 92, 246, 0.3)",
+                            }}
+                          >
+                            ゲスト
+                          </span>
+                        )}
                       </span>
                     )}
                     <div
@@ -305,7 +337,7 @@ export function ChatView({
                   className="text-xs"
                   style={{
                     color: "var(--text-muted)",
-                    paddingLeft: isMe ? undefined : "40px",
+                    paddingLeft: isMe || isGuest ? undefined : "40px",
                   }}
                 >
                   {new Date(msg.createdAt).toLocaleTimeString("ja-JP", {

--- a/app/rooms/[roomId]/chat/page.tsx
+++ b/app/rooms/[roomId]/chat/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { cookies } from "next/headers";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { type ChatMessage, type Participant } from "@/lib/stores/chatStore";
@@ -14,6 +15,9 @@ export default async function ChatPage({ params }: Props) {
   const session = await auth();
   const currentUserId = session?.user?.id ?? null;
 
+  const cookieStore = await cookies();
+  const currentGuestSessionId = cookieStore.get("quest_link_guest_session")?.value ?? null;
+
   const room = await prisma.room.findUnique({
     where: { id: roomId },
     select: {
@@ -27,12 +31,26 @@ export default async function ChatPage({ params }: Props) {
         select: {
           userId: true,
           isHost: true,
+          guestSessionId: true,
           user: { select: { username: true, iconUrl: true, avgRating: true } },
         },
       },
     },
   });
   if (!room) notFound();
+
+  // ゲスト参加者の displayName を Guest テーブルから一括取得
+  const guestSessionIds = room.participants
+    .map((p) => p.guestSessionId)
+    .filter((id): id is string => id !== null);
+  const guestRecords =
+    guestSessionIds.length > 0
+      ? await prisma.guest.findMany({
+          where: { guestSessionId: { in: guestSessionIds } },
+          select: { guestSessionId: true, displayName: true },
+        })
+      : [];
+  const guestMap = new Map(guestRecords.map((g) => [g.guestSessionId, g.displayName]));
 
   const tags = room.playStyleTags.map((t) => t.tag);
 
@@ -45,6 +63,7 @@ export default async function ChatPage({ params }: Props) {
       content: true,
       isSystem: true,
       createdAt: true,
+      guest: { select: { guestSessionId: true, displayName: true } },
       user: { select: { id: true, username: true, iconUrl: true } },
     },
   });
@@ -53,6 +72,8 @@ export default async function ChatPage({ params }: Props) {
     id: m.id,
     roomId,
     user: m.user ?? null,
+    displayName: m.guest?.displayName ?? undefined,
+    guestSessionId: m.guest?.guestSessionId ?? undefined,
     content: m.content,
     isSystem: m.isSystem,
     createdAt: m.createdAt,
@@ -61,6 +82,8 @@ export default async function ChatPage({ params }: Props) {
   const initialParticipants: Participant[] = room.participants.map((p) => ({
     userId: p.userId,
     isHost: p.isHost,
+    displayName: p.guestSessionId ? (guestMap.get(p.guestSessionId) ?? undefined) : undefined,
+    guestSessionId: p.guestSessionId ?? undefined,
     user: p.user
       ? {
           username: p.user.username,
@@ -74,6 +97,7 @@ export default async function ChatPage({ params }: Props) {
     <ChatView
       roomId={room.id}
       currentUserId={currentUserId}
+      currentGuestSessionId={currentGuestSessionId}
       initialMessages={initialMessages}
       initialParticipants={initialParticipants}
       roomInfo={{ title: room.title, maxPlayers: room.maxPlayers, game: room.game, tags }}

--- a/app/rooms/[roomId]/guest-leave/page.tsx
+++ b/app/rooms/[roomId]/guest-leave/page.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { GameController, CheckCircle, Star, PlusCircle } from "@phosphor-icons/react/dist/ssr";
+
+const features = [
+  { icon: CheckCircle, text: "プロフィールを作成して信頼度UP" },
+  { icon: Star, text: "他のプレイヤーを評価・評価される" },
+  { icon: PlusCircle, text: "部屋を作成・招待リンクを発行" },
+];
+
+export default function GuestLeavePage() {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 px-4 text-center">
+      <div
+        className="flex h-16 w-16 items-center justify-center rounded-2xl mb-5"
+        style={{ backgroundColor: "rgba(124,58,237,0.15)" }}
+      >
+        <GameController className="h-8 w-8" style={{ color: "var(--accent-light)" }} />
+      </div>
+
+      <h1 className="text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
+        セッション終了
+      </h1>
+      <p className="mt-2 text-sm" style={{ color: "var(--text-secondary)" }}>
+        ご参加ありがとうございました！
+      </p>
+
+      <div className="mt-8 w-full max-w-xs space-y-3 text-left">
+        {features.map(({ icon: Icon, text }) => (
+          <div key={text} className="flex items-center gap-3">
+            <Icon className="h-4 w-4 shrink-0" style={{ color: "var(--accent-light)" }} />
+            <span className="text-sm" style={{ color: "var(--text-secondary)" }}>
+              {text}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <Link
+        href="/login"
+        className="mt-8 inline-flex w-full max-w-xs items-center justify-center rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90 active:scale-[0.97]"
+        style={{
+          background: "linear-gradient(135deg, var(--accent), #6d28d9)",
+          boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
+        }}
+      >
+        ログイン / 新規登録
+      </Link>
+    </div>
+  );
+}

--- a/components/rooms/GuestJoinModal.test.tsx
+++ b/components/rooms/GuestJoinModal.test.tsx
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
-const mockPush = vi.fn();
+const mockInvalidateQueries = vi.fn();
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: mockPush }),
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
 }));
 
 import { GuestJoinModal } from "./GuestJoinModal";
@@ -14,6 +14,7 @@ const defaultProps = { roomId: "room-1", inviteToken: "valid-token" };
 beforeEach(() => {
   vi.clearAllMocks();
   vi.stubGlobal("fetch", vi.fn());
+  mockInvalidateQueries.mockResolvedValue(undefined);
 });
 
 describe("GuestJoinModal", () => {
@@ -37,7 +38,7 @@ describe("GuestJoinModal", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("成功時に router.push が /rooms/room-1/chat で呼ばれる", async () => {
+  it("成功時に invalidateQueries が room クエリで呼ばれる", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       json: async () => ({ data: { roomId: "room-1", guestSessionId: "guest_abc", isGuest: true } }),
@@ -51,7 +52,7 @@ describe("GuestJoinModal", () => {
     fireEvent.click(screen.getByRole("button", { name: "参加する" }));
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith("/rooms/room-1/chat");
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ["room", "room-1"] });
     });
   });
 

--- a/components/rooms/GuestJoinModal.tsx
+++ b/components/rooms/GuestJoinModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 
 const ERROR_MESSAGES: Record<string, string> = {
   ROOM_CLOSED: "この部屋はすでに終了しています",
@@ -16,7 +16,7 @@ type Props = {
 };
 
 export function GuestJoinModal({ roomId, inviteToken }: Props) {
-  const router = useRouter();
+  const queryClient = useQueryClient();
   const [displayName, setDisplayName] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isPending, setIsPending] = useState(false);
@@ -41,7 +41,7 @@ export function GuestJoinModal({ roomId, inviteToken }: Props) {
         setError(ERROR_MESSAGES[body.error?.code ?? ""] ?? "参加に失敗しました");
         return;
       }
-      router.push(`/rooms/${roomId}/chat`);
+      await queryClient.invalidateQueries({ queryKey: ["room", roomId] });
     } catch {
       setError("ネットワークエラーが発生しました");
     } finally {

--- a/lib/api/rooms.ts
+++ b/lib/api/rooms.ts
@@ -47,6 +47,8 @@ export type RoomDetail = RoomSummary & {
   description: string | null;
   participants: RoomParticipant[];
   closedAt: string | null;
+  isCurrentGuestParticipant: boolean;
+  currentGuestSessionId: string | null;
 };
 
 export type RoomsListResponse = {

--- a/lib/stores/chatStore.ts
+++ b/lib/stores/chatStore.ts
@@ -4,6 +4,8 @@ export type ChatMessage = {
   id: string;
   roomId: string;
   user: { id: string; username: string; iconUrl: string | null } | null;
+  displayName?: string;
+  guestSessionId?: string;
   content: string;
   isSystem: boolean;
   createdAt: Date;
@@ -13,6 +15,8 @@ export type ChatMessage = {
 export type Participant = {
   userId: string | null;
   isHost: boolean;
+  displayName?: string;
+  guestSessionId?: string;
   user: { username: string; iconUrl: string | null; avgRating: number | null } | null;
 };
 

--- a/prisma/migrations/20260405000000_fix_chat_messages_guest_constraint/migration.sql
+++ b/prisma/migrations/20260405000000_fix_chat_messages_guest_constraint/migration.sql
@@ -1,0 +1,4 @@
+-- ゲストメッセージ（userId=null, isSystem=false, displayName=非null）を許容するよう制約を修正
+ALTER TABLE "chat_messages" DROP CONSTRAINT "chk_user_or_system";
+ALTER TABLE "chat_messages" ADD CONSTRAINT "chk_user_or_system"
+    CHECK (is_system = true OR user_id IS NOT NULL OR display_name IS NOT NULL);

--- a/prisma/migrations/20260405000001_add_guests_table/migration.sql
+++ b/prisma/migrations/20260405000001_add_guests_table/migration.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "guests" (
+  "id"               UUID        NOT NULL DEFAULT gen_random_uuid(),
+  "guest_session_id" VARCHAR(50) NOT NULL,
+  "display_name"     VARCHAR(50) NOT NULL,
+  "created_at"       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT "guests_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "guests_guest_session_id_key" ON "guests"("guest_session_id");

--- a/prisma/migrations/20260405000002_add_guest_id_to_chat_messages/migration.sql
+++ b/prisma/migrations/20260405000002_add_guest_id_to_chat_messages/migration.sql
@@ -1,0 +1,21 @@
+ALTER TABLE "chat_messages" ADD COLUMN IF NOT EXISTS "guest_id" UUID;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'chat_messages_guest_id_fkey'
+  ) THEN
+    ALTER TABLE "chat_messages"
+      ADD CONSTRAINT "chat_messages_guest_id_fkey"
+      FOREIGN KEY ("guest_id") REFERENCES "guests"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- guest_id 未設定のゲストメッセージ（旧方式: display_name のみ）を削除
+DELETE FROM "chat_messages" WHERE user_id IS NULL AND is_system = false AND guest_id IS NULL;
+
+-- CHECK 制約を更新: display_name → guest_id ベースへ
+ALTER TABLE "chat_messages" DROP CONSTRAINT IF EXISTS "chk_user_or_system";
+ALTER TABLE "chat_messages" ADD CONSTRAINT "chk_user_or_system"
+  CHECK (is_system = true OR user_id IS NOT NULL OR guest_id IS NOT NULL);
+
+ALTER TABLE "chat_messages" DROP COLUMN IF EXISTS "display_name";

--- a/prisma/migrations/20260405000003_remove_display_name_from_participants/migration.sql
+++ b/prisma/migrations/20260405000003_remove_display_name_from_participants/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "room_participants" DROP COLUMN "display_name";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,12 +91,21 @@ model Room {
   @@map("rooms")
 }
 
+model Guest {
+  id             String        @id @default(uuid()) @db.Uuid
+  guestSessionId String        @unique @map("guest_session_id") @db.VarChar(50)
+  displayName    String        @map("display_name") @db.VarChar(50)
+  createdAt      DateTime      @default(now()) @map("created_at") @db.Timestamptz
+  chatMessages   ChatMessage[]
+
+  @@map("guests")
+}
+
 model RoomParticipant {
   id             String    @id @default(uuid()) @db.Uuid
   roomId         String    @map("room_id") @db.Uuid
   userId         String?   @map("user_id") @db.Uuid
   guestSessionId String?   @map("guest_session_id") @db.VarChar(50)
-  displayName    String?   @map("display_name") @db.VarChar(50)
   isHost         Boolean   @default(false) @map("is_host")
   joinedAt       DateTime  @default(now()) @map("joined_at") @db.Timestamptz
   leftAt         DateTime? @map("left_at") @db.Timestamptz
@@ -114,13 +123,14 @@ model ChatMessage {
   id        String   @id @default(uuid()) @db.Uuid
   roomId    String   @map("room_id") @db.Uuid
   userId    String?  @map("user_id") @db.Uuid
+  guestId   String?  @map("guest_id") @db.Uuid
   content   String
-  isSystem    Boolean  @default(false) @map("is_system")
-  displayName String?  @map("display_name") @db.VarChar(50)
-  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
+  isSystem  Boolean  @default(false) @map("is_system")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
 
-  room Room  @relation(fields: [roomId], references: [id], onDelete: Cascade)
-  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+  room  Room   @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  user  User?  @relation(fields: [userId], references: [id], onDelete: SetNull)
+  guest Guest? @relation(fields: [guestId], references: [id], onDelete: SetNull)
 
   @@index([roomId, createdAt(sort: Desc)])
   @@map("chat_messages")

--- a/socket-server/index.ts
+++ b/socket-server/index.ts
@@ -12,12 +12,11 @@ import { PrismaClient } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { Pool } from "pg";
 
-interface AuthenticatedSocketData {
-  userId: string;
-  username: string;
-  iconUrl: string | null;
-  avgRating: number;
-}
+type AuthenticatedSocketData =
+  | { kind: "user"; userId: string; username: string; iconUrl: string | null; avgRating: number }
+  | { kind: "guest"; guestSessionId: string; displayName: string };
+
+const GUEST_ID_RE = /^guest_[0-9a-f]{32}$/;
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 const adapter = new PrismaPg(pool);
@@ -102,6 +101,7 @@ httpServer.on("request", async (req: IncomingMessage, res: ServerResponse) => {
 });
 
 // 認証ミドルウェア: セッションCookieを検証し未認証接続を拒否する
+// 通常ユーザー: authjs.session-token / ゲスト: quest_link_guest_session
 io.use(async (socket, next) => {
   try {
     const cookieHeader = socket.request.headers.cookie ?? "";
@@ -112,25 +112,52 @@ io.use(async (socket, next) => {
         : "authjs.session-token";
     const sessionToken = cookies[cookieName];
 
-    if (!sessionToken) {
+    if (sessionToken) {
+      const decoded = await decode({
+        token: sessionToken,
+        secret: process.env.AUTH_SECRET ?? "",
+        salt: cookieName,
+      });
+
+      if (decoded?.userId) {
+        socket.data = {
+          kind: "user",
+          userId: decoded.userId as string,
+          username: (decoded.username as string | undefined) ?? "",
+          iconUrl: (decoded.iconUrl as string | null | undefined) ?? null,
+          avgRating: (decoded.avgRating as number | undefined) ?? 0,
+        } satisfies AuthenticatedSocketData;
+        return next();
+      }
+    }
+
+    // ゲストセッション Cookie によるフォールバック認証
+    const guestSessionId = cookies["quest_link_guest_session"] ?? "";
+    if (!GUEST_ID_RE.test(guestSessionId)) {
       return next(new Error("UNAUTHORIZED"));
     }
 
-    const decoded = await decode({
-      token: sessionToken,
-      secret: process.env.AUTH_SECRET ?? "",
-      salt: cookieName,
+    const participant = await prisma.roomParticipant.findFirst({
+      where: { guestSessionId, leftAt: null },
+      select: { id: true },
     });
-
-    if (!decoded?.userId) {
+    if (!participant) {
       return next(new Error("UNAUTHORIZED"));
     }
 
-    socket.data.userId = decoded.userId as string;
-    socket.data.username = (decoded.username as string | undefined) ?? "";
-    socket.data.iconUrl = (decoded.iconUrl as string | null | undefined) ?? null;
-    socket.data.avgRating = (decoded.avgRating as number | undefined) ?? 0;
+    const guest = await prisma.guest.findUnique({
+      where: { guestSessionId },
+      select: { displayName: true },
+    });
+    if (!guest) {
+      return next(new Error("UNAUTHORIZED"));
+    }
 
+    socket.data = {
+      kind: "guest",
+      guestSessionId,
+      displayName: guest.displayName,
+    } satisfies AuthenticatedSocketData;
     next();
   } catch {
     next(new Error("UNAUTHORIZED"));
@@ -138,7 +165,7 @@ io.use(async (socket, next) => {
 });
 
 io.on("connection", (socket) => {
-  const { userId } = socket.data as AuthenticatedSocketData;
+  const socketData = socket.data as AuthenticatedSocketData;
 
   // クライアント → サーバー: 部屋チャンネルに参加（REST /join 後に送信）
   // 通知・システムメッセージは REST /join ハンドラが担う
@@ -167,34 +194,70 @@ io.on("connection", (socket) => {
         return;
 
       try {
-        const message = await prisma.chatMessage.create({
-          data: {
-            roomId,
-            userId,
-            content: content.trim(),
-            isSystem: false,
-          },
-          include: {
-            user: {
-              select: { id: true, username: true, iconUrl: true },
+        if (socketData.kind === "user") {
+          const message = await prisma.chatMessage.create({
+            data: {
+              roomId,
+              userId: socketData.userId,
+              content: content.trim(),
+              isSystem: false,
             },
-          },
-        });
+            include: {
+              user: {
+                select: { id: true, username: true, iconUrl: true },
+              },
+            },
+          });
 
-        io.to(roomId).emit("chat:message", {
-          id: message.id,
-          roomId: message.roomId,
-          user: message.user
-            ? {
-                id: message.user.id,
-                username: message.user.username,
-                iconUrl: message.user.iconUrl,
-              }
-            : null,
-          content: message.content,
-          isSystem: false,
-          createdAt: message.createdAt,
-        });
+          io.to(roomId).emit("chat:message", {
+            id: message.id,
+            roomId: message.roomId,
+            user: message.user
+              ? {
+                  id: message.user.id,
+                  username: message.user.username,
+                  iconUrl: message.user.iconUrl,
+                }
+              : null,
+            content: message.content,
+            isSystem: false,
+            createdAt: message.createdAt,
+          });
+        } else {
+          // ゲスト: 送信対象ルームへの参加を確認してから保存
+          const participant = await prisma.roomParticipant.findFirst({
+            where: { guestSessionId: socketData.guestSessionId, roomId, leftAt: null },
+            select: { id: true },
+          });
+          if (!participant) return;
+
+          const guest = await prisma.guest.findUnique({
+            where: { guestSessionId: socketData.guestSessionId },
+            select: { id: true },
+          });
+          if (!guest) return;
+
+          const message = await prisma.chatMessage.create({
+            data: {
+              roomId,
+              userId: null,
+              guestId: guest.id,
+              content: content.trim(),
+              isSystem: false,
+            },
+          });
+
+          io.to(roomId).emit("chat:message", {
+            id: message.id,
+            roomId: message.roomId,
+            user: null,
+            displayName: socketData.displayName,
+            guestSessionId: socketData.guestSessionId,
+            content: message.content,
+            isSystem: false,
+            createdAt: message.createdAt,
+          });
+        }
       } catch (err) {
         console.error("Error in chat:send handler:", err);
       }


### PR DESCRIPTION
## Summary

- `Guest` テーブルを新設し `guestSessionId ↔ displayName` を一元管理（DBマイグレーション4本）
- Socket.IO サーバーにゲスト認証（`quest_link_guest_session` クッキー）を追加し、メッセージ送受信・右寄せ表示・リロード後の `isMe` 判定を実装
- 部屋詳細画面にゲストの参加状態（`isCurrentGuestParticipant`）を反映し、参加後UIへ切り替わるよう修正
- `GuestJoinModal`: 参加成功後 `invalidateQueries` で部屋詳細を更新（通常ユーザーと同じ挙動に統一）
- 退室APIをゲスト対応にし、退室後はセッション終了・ログイン促進画面（`/rooms/[roomId]/guest-leave`）へ遷移
- チャット画面サイドバーにゲスト名・バッジを表示
- 関連テストを追加・更新（`leave` / `invite-join` / `room-detail` / `GuestJoinModal`）

## Test plan

- [ ] 招待URLを開く → `GuestJoinModal` が表示される
- [ ] ゲスト名を入力して参加 → 部屋詳細が参加後UIに切り替わる（「退室する」ボタンが表示）
- [ ] チャット画面でメッセージを送信 → 自分のメッセージが右寄せで表示される
- [ ] ページをリロード → リロード後も自分のメッセージが右寄せのまま
- [ ] チャットサイドバーにゲスト名とバッジが表示される
- [ ] 「退室する」を押す → エラーなく退室、`/rooms/[roomId]/guest-leave` に遷移
- [ ] ゲスト退室後ページから「ログイン / 新規登録」ボタンでログイン画面へ遷移
- [ ] `pnpm test` が全テスト通過する

🤖 Generated with [Claude Code](https://claude.com/claude-code)