### PR TITLE
feat: ユーザープロフィール共通コンポーネントの作成

### DIFF
--- a/app/users/[userId]/page.tsx
+++ b/app/users/[userId]/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft, GameController } from "@phosphor-icons/react";
-import { UserAvatar } from "@/components/ui/UserAvatar";
-import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
-import { RatingDisplay } from "@/components/ui/StarRating";
+import { ArrowLeft } from "@phosphor-icons/react";
+import { ProfileHero } from "@/components/users/ProfileHero";
+import { ProfileInfo } from "@/components/users/ProfileInfo";
+import { ProfileStats } from "@/components/users/ProfileStats";
+import { GameScrollList } from "@/components/users/GameScrollList";
 
 type UserProfile = {
   id: string;
@@ -74,33 +74,12 @@ export default function UserProfilePage() {
 
   return (
     <div className="mx-auto max-w-3xl pb-8 sm:mt-6 sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)]">
-      {/* Hero + Avatar wrapper — relative so avatar can overflow hero */}
-      <div className="relative">
-        {/* Hero Banner */}
-        <div
-          className="min-h-[200px] overflow-hidden sm:rounded-t-2xl"
-          style={{ backgroundColor: "var(--bg-card)" }}
-        >
-          {/* Background image */}
-          <div className="absolute inset-0">
-            {user.games[0]?.coverImageUrl ? (
-              <Image
-                src={user.games[0].coverImageUrl}
-                alt=""
-                fill
-                className="object-cover"
-                sizes="768px"
-                aria-hidden="true"
-              />
-            ) : (
-              <div
-                className="h-full w-full"
-                style={{ background: "linear-gradient(135deg, #1e1030 0%, #2d1b69 50%, #1a0f2e 100%)" }}
-              />
-            )}
-          </div>
-          {/* Back link — top left */}
-          <div className="relative z-10 px-4 pt-4 sm:px-6">
+      <ProfileHero
+        coverImageUrl={user.games[0]?.coverImageUrl}
+        username={user.username}
+        iconUrl={user.iconUrl}
+        actions={
+          <div className="px-4 pt-4 sm:px-6">
             <Link
               href="/rooms"
               className="flex items-center gap-2 text-sm transition-colors hover:text-white"
@@ -110,100 +89,18 @@ export default function UserProfilePage() {
               部屋一覧
             </Link>
           </div>
-          {/* Spacer for hero height */}
-          <div className="pb-10 pt-14" />
-        </div>
-        {/* Avatar — centered at hero bottom, outside overflow-hidden */}
-        <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 z-10">
-          <UserAvatar username={user.username} iconUrl={user.iconUrl} size="xl" />
-        </div>
-      </div>
-
-      {/* Profile Info — centered */}
-      <div className="px-4 sm:px-6 pt-14 pb-4 text-center">
-        <h1 className="text-xl sm:text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
-          {user.username}
-        </h1>
-        <div className="mt-1.5 flex justify-center">
-          <RatingDisplay avgRating={user.avgRating} ratingCount={user.ratingCount} />
-        </div>
-        {user.playStyleTags.length > 0 && (
-          <div className="mt-3 flex flex-wrap justify-center gap-2">
-            {user.playStyleTags.map((tag) => (
-              <PlayStyleTag key={tag.id} tag={tag} />
-            ))}
-          </div>
-        )}
-        {user.bio ? (
-          <p className="mt-3 text-sm leading-relaxed" style={{ color: "var(--text-secondary)" }}>
-            {user.bio}
-          </p>
-        ) : (
-          <p className="mt-3 text-sm" style={{ color: "var(--text-muted)" }}>
-            自己紹介はまだありません
-          </p>
-        )}
-      </div>
-
-      {/* Stats — inline with dividers */}
-      <div className="flex justify-center px-4 sm:px-6 py-4">
-        {[
-          { label: "平均評価", value: user.avgRating > 0 ? user.avgRating.toFixed(1) : "-", sub: "/ 5.0" },
-          { label: "評価件数", value: user.ratingCount.toString(), sub: "件" },
-        ].map(({ label, value, sub }, i) => (
-          <div key={label} className="flex">
-            {i > 0 && (
-              <div className="mx-6 w-px self-stretch" style={{ backgroundColor: "var(--border)" }} />
-            )}
-            <div className="text-center">
-              <p className="text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
-                {value}
-                <span className="ml-1 text-sm font-normal" style={{ color: "var(--text-secondary)" }}>
-                  {sub}
-                </span>
-              </p>
-              <p className="mt-0.5 text-xs" style={{ color: "var(--text-muted)" }}>
-                {label}
-              </p>
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {/* My Games */}
-      <div className="mt-4">
-        <h2 className="mb-3 px-4 sm:px-6 text-sm font-semibold uppercase tracking-wider" style={{ color: "var(--text-muted)" }}>
-          プレイしているゲーム
-        </h2>
-        {user.games.length > 0 ? (
-          <div className="flex gap-3 overflow-x-auto px-4 sm:px-6 pb-2 scrollbar-none">
-            {user.games.map((game) => (
-              <div key={game.id} className="flex shrink-0 flex-col items-center gap-2">
-                <div
-                  className="relative h-36 w-28 overflow-hidden rounded-lg"
-                  style={{ backgroundColor: "rgba(124,58,237,0.15)", border: "1px solid rgba(124,58,237,0.2)" }}
-                >
-                  {game.coverImageUrl ? (
-                    <Image src={game.coverImageUrl} alt={game.name} fill className="object-cover" sizes="112px" />
-                  ) : (
-                    <div className="flex h-full items-center justify-center">
-                      <GameController className="h-6 w-6" style={{ color: "var(--accent-light)" }} />
-                    </div>
-                  )}
-                </div>
-                <span className="w-28 truncate text-center text-xs" style={{ color: "var(--text-secondary)" }}>
-                  {game.name}
-                </span>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="px-4 sm:px-6 text-sm" style={{ color: "var(--text-muted)" }}>
-            ゲームが設定されていません
-          </p>
-        )}
-      </div>
-
+        }
+      />
+      <ProfileInfo
+        username={user.username}
+        avgRating={user.avgRating}
+        ratingCount={user.ratingCount}
+        playStyleTags={user.playStyleTags}
+        bio={user.bio}
+        bioFallback="自己紹介はまだありません"
+      />
+      <ProfileStats avgRating={user.avgRating} ratingCount={user.ratingCount} />
+      <GameScrollList games={user.games} />
     </div>
   );
 }

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { PencilSimple, ClockCounterClockwise, Star, GameController } from "@phosphor-icons/react";
-import { UserAvatar } from "@/components/ui/UserAvatar";
-import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
-import { RatingDisplay, StarRating } from "@/components/ui/StarRating";
+import { PencilSimple, ClockCounterClockwise } from "@phosphor-icons/react";
+import { ProfileHero } from "@/components/users/ProfileHero";
+import { ProfileInfo } from "@/components/users/ProfileInfo";
+import { ProfileStats } from "@/components/users/ProfileStats";
+import { GameScrollList } from "@/components/users/GameScrollList";
+import { ReceivedRatingsList } from "@/components/users/ReceivedRatingsList";
 import { DeleteAccountButton } from "./DeleteAccountButton";
 
 type ReceivedRating = {
@@ -37,11 +37,7 @@ async function fetchMyProfile(): Promise<UserProfile> {
   return json.data;
 }
 
-const RATINGS_PREVIEW_COUNT = 3;
-
 export default function MyProfilePage() {
-  const [showAllRatings, setShowAllRatings] = useState(false);
-
   const { data: user, isLoading, isError } = useQuery({
     queryKey: ["users", "me"],
     queryFn: fetchMyProfile,
@@ -84,33 +80,12 @@ export default function MyProfilePage() {
 
   return (
     <div className="mx-auto max-w-3xl pb-8 sm:mt-6 sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)]">
-      {/* Hero + Avatar wrapper — relative so avatar can overflow hero */}
-      <div className="relative">
-        {/* Hero Banner */}
-        <div
-          className="min-h-[200px] overflow-hidden sm:rounded-t-2xl"
-          style={{ backgroundColor: "var(--bg-card)" }}
-        >
-          {/* Background image */}
-          <div className="absolute inset-0">
-            {user.games[0]?.coverImageUrl ? (
-              <Image
-                src={user.games[0].coverImageUrl}
-                alt=""
-                fill
-                className="object-cover"
-                sizes="768px"
-                aria-hidden="true"
-              />
-            ) : (
-              <div
-                className="h-full w-full"
-                style={{ background: "linear-gradient(135deg, #1e1030 0%, #2d1b69 50%, #1a0f2e 100%)" }}
-              />
-            )}
-          </div>
-          {/* Action buttons — top right */}
-          <div className="relative z-10 flex justify-end gap-2 px-4 pt-4 sm:px-6">
+      <ProfileHero
+        coverImageUrl={user.games[0]?.coverImageUrl}
+        username={user.username}
+        iconUrl={user.iconUrl}
+        actions={
+          <div className="flex justify-end gap-2 px-4 pt-4 sm:px-6">
             <Link
               href="/users/me/edit"
               className="flex items-center gap-2 rounded-xl border p-2 sm:px-4 sm:py-2 text-sm font-medium transition-all hover:border-[var(--accent)]"
@@ -128,167 +103,18 @@ export default function MyProfilePage() {
               <span className="hidden sm:inline">参加履歴</span>
             </Link>
           </div>
-          {/* Spacer for hero height */}
-          <div className="pb-10 pt-14" />
-        </div>
-        {/* Avatar — centered at hero bottom, outside overflow-hidden */}
-        <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 z-10">
-          <UserAvatar username={user.username} iconUrl={user.iconUrl} size="xl" />
-        </div>
-      </div>
-
-      {/* Profile Info — centered */}
-      <div className="px-4 sm:px-6 pt-14 pb-4 text-center">
-        <h1 className="text-xl sm:text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
-          {user.username}
-        </h1>
-        <div className="mt-1.5 flex justify-center">
-          <RatingDisplay avgRating={user.avgRating} ratingCount={user.ratingCount} />
-        </div>
-        {user.playStyleTags.length > 0 && (
-          <div className="mt-3 flex flex-wrap justify-center gap-2">
-            {user.playStyleTags.map((tag) => (
-              <PlayStyleTag key={tag.id} tag={tag} />
-            ))}
-          </div>
-        )}
-        {user.bio && (
-          <p className="mt-3 text-sm leading-relaxed" style={{ color: "var(--text-secondary)" }}>
-            {user.bio}
-          </p>
-        )}
-      </div>
-
-      {/* Stats — inline with dividers */}
-      <div className="flex justify-center px-4 sm:px-6 py-4">
-        {[
-          { label: "平均評価", value: user.avgRating > 0 ? user.avgRating.toFixed(1) : "-", sub: "/ 5.0" },
-          { label: "評価件数", value: user.ratingCount.toString(), sub: "件" },
-        ].map(({ label, value, sub }, i) => (
-          <div key={label} className="flex">
-            {i > 0 && (
-              <div className="mx-6 w-px self-stretch" style={{ backgroundColor: "var(--border)" }} />
-            )}
-            <div className="text-center">
-              <p className="text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
-                {value}
-                <span className="ml-1 text-sm font-normal" style={{ color: "var(--text-secondary)" }}>
-                  {sub}
-                </span>
-              </p>
-              <p className="mt-0.5 text-xs" style={{ color: "var(--text-muted)" }}>
-                {label}
-              </p>
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {/* My Games */}
-      <div className="mt-4">
-        <h2 className="mb-3 px-4 sm:px-6 text-sm font-semibold uppercase tracking-wider" style={{ color: "var(--text-muted)" }}>
-          プレイしているゲーム
-        </h2>
-        {user.games.length > 0 ? (
-          <div className="flex gap-3 overflow-x-auto px-4 sm:px-6 pb-2 scrollbar-none">
-            {user.games.map((game) => (
-              <div key={game.id} className="flex shrink-0 flex-col items-center gap-2">
-                <div
-                  className="relative h-36 w-28 overflow-hidden rounded-lg"
-                  style={{ backgroundColor: "rgba(124,58,237,0.15)", border: "1px solid rgba(124,58,237,0.2)" }}
-                >
-                  {game.coverImageUrl ? (
-                    <Image src={game.coverImageUrl} alt={game.name} fill className="object-cover" sizes="112px" />
-                  ) : (
-                    <div className="flex h-full items-center justify-center">
-                      <GameController className="h-6 w-6" style={{ color: "var(--accent-light)" }} />
-                    </div>
-                  )}
-                </div>
-                <span className="w-28 truncate text-center text-xs" style={{ color: "var(--text-secondary)" }}>
-                  {game.name}
-                </span>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="px-4 sm:px-6 text-sm" style={{ color: "var(--text-muted)" }}>
-            ゲームが設定されていません
-          </p>
-        )}
-      </div>
-
-      {/* Received Ratings */}
-      <div className="mt-8 px-4 sm:px-6">
-        <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider" style={{ color: "var(--text-muted)" }}>
-          <Star className="h-3.5 w-3.5" style={{ fill: "#eab308", color: "#eab308" }} />
-          受け取った評価
-        </h2>
-        {user.receivedRatings.length === 0 ? (
-          <p className="text-sm" style={{ color: "var(--text-muted)" }}>
-            まだ評価がありません
-          </p>
-        ) : (
-          <>
-            <div className="space-y-3">
-              {(showAllRatings
-                ? user.receivedRatings
-                : user.receivedRatings.slice(0, RATINGS_PREVIEW_COUNT)
-              ).map((rating) => (
-                <div
-                  key={rating.id}
-                  className="rounded-xl p-4"
-                  style={{ backgroundColor: "var(--bg-input)", border: "1px solid var(--border)" }}
-                >
-                  <div className="flex items-start gap-3">
-                    <UserAvatar
-                      username={rating.reviewer.username}
-                      iconUrl={rating.reviewer.iconUrl}
-                      size="sm"
-                    />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium truncate" style={{ color: "var(--text-primary)" }}>
-                          {rating.reviewer.username ?? "退会済みユーザー"}
-                        </span>
-                        <span className="text-xs shrink-0" style={{ color: "var(--text-muted)" }}>
-                          {new Date(rating.createdAt).toLocaleDateString("ja-JP")}
-                        </span>
-                      </div>
-                      <div className="mt-1">
-                        <StarRating value={rating.score} readonly size="sm" />
-                      </div>
-                      {rating.comment && (
-                        <p className="mt-1.5 text-sm leading-relaxed" style={{ color: "var(--text-secondary)" }}>
-                          {rating.comment}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-            {user.receivedRatings.length > RATINGS_PREVIEW_COUNT && (
-              <button
-                type="button"
-                onClick={() => setShowAllRatings((prev) => !prev)}
-                className="mt-3 w-full rounded-xl py-2.5 text-sm font-medium transition-colors hover:opacity-80"
-                style={{
-                  backgroundColor: "var(--bg-input)",
-                  border: "1px solid var(--border)",
-                  color: "var(--accent-light)",
-                }}
-              >
-                {showAllRatings
-                  ? "折りたたむ"
-                  : `すべて見る（${user.receivedRatings.length}件）`}
-              </button>
-            )}
-          </>
-        )}
-      </div>
-
-      {/* Danger Zone */}
+        }
+      />
+      <ProfileInfo
+        username={user.username}
+        avgRating={user.avgRating}
+        ratingCount={user.ratingCount}
+        playStyleTags={user.playStyleTags}
+        bio={user.bio}
+      />
+      <ProfileStats avgRating={user.avgRating} ratingCount={user.ratingCount} />
+      <GameScrollList games={user.games} />
+      <ReceivedRatingsList ratings={user.receivedRatings} />
       <div className="mx-4 sm:mx-6 mt-8">
         <DeleteAccountButton />
       </div>

--- a/components/users/GameScrollList.test.tsx
+++ b/components/users/GameScrollList.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/image", () => ({
+  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+vi.mock("@phosphor-icons/react", () => ({
+  GameController: () => <span data-testid="game-controller-icon" />,
+}));
+
+import { GameScrollList } from "./GameScrollList";
+
+const games = [
+  { id: "g1", igdbId: 1, name: "Apex Legends", coverImageUrl: "https://example.com/apex.jpg" },
+  { id: "g2", igdbId: 2, name: "Valorant", coverImageUrl: null },
+];
+
+describe("GameScrollList", () => {
+  it("ゲーム名が表示される", () => {
+    render(<GameScrollList games={games} />);
+    expect(screen.getByText("Apex Legends")).toBeInTheDocument();
+    expect(screen.getByText("Valorant")).toBeInTheDocument();
+  });
+
+  it("coverImageUrl がある場合は img が表示される", () => {
+    render(<GameScrollList games={games} />);
+    expect(screen.getByAltText("Apex Legends")).toBeInTheDocument();
+  });
+
+  it("coverImageUrl が null の場合はアイコンが表示される", () => {
+    render(<GameScrollList games={games} />);
+    expect(screen.getByTestId("game-controller-icon")).toBeInTheDocument();
+  });
+
+  it("games が空の場合は空状態テキストが表示される", () => {
+    render(<GameScrollList games={[]} />);
+    expect(screen.getByText("ゲームが設定されていません")).toBeInTheDocument();
+  });
+
+  it("セクション見出しが表示される", () => {
+    render(<GameScrollList games={games} />);
+    expect(screen.getByText("プレイしているゲーム")).toBeInTheDocument();
+  });
+});

--- a/components/users/GameScrollList.tsx
+++ b/components/users/GameScrollList.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Image from "next/image";
+import { GameController } from "@phosphor-icons/react";
+
+type Game = {
+  id: string;
+  igdbId: number;
+  name: string;
+  coverImageUrl: string | null;
+};
+
+type GameScrollListProps = {
+  games: Game[];
+};
+
+export function GameScrollList({ games }: GameScrollListProps) {
+  return (
+    <div className="mt-4">
+      <h2
+        className="mb-3 px-4 sm:px-6 text-sm font-semibold uppercase tracking-wider"
+        style={{ color: "var(--text-muted)" }}
+      >
+        プレイしているゲーム
+      </h2>
+      {games.length > 0 ? (
+        <div className="flex gap-3 overflow-x-auto px-4 sm:px-6 pb-2 scrollbar-none">
+          {games.map((game) => (
+            <div key={game.id} className="flex shrink-0 flex-col items-center gap-2">
+              <div
+                className="relative h-36 w-28 overflow-hidden rounded-lg"
+                style={{
+                  backgroundColor: "rgba(124,58,237,0.15)",
+                  border: "1px solid rgba(124,58,237,0.2)",
+                }}
+              >
+                {game.coverImageUrl ? (
+                  <Image
+                    src={game.coverImageUrl}
+                    alt={game.name}
+                    fill
+                    className="object-cover"
+                    sizes="112px"
+                  />
+                ) : (
+                  <div className="flex h-full items-center justify-center">
+                    <GameController className="h-6 w-6" style={{ color: "var(--accent-light)" }} />
+                  </div>
+                )}
+              </div>
+              <span
+                className="w-28 truncate text-center text-xs"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                {game.name}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="px-4 sm:px-6 text-sm" style={{ color: "var(--text-muted)" }}>
+          ゲームが設定されていません
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/users/ProfileHero.tsx
+++ b/components/users/ProfileHero.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import Image from "next/image";
+import { UserAvatar } from "@/components/ui/UserAvatar";
+
+type ProfileHeroProps = {
+  coverImageUrl?: string | null;
+  username: string;
+  iconUrl: string | null;
+  actions?: React.ReactNode;
+};
+
+export function ProfileHero({ coverImageUrl, username, iconUrl, actions }: ProfileHeroProps) {
+  return (
+    <div className="relative">
+      {/* Hero Banner */}
+      <div
+        className="min-h-[200px] overflow-hidden sm:rounded-t-2xl"
+        style={{ backgroundColor: "var(--bg-card)" }}
+      >
+        {/* Background image */}
+        <div className="absolute inset-0">
+          {coverImageUrl ? (
+            <Image
+              src={coverImageUrl}
+              alt=""
+              fill
+              className="object-cover"
+              sizes="768px"
+              aria-hidden="true"
+            />
+          ) : (
+            <div
+              className="h-full w-full"
+              style={{ background: "linear-gradient(135deg, #1e1030 0%, #2d1b69 50%, #1a0f2e 100%)" }}
+            />
+          )}
+        </div>
+        {/* Action slot — top area */}
+        {actions && (
+          <div className="relative z-10">
+            {actions}
+          </div>
+        )}
+        {/* Spacer for hero height */}
+        <div className="pb-10 pt-14" />
+      </div>
+      {/* Avatar — centered at hero bottom, outside overflow-hidden */}
+      <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 z-10">
+        <UserAvatar username={username} iconUrl={iconUrl} size="xl" />
+      </div>
+    </div>
+  );
+}

--- a/components/users/ProfileInfo.test.tsx
+++ b/components/users/ProfileInfo.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/components/ui/PlayStyleTag", () => ({
+  PlayStyleTag: ({ tag }: { tag: { name: string } }) => <span>{tag.name}</span>,
+}));
+
+vi.mock("@/components/ui/StarRating", () => ({
+  RatingDisplay: () => <div data-testid="rating-display" />,
+}));
+
+import { ProfileInfo } from "./ProfileInfo";
+
+const defaultProps = {
+  username: "testuser",
+  avgRating: 4.2,
+  ratingCount: 10,
+  playStyleTags: [{ id: "t1", name: "ガチ", slug: "serious" }],
+  bio: null,
+};
+
+describe("ProfileInfo", () => {
+  it("ユーザー名が表示される", () => {
+    render(<ProfileInfo {...defaultProps} />);
+    expect(screen.getByText("testuser")).toBeInTheDocument();
+  });
+
+  it("RatingDisplay が表示される", () => {
+    render(<ProfileInfo {...defaultProps} />);
+    expect(screen.getByTestId("rating-display")).toBeInTheDocument();
+  });
+
+  it("playStyleTags が表示される", () => {
+    render(<ProfileInfo {...defaultProps} />);
+    expect(screen.getByText("ガチ")).toBeInTheDocument();
+  });
+
+  it("bio がある場合にテキストが表示される", () => {
+    render(<ProfileInfo {...defaultProps} bio="自己紹介文" />);
+    expect(screen.getByText("自己紹介文")).toBeInTheDocument();
+  });
+
+  it("bio が null で bioFallback がある場合にフォールバックが表示される", () => {
+    render(<ProfileInfo {...defaultProps} bioFallback="自己紹介はまだありません" />);
+    expect(screen.getByText("自己紹介はまだありません")).toBeInTheDocument();
+  });
+
+  it("bio が null で bioFallback もない場合は何も表示されない", () => {
+    render(<ProfileInfo {...defaultProps} />);
+    expect(screen.queryByText("自己紹介はまだありません")).not.toBeInTheDocument();
+  });
+
+  it("playStyleTags が空の場合はタグが表示されない", () => {
+    render(<ProfileInfo {...defaultProps} playStyleTags={[]} />);
+    expect(screen.queryByText("ガチ")).not.toBeInTheDocument();
+  });
+});

--- a/components/users/ProfileInfo.tsx
+++ b/components/users/ProfileInfo.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
+import { RatingDisplay } from "@/components/ui/StarRating";
+
+type PlayStyleTagItem = {
+  id: string;
+  name: string;
+  slug: string;
+};
+
+type ProfileInfoProps = {
+  username: string;
+  avgRating: number;
+  ratingCount: number;
+  playStyleTags: PlayStyleTagItem[];
+  bio: string | null;
+  bioFallback?: string;
+};
+
+export function ProfileInfo({
+  username,
+  avgRating,
+  ratingCount,
+  playStyleTags,
+  bio,
+  bioFallback,
+}: ProfileInfoProps) {
+  return (
+    <div className="px-4 sm:px-6 pt-14 pb-4 text-center">
+      <h1 className="text-xl sm:text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
+        {username}
+      </h1>
+      <div className="mt-1.5 flex justify-center">
+        <RatingDisplay avgRating={avgRating} ratingCount={ratingCount} />
+      </div>
+      {playStyleTags.length > 0 && (
+        <div className="mt-3 flex flex-wrap justify-center gap-2">
+          {playStyleTags.map((tag) => (
+            <PlayStyleTag key={tag.id} tag={tag} />
+          ))}
+        </div>
+      )}
+      {bio ? (
+        <p className="mt-3 text-sm leading-relaxed" style={{ color: "var(--text-secondary)" }}>
+          {bio}
+        </p>
+      ) : bioFallback ? (
+        <p className="mt-3 text-sm" style={{ color: "var(--text-muted)" }}>
+          {bioFallback}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/components/users/ProfileStats.test.tsx
+++ b/components/users/ProfileStats.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProfileStats } from "./ProfileStats";
+
+describe("ProfileStats", () => {
+  it("平均評価が小数第1位で表示される", () => {
+    render(<ProfileStats avgRating={4.2} ratingCount={10} />);
+    expect(screen.getByText("4.2")).toBeInTheDocument();
+  });
+
+  it("avgRating が 0 のとき「-」が表示される", () => {
+    render(<ProfileStats avgRating={0} ratingCount={0} />);
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+
+  it("評価件数が表示される", () => {
+    render(<ProfileStats avgRating={4.2} ratingCount={10} />);
+    expect(screen.getByText("10")).toBeInTheDocument();
+  });
+
+  it("ラベル「平均評価」と「評価件数」が表示される", () => {
+    render(<ProfileStats avgRating={4.2} ratingCount={10} />);
+    expect(screen.getByText("平均評価")).toBeInTheDocument();
+    expect(screen.getByText("評価件数")).toBeInTheDocument();
+  });
+});

--- a/components/users/ProfileStats.tsx
+++ b/components/users/ProfileStats.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+type ProfileStatsProps = {
+  avgRating: number;
+  ratingCount: number;
+};
+
+export function ProfileStats({ avgRating, ratingCount }: ProfileStatsProps) {
+  const stats = [
+    { label: "平均評価", value: avgRating > 0 ? avgRating.toFixed(1) : "-", sub: "/ 5.0" },
+    { label: "評価件数", value: ratingCount.toString(), sub: "件" },
+  ];
+
+  return (
+    <div className="flex justify-center px-4 sm:px-6 py-4">
+      {stats.map(({ label, value, sub }, i) => (
+        <div key={label} className="flex">
+          {i > 0 && (
+            <div className="mx-6 w-px self-stretch" style={{ backgroundColor: "var(--border)" }} />
+          )}
+          <div className="text-center">
+            <p className="text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
+              {value}
+              <span className="ml-1 text-sm font-normal" style={{ color: "var(--text-secondary)" }}>
+                {sub}
+              </span>
+            </p>
+            <p className="mt-0.5 text-xs" style={{ color: "var(--text-muted)" }}>
+              {label}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/users/ReceivedRatingsList.test.tsx
+++ b/components/users/ReceivedRatingsList.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/components/ui/UserAvatar", () => ({
+  UserAvatar: () => <div data-testid="user-avatar" />,
+}));
+
+vi.mock("@/components/ui/StarRating", () => ({
+  StarRating: () => <div data-testid="star-rating" />,
+}));
+
+vi.mock("@phosphor-icons/react", () => ({
+  Star: () => <span />,
+}));
+
+import { ReceivedRatingsList } from "./ReceivedRatingsList";
+
+const makeRating = (id: string, username: string | null, comment: string | null = null) => ({
+  id,
+  score: 4,
+  comment,
+  createdAt: "2026-04-01T00:00:00Z",
+  reviewer: { username, iconUrl: null },
+});
+
+const ratings = [
+  makeRating("r1", "user1", "良いプレイヤーです"),
+  makeRating("r2", "user2"),
+  makeRating("r3", "user3"),
+  makeRating("r4", "user4"),
+];
+
+describe("ReceivedRatingsList", () => {
+  it("ratings が空のとき「まだ評価がありません」が表示される", () => {
+    render(<ReceivedRatingsList ratings={[]} />);
+    expect(screen.getByText("まだ評価がありません")).toBeInTheDocument();
+  });
+
+  it("レビュアーのユーザー名が表示される", () => {
+    render(<ReceivedRatingsList ratings={[makeRating("r1", "testuser")]} />);
+    expect(screen.getByText("testuser")).toBeInTheDocument();
+  });
+
+  it("username が null のとき「退会済みユーザー」が表示される", () => {
+    render(<ReceivedRatingsList ratings={[makeRating("r1", null)]} />);
+    expect(screen.getByText("退会済みユーザー")).toBeInTheDocument();
+  });
+
+  it("comment があるとき表示される", () => {
+    render(<ReceivedRatingsList ratings={[makeRating("r1", "user1", "良いです")]} />);
+    expect(screen.getByText("良いです")).toBeInTheDocument();
+  });
+
+  it("3件以下のときは「すべて見る」ボタンが表示されない", () => {
+    render(<ReceivedRatingsList ratings={ratings.slice(0, 3)} />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("4件以上のとき最初は3件だけ表示され「すべて見る」ボタンが表示される", () => {
+    render(<ReceivedRatingsList ratings={ratings} />);
+    expect(screen.getByText("すべて見る（4件）")).toBeInTheDocument();
+    expect(screen.queryByText("user4")).not.toBeInTheDocument();
+  });
+
+  it("「すべて見る」クリックで全件表示され「折りたたむ」に変わる", async () => {
+    const user = userEvent.setup();
+    render(<ReceivedRatingsList ratings={ratings} />);
+    await user.click(screen.getByText("すべて見る（4件）"));
+    expect(screen.getByText("user4")).toBeInTheDocument();
+    expect(screen.getByText("折りたたむ")).toBeInTheDocument();
+  });
+
+  it("「折りたたむ」クリックで3件に戻る", async () => {
+    const user = userEvent.setup();
+    render(<ReceivedRatingsList ratings={ratings} />);
+    await user.click(screen.getByText("すべて見る（4件）"));
+    await user.click(screen.getByText("折りたたむ"));
+    expect(screen.queryByText("user4")).not.toBeInTheDocument();
+    expect(screen.getByText("すべて見る（4件）")).toBeInTheDocument();
+  });
+});

--- a/components/users/ReceivedRatingsList.tsx
+++ b/components/users/ReceivedRatingsList.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState } from "react";
+import { Star } from "@phosphor-icons/react";
+import { UserAvatar } from "@/components/ui/UserAvatar";
+import { StarRating } from "@/components/ui/StarRating";
+
+type ReceivedRating = {
+  id: string;
+  score: number;
+  comment: string | null;
+  createdAt: string;
+  reviewer: { username: string | null; iconUrl: string | null };
+};
+
+type ReceivedRatingsListProps = {
+  ratings: ReceivedRating[];
+};
+
+const RATINGS_PREVIEW_COUNT = 3;
+
+export function ReceivedRatingsList({ ratings }: ReceivedRatingsListProps) {
+  const [showAll, setShowAll] = useState(false);
+
+  return (
+    <div className="mt-8 px-4 sm:px-6">
+      <h2
+        className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider"
+        style={{ color: "var(--text-muted)" }}
+      >
+        <Star className="h-3.5 w-3.5" style={{ fill: "#eab308", color: "#eab308" }} />
+        受け取った評価
+      </h2>
+      {ratings.length === 0 ? (
+        <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+          まだ評価がありません
+        </p>
+      ) : (
+        <>
+          <div className="space-y-3">
+            {(showAll ? ratings : ratings.slice(0, RATINGS_PREVIEW_COUNT)).map((rating) => (
+              <div
+                key={rating.id}
+                className="rounded-xl p-4"
+                style={{ backgroundColor: "var(--bg-input)", border: "1px solid var(--border)" }}
+              >
+                <div className="flex items-start gap-3">
+                  <UserAvatar
+                    username={rating.reviewer.username}
+                    iconUrl={rating.reviewer.iconUrl}
+                    size="sm"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="text-sm font-medium truncate"
+                        style={{ color: "var(--text-primary)" }}
+                      >
+                        {rating.reviewer.username ?? "退会済みユーザー"}
+                      </span>
+                      <span className="text-xs shrink-0" style={{ color: "var(--text-muted)" }}>
+                        {new Date(rating.createdAt).toLocaleDateString("ja-JP")}
+                      </span>
+                    </div>
+                    <div className="mt-1">
+                      <StarRating value={rating.score} readonly size="sm" />
+                    </div>
+                    {rating.comment && (
+                      <p
+                        className="mt-1.5 text-sm leading-relaxed"
+                        style={{ color: "var(--text-secondary)" }}
+                      >
+                        {rating.comment}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+          {ratings.length > RATINGS_PREVIEW_COUNT && (
+            <button
+              type="button"
+              onClick={() => setShowAll((prev) => !prev)}
+              className="mt-3 w-full rounded-xl py-2.5 text-sm font-medium transition-colors hover:opacity-80"
+              style={{
+                backgroundColor: "var(--bg-input)",
+                border: "1px solid var(--border)",
+                color: "var(--accent-light)",
+              }}
+            >
+              {showAll ? "折りたたむ" : `すべて見る（${ratings.length}件）`}
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

`app/users/me/page.tsx`（297行）と `app/users/[userId]/page.tsx`（209行）で約130行にわたり重複していたヒーローバナー・プロフィール情報・統計・ゲームリストのJSXを、共通コンポーネント群に切り出して解消する。

## 変更内容

### 新規コンポーネント（`components/users/`）

| ファイル | 役割 |
|---------|------|
| `ProfileHero.tsx` | ヒーローバナー（ゲームカバー背景 + アバターオーバーフロー）+ `actions` スロット |
| `ProfileInfo.tsx` | ユーザー名・RatingDisplay・PlayStyleTags・bio（`bioFallback` prop で空状態テキストを制御） |
| `ProfileStats.tsx` | 平均評価 / 評価件数の統計行（仕切り線付き） |
| `GameScrollList.tsx` | 横スクロールのゲームカバーリスト（フォールバック付き） |
| `ReceivedRatingsList.tsx` | 受け取り評価リスト（「すべて見る」折りたたみUI）※ me/page のみ利用 |

### 既存ページの変更

- `app/users/me/page.tsx`: 297行 → 100行
- `app/users/[userId]/page.tsx`: 209行 → 84行

### テスト追加

ProfileInfo / ProfileStats / GameScrollList / ReceivedRatingsList に Vitest + Testing Library による単体テストを追加（計24件）。

## AC チェック

- [x] 上記5コンポーネントが `components/users/` に named export されている
- [x] `users/me/page.tsx` と `users/[userId]/page.tsx` からヒーロー・Stats・ゲームリストの重複JSXが削除されている
- [x] `ProfileHero` の `actions` スロットで、me ページは編集/履歴ボタン、[userId] ページは戻るリンクが表示される
- [x] `pnpm lint` エラーなし

Closes #115