### PR TITLE
feat: GameCoverImage共通コンポーネントの作成 (#113)

### DIFF
--- a/app/HomeGameGrid.tsx
+++ b/app/HomeGameGrid.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
-import { GameController } from "@phosphor-icons/react";
 import type { GameResult } from "@/lib/games";
+import { GameCoverImage } from "@/components/ui/GameCoverImage";
 
 type Props = {
   games: GameResult[];
@@ -12,16 +10,10 @@ type Props = {
 
 export function HomeGameGrid({ games }: Props) {
   const router = useRouter();
-  const [imgErrors, setImgErrors] = useState<Set<string>>(new Set());
-
-  const handleImgError = (gameId: string) => {
-    setImgErrors((prev) => new Set(prev).add(gameId));
-  };
 
   return (
     <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-6">
       {games.map((game, index) => {
-        const hasError = imgErrors.has(game.id);
         return (
           <button
             key={game.id}
@@ -30,23 +22,11 @@ export function HomeGameGrid({ games }: Props) {
             style={{ animationDelay: `${Math.min(index, 11) * 50}ms` }}
           >
             <div className="relative aspect-[3/4] w-full overflow-hidden rounded-xl">
-              {!hasError && game.coverImageUrl ? (
-                <Image
-                  src={game.coverImageUrl}
-                  alt={game.name}
-                  fill
-                  className="object-cover transition-transform duration-300 group-hover:scale-105"
-                  sizes="(max-width: 640px) 33vw, (max-width: 768px) 25vw, 17vw"
-                  onError={() => handleImgError(game.id)}
-                />
-              ) : (
-                <div
-                  className="flex h-full w-full items-center justify-center"
-                  style={{ background: "var(--bg-card-hover)" }}
-                >
-                  <GameController className="h-8 w-8 opacity-40" style={{ color: "var(--accent)" }} />
-                </div>
-              )}
+              <GameCoverImage
+                coverImageUrl={game.coverImageUrl}
+                name={game.name}
+                className="transition-transform duration-300 group-hover:scale-105"
+              />
               <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/70 via-transparent p-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
                 <span className="text-xs font-semibold text-white">探す →</span>
               </div>

--- a/app/games/GamesGrid.tsx
+++ b/app/games/GamesGrid.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
-import { MagnifyingGlass, GameController } from "@phosphor-icons/react";
+import { MagnifyingGlass } from "@phosphor-icons/react";
 import type { GameResult } from "@/lib/games";
+import { GameCoverImage } from "@/components/ui/GameCoverImage";
 
 type Props = {
   games: GameResult[];
@@ -14,17 +14,12 @@ type Props = {
 export function GamesGrid({ games, roomCounts }: Props) {
   const router = useRouter();
   const [query, setQuery] = useState("");
-  const [imgErrors, setImgErrors] = useState<Set<string>>(new Set());
 
   const filteredGames = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return games;
     return games.filter((g) => g.name.toLowerCase().includes(q));
   }, [query, games]);
-
-  const handleImgError = (gameId: string) => {
-    setImgErrors((prev) => new Set(prev).add(gameId));
-  };
 
   return (
     <>
@@ -58,7 +53,6 @@ export function GamesGrid({ games, roomCounts }: Props) {
         <div className="grid grid-cols-3 gap-4 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
           {filteredGames.map((game, index) => {
             const roomCount = roomCounts[game.id] ?? 0;
-            const hasError = imgErrors.has(game.id);
 
             return (
               <button
@@ -69,23 +63,11 @@ export function GamesGrid({ games, roomCounts }: Props) {
               >
                 {/* Cover image */}
                 <div className="relative aspect-[3/4] w-full overflow-hidden rounded-xl">
-                  {!hasError && game.coverImageUrl ? (
-                    <Image
-                      src={game.coverImageUrl}
-                      alt={game.name}
-                      fill
-                      className="object-cover transition-transform duration-300 group-hover:scale-105"
-                      sizes="(max-width: 640px) 33vw, (max-width: 768px) 25vw, 20vw"
-                      onError={() => handleImgError(game.id)}
-                    />
-                  ) : (
-                    <div
-                      className="flex h-full w-full items-center justify-center"
-                      style={{ background: "var(--bg-card-hover)" }}
-                    >
-                      <GameController className="h-10 w-10 opacity-40" style={{ color: "var(--accent)" }} />
-                    </div>
-                  )}
+                  <GameCoverImage
+                    coverImageUrl={game.coverImageUrl}
+                    name={game.name}
+                    className="transition-transform duration-300 group-hover:scale-105"
+                  />
 
                   {/* Hover overlay */}
                   <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/70 via-transparent p-3 opacity-0 transition-opacity duration-200 group-hover:opacity-100">

--- a/components/ui/GameCoverImage.test.tsx
+++ b/components/ui/GameCoverImage.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GameCoverImage } from "./GameCoverImage";
+
+vi.mock("next/image", () => ({
+  default: ({
+    src,
+    alt,
+    onError,
+    className,
+  }: {
+    src: string;
+    alt: string;
+    onError?: () => void;
+    className?: string;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} onError={onError} className={className} />
+  ),
+}));
+
+describe("GameCoverImage", () => {
+  describe("固定サイズモード (size あり)", () => {
+    it("coverImageUrl が null の場合フォールバックコンテナを表示する", () => {
+      render(<GameCoverImage coverImageUrl={null} name="Apex Legends" size="md" />);
+      expect(screen.queryByRole("img")).toBeNull();
+    });
+
+    it("coverImageUrl がある場合に img を表示する", () => {
+      render(
+        <GameCoverImage
+          coverImageUrl="https://example.com/apex.jpg"
+          name="Apex Legends"
+          size="md"
+        />
+      );
+      expect(screen.getByRole("img", { name: "Apex Legends" })).toBeInTheDocument();
+    });
+
+    it("画像ロードエラー時にフォールバックコンテナを表示する", () => {
+      render(
+        <GameCoverImage
+          coverImageUrl="https://example.com/broken.jpg"
+          name="Broken Game"
+          size="sm"
+        />
+      );
+
+      const img = screen.getByRole("img", { name: "Broken Game" });
+      fireEvent.error(img);
+
+      expect(screen.queryByRole("img")).toBeNull();
+    });
+
+    it.each(["sm", "md", "lg"] as const)("size=%s が渡されたとき img が表示される", (size) => {
+      render(
+        <GameCoverImage
+          coverImageUrl="https://example.com/game.jpg"
+          name="Some Game"
+          size={size}
+        />
+      );
+      expect(screen.getByRole("img", { name: "Some Game" })).toBeInTheDocument();
+    });
+  });
+
+  describe("fill モード (size なし)", () => {
+    it("coverImageUrl が null の場合フォールバックコンテナを表示する", () => {
+      render(<GameCoverImage coverImageUrl={null} name="Apex Legends" />);
+      expect(screen.queryByRole("img")).toBeNull();
+    });
+
+    it("coverImageUrl がある場合に img を表示する", () => {
+      render(
+        <GameCoverImage
+          coverImageUrl="https://example.com/apex.jpg"
+          name="Apex Legends"
+        />
+      );
+      expect(screen.getByRole("img", { name: "Apex Legends" })).toBeInTheDocument();
+    });
+
+    it("画像ロードエラー時にフォールバックコンテナを表示する", () => {
+      render(
+        <GameCoverImage
+          coverImageUrl="https://example.com/broken.jpg"
+          name="Broken Game"
+        />
+      );
+
+      const img = screen.getByRole("img", { name: "Broken Game" });
+      fireEvent.error(img);
+
+      expect(screen.queryByRole("img")).toBeNull();
+    });
+
+    it("className が fill モードのラッパー div に適用される", () => {
+      const { container } = render(
+        <GameCoverImage
+          coverImageUrl={null}
+          name="Some Game"
+          className="custom-class"
+        />
+      );
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+  });
+});

--- a/components/ui/GameCoverImage.tsx
+++ b/components/ui/GameCoverImage.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { memo, useState } from "react";
+import Image from "next/image";
+import { GameController } from "@phosphor-icons/react";
+import clsx from "clsx";
+
+type GameCoverImageProps = {
+  coverImageUrl: string | null;
+  name: string;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+};
+
+const coverSizes = {
+  sm: "h-10 w-8",
+  md: "h-14 w-11",
+  lg: "h-24 w-18",
+};
+
+const iconSizes = {
+  sm: "h-4 w-4",
+  md: "h-5 w-5",
+  lg: "h-8 w-8",
+};
+
+/**
+ * ゲームカバー画像コンポーネント。
+ *
+ * - `size` を指定するとその固定サイズで表示（GamePicker 内など）
+ * - `size` を省略すると親の relative コンテナを埋める absolute モードになる
+ *   （GamesGrid / HomeGameGrid のグリッドセル内で使用）
+ * - `coverImageUrl` が null または画像ロードに失敗した場合は GameController アイコンをフォールバック表示
+ */
+export const GameCoverImage = memo(function GameCoverImage({
+  coverImageUrl,
+  name,
+  size,
+  className,
+}: GameCoverImageProps) {
+  const [error, setError] = useState(false);
+
+  if (size) {
+    const sizeClass = coverSizes[size];
+
+    if (!coverImageUrl || error) {
+      return (
+        <div
+          className={clsx(
+            "flex shrink-0 items-center justify-center rounded-md",
+            sizeClass,
+            className
+          )}
+          style={{
+            backgroundColor: "rgba(124,58,237,0.15)",
+            border: "1px solid rgba(124,58,237,0.2)",
+          }}
+          title={name}
+        >
+          <GameController className={iconSizes[size]} style={{ color: "var(--accent-light)" }} />
+        </div>
+      );
+    }
+
+    return (
+      <div className={clsx("relative shrink-0 overflow-hidden rounded-md", sizeClass, className)}>
+        <Image
+          src={coverImageUrl}
+          alt={name}
+          fill
+          className="object-cover"
+          sizes="64px"
+          onError={() => setError(true)}
+        />
+      </div>
+    );
+  }
+
+  // fill モード: 親の relative コンテナを absolute inset-0 で埋める
+  return (
+    <div className={clsx("absolute inset-0", className)}>
+      {!coverImageUrl || error ? (
+        <div
+          className="flex h-full w-full items-center justify-center"
+          style={{ background: "var(--bg-card-hover)" }}
+        >
+          <GameController className="h-8 w-8 opacity-40" style={{ color: "var(--accent)" }} />
+        </div>
+      ) : (
+        <Image
+          src={coverImageUrl}
+          alt={name}
+          fill
+          className="object-cover"
+          sizes="(max-width: 640px) 33vw, (max-width: 768px) 25vw, 20vw"
+          onError={() => setError(true)}
+        />
+      )}
+    </div>
+  );
+});

--- a/components/ui/GamePicker.tsx
+++ b/components/ui/GamePicker.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { MagnifyingGlass, X, GameController, Check, CaretDown } from "@phosphor-icons/react";
 import { type Game } from "@/lib/mock-data";
 import clsx from "clsx";
+import { GameCoverImage } from "@/components/ui/GameCoverImage";
 
 // ─── ゲームカバー画像 ─────────────────────────────────────────────────────────
 
@@ -14,43 +15,14 @@ type GameCoverProps = {
   className?: string;
 };
 
-const coverSizes = {
-  sm: "h-10 w-8",
-  md: "h-14 w-11",
-  lg: "h-24 w-18",
-};
-
 export const GameCover = memo(function GameCover({ game, size = "md", className }: GameCoverProps) {
-  const [error, setError] = useState(false);
-  const sizeClass = coverSizes[size];
-
-  if (!game.coverImageUrl || error) {
-    return (
-      <div
-        className={clsx(
-          "flex shrink-0 items-center justify-center rounded-md",
-          sizeClass,
-          className
-        )}
-        style={{ backgroundColor: "rgba(124,58,237,0.15)", border: "1px solid rgba(124,58,237,0.2)" }}
-        title={game.name}
-      >
-        <GameController className="h-4 w-4" style={{ color: "var(--accent-light)" }} />
-      </div>
-    );
-  }
-
   return (
-    <div className={clsx("relative shrink-0 overflow-hidden rounded-md", sizeClass, className)}>
-      <Image
-        src={game.coverImageUrl}
-        alt={game.name}
-        fill
-        className="object-cover"
-        sizes="64px"
-        onError={() => setError(true)}
-      />
-    </div>
+    <GameCoverImage
+      coverImageUrl={game.coverImageUrl}
+      name={game.name}
+      size={size}
+      className={className}
+    />
   );
 });
 


### PR DESCRIPTION
## 概要

`HomeGameGrid.tsx`・`GamesGrid.tsx`・`GamePicker.tsx` の3箇所で重複していたゲームカバー画像実装（`next/image` + `GameController` フォールバック）を、共通の `GameCoverImage` コンポーネントに切り出しました。

## 変更内容

- **`components/ui/GameCoverImage.tsx`（新規）**: `coverImageUrl`・`name`・`size?`・`className?` を Props とする共通コンポーネント
  - `size` あり → 固定サイズコンテナ（GamePicker 内など）
  - `size` なし → 親の `relative` コンテナを `absolute inset-0` で埋める fill モード（グリッド用）
  - `coverImageUrl` が null または画像ロードエラー時に `GameController` アイコンをフォールバック表示
- **`components/ui/GamePicker.tsx`**: `GameCover` の内部実装を `GameCoverImage` に委譲（Props 型・エクスポートは維持）
- **`app/games/GamesGrid.tsx`**: `imgErrors` の `useState` を削除し `GameCoverImage` を使用
- **`app/HomeGameGrid.tsx`**: 同上
- **`components/ui/GameCoverImage.test.tsx`（新規）**: 固定サイズ・fill モードそれぞれの null・エラー・正常表示を網羅（10ケース）

## AC チェック

- [x] `GameCoverImage` が `components/ui/GameCoverImage.tsx` として named export されている
- [x] `coverImageUrl` が null または空の場合、`GameController` アイコンがフォールバックとして表示される
- [x] `GamesGrid.tsx`・`HomeGameGrid.tsx` から `imgErrors` の `useState` が削除されている
- [x] `GameCover`（`GamePicker.tsx` からの既存エクスポート）の Props 型・動作が変わっていない
- [x] `pnpm lint` がエラーなしで通る

Closes #113