### PR TITLE
refactor: Onboardingステップのコンポーネント分割

### DIFF
--- a/app/(onboarding)/onboarding/OnboardingNavButtons.test.tsx
+++ b/app/(onboarding)/onboarding/OnboardingNavButtons.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@phosphor-icons/react", () => ({
+  ArrowLeft: () => <span data-testid="icon-arrow-left" />,
+  CaretRight: () => <span data-testid="icon-caret-right" />,
+}));
+
+import { OnboardingNavButtons } from "./OnboardingNavButtons";
+
+describe("OnboardingNavButtons", () => {
+  it("onBack が未指定の場合 Back ボタンを表示しない", () => {
+    render(<OnboardingNavButtons primaryLabel="次へ" onPrimary={vi.fn()} />);
+    expect(screen.queryByText("戻る")).not.toBeInTheDocument();
+  });
+
+  it("onBack が指定された場合 Back ボタンを表示する", () => {
+    render(
+      <OnboardingNavButtons primaryLabel="次へ" onPrimary={vi.fn()} onBack={vi.fn()} />
+    );
+    expect(screen.getByText("戻る")).toBeInTheDocument();
+  });
+
+  it("primaryWidth='full' のとき Primary ボタンに w-full クラスが付く", () => {
+    render(
+      <OnboardingNavButtons primaryLabel="次へ" onPrimary={vi.fn()} primaryWidth="full" />
+    );
+    const btn = screen.getByRole("button", { name: /次へ/ });
+    expect(btn.className).toContain("w-full");
+  });
+
+  it("primaryDisabled={true} のとき Primary ボタンが disabled になる", () => {
+    render(
+      <OnboardingNavButtons primaryLabel="次へ" onPrimary={vi.fn()} primaryDisabled />
+    );
+    expect(screen.getByRole("button", { name: /次へ/ })).toBeDisabled();
+  });
+
+  it("showPrimaryIcon={false} のとき CaretRight アイコンを表示しない", () => {
+    render(
+      <OnboardingNavButtons primaryLabel="はじめる" onPrimary={vi.fn()} showPrimaryIcon={false} />
+    );
+    expect(screen.queryByTestId("icon-caret-right")).not.toBeInTheDocument();
+  });
+
+  it("デフォルトで CaretRight アイコンを表示する", () => {
+    render(<OnboardingNavButtons primaryLabel="次へ" onPrimary={vi.fn()} />);
+    expect(screen.getByTestId("icon-caret-right")).toBeInTheDocument();
+  });
+});

--- a/app/(onboarding)/onboarding/OnboardingNavButtons.tsx
+++ b/app/(onboarding)/onboarding/OnboardingNavButtons.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { ArrowLeft, CaretRight } from "@phosphor-icons/react";
+import clsx from "clsx";
+
+interface OnboardingNavButtonsProps {
+  primaryLabel: string;
+  primaryType?: "button" | "submit";
+  onPrimary?: () => void;
+  primaryDisabled?: boolean;
+  showPrimaryIcon?: boolean;
+  /** undefined の場合 Back ボタン非表示 */
+  onBack?: () => void;
+  /**
+   * "full"  → w-full py-3.5（StepWelcome: Back なし・全幅）
+   * "flex1" → flex-1 py-3  （Steps 2〜5: Back と横並び）
+   */
+  primaryWidth?: "full" | "flex1";
+}
+
+export function OnboardingNavButtons({
+  primaryLabel,
+  primaryType = "button",
+  onPrimary,
+  primaryDisabled = false,
+  showPrimaryIcon = true,
+  onBack,
+  primaryWidth = "flex1",
+}: OnboardingNavButtonsProps) {
+  return (
+    <div className="flex items-center gap-3">
+      {onBack && (
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex flex-1 items-center justify-center gap-1 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
+          style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
+        >
+          <ArrowLeft className="h-4 w-4" />
+          戻る
+        </button>
+      )}
+      <button
+        type={primaryType}
+        onClick={onPrimary}
+        disabled={primaryDisabled}
+        className={clsx(
+          "flex items-center justify-center rounded-xl px-6 text-sm font-semibold text-white transition-all hover:opacity-90 disabled:opacity-50",
+          showPrimaryIcon && "gap-2",
+          primaryWidth === "full" ? "w-full py-3.5" : "flex-1 py-3",
+        )}
+        style={{
+          background: "linear-gradient(135deg, var(--accent), #6d28d9)",
+          boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
+        }}
+      >
+        {primaryLabel}
+        {showPrimaryIcon && <CaretRight className="h-4 w-4" />}
+      </button>
+    </div>
+  );
+}

--- a/app/(onboarding)/onboarding/OnboardingProgressDots.tsx
+++ b/app/(onboarding)/onboarding/OnboardingProgressDots.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+interface OnboardingProgressDotsProps {
+  currentStep: number;
+  totalSteps: number;
+}
+
+export function OnboardingProgressDots({ currentStep, totalSteps }: OnboardingProgressDotsProps) {
+  return (
+    <div className={`mb-8 flex items-center justify-center gap-2 ${currentStep === 1 ? "invisible" : ""}`}>
+      {Array.from({ length: totalSteps - 1 }, (_, i) => {
+        const step = i + 2;
+        const isCompleted = step < currentStep;
+        const isCurrent = step === currentStep;
+        return (
+          <div
+            key={step}
+            className="h-1.5 w-1.5 rounded-full transition-all"
+            style={
+              isCompleted
+                ? { backgroundColor: "var(--accent)" }
+                : isCurrent
+                  ? { backgroundColor: "var(--accent-light)", transform: "scale(1.4)" }
+                  : { backgroundColor: "var(--border)" }
+            }
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(onboarding)/onboarding/StepAvatar.tsx
+++ b/app/(onboarding)/onboarding/StepAvatar.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useRef } from "react";
+import { ArrowLeft, CaretRight, Camera } from "@phosphor-icons/react";
+import { UserAvatar } from "@/components/ui/UserAvatar";
+
+interface StepAvatarProps {
+  username: string;
+  avatarPreview: string | null;
+  onFileChange: (file: File) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+export function StepAvatar({ username, avatarPreview, onFileChange, onNext, onBack }: StepAvatarProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="animate-fade-in-up flex flex-col min-h-[38rem] space-y-10">
+      <div className="space-y-8">
+        <div>
+          <h1 className="mb-1 text-2xl sm:text-3xl font-bold" style={{ color: "var(--text-primary)" }}>
+            プロフィール画像を設定
+          </h1>
+          <p className="mt-2 text-sm" style={{ color: "var(--text-secondary)" }}>
+            アイコン画像を設定してください。後から変更できます。
+          </p>
+        </div>
+
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="group relative flex-shrink-0"
+            aria-label="アイコン画像を選択"
+          >
+            <UserAvatar username={username || "?"} iconUrl={avatarPreview} size="xl" />
+            <div className="absolute inset-0 rounded-full bg-black/50 opacity-0 transition-opacity group-hover:opacity-100" />
+            <div className="absolute bottom-0 right-0 flex h-6 w-6 items-center justify-center rounded-full bg-black/80">
+              <Camera className="h-3.5 w-3.5 text-white" />
+            </div>
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp,image/gif"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) onFileChange(f);
+            }}
+            className="hidden"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex flex-1 items-center justify-center gap-1 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
+          style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
+        >
+          <ArrowLeft className="h-4 w-4" />
+          戻る
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          className="flex flex-1 items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90"
+          style={{
+            background: "linear-gradient(135deg, var(--accent), #6d28d9)",
+            boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
+          }}
+        >
+          次へ
+          <CaretRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/(onboarding)/onboarding/StepAvatar.tsx
+++ b/app/(onboarding)/onboarding/StepAvatar.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useRef } from "react";
-import { ArrowLeft, CaretRight, Camera } from "@phosphor-icons/react";
+import { Camera } from "@phosphor-icons/react";
 import { UserAvatar } from "@/components/ui/UserAvatar";
+import { OnboardingNavButtons } from "./OnboardingNavButtons";
 
 interface StepAvatarProps {
   username: string;
@@ -53,29 +54,11 @@ export function StepAvatar({ username, avatarPreview, onFileChange, onNext, onBa
         </div>
       </div>
 
-      <div className="flex items-center gap-3">
-        <button
-          type="button"
-          onClick={onBack}
-          className="flex flex-1 items-center justify-center gap-1 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
-          style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
-        >
-          <ArrowLeft className="h-4 w-4" />
-          戻る
-        </button>
-        <button
-          type="button"
-          onClick={onNext}
-          className="flex flex-1 items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90"
-          style={{
-            background: "linear-gradient(135deg, var(--accent), #6d28d9)",
-            boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
-          }}
-        >
-          次へ
-          <CaretRight className="h-4 w-4" />
-        </button>
-      </div>
+      <OnboardingNavButtons
+        primaryLabel="次へ"
+        onPrimary={onNext}
+        onBack={onBack}
+      />
     </div>
   );
 }

--- a/app/(onboarding)/onboarding/StepBio.tsx
+++ b/app/(onboarding)/onboarding/StepBio.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeft, CaretRight } from "@phosphor-icons/react";
+import { OnboardingNavButtons } from "./OnboardingNavButtons";
 
 interface StepBioProps {
   bio: string;
@@ -53,31 +53,11 @@ export function StepBio({ bio, onBioChange, onNext, onBack }: StepBioProps) {
         </div>
       </div>
 
-      <div className="space-y-3">
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={onBack}
-            className="flex flex-1 items-center justify-center gap-1 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
-            style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
-          >
-            <ArrowLeft className="h-4 w-4" />
-            戻る
-          </button>
-          <button
-            type="button"
-            onClick={onNext}
-            className="flex flex-1 items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90"
-            style={{
-              background: "linear-gradient(135deg, var(--accent), #6d28d9)",
-              boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
-            }}
-          >
-            次へ
-            <CaretRight className="h-4 w-4" />
-          </button>
-        </div>
-      </div>
+      <OnboardingNavButtons
+        primaryLabel="次へ"
+        onPrimary={onNext}
+        onBack={onBack}
+      />
     </div>
   );
 }

--- a/app/(onboarding)/onboarding/StepBio.tsx
+++ b/app/(onboarding)/onboarding/StepBio.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { ArrowLeft, CaretRight } from "@phosphor-icons/react";
+
+interface StepBioProps {
+  bio: string;
+  onBioChange: (value: string) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const inputStyle = {
+  backgroundColor: "var(--bg-input)",
+  borderColor: "var(--border)",
+  color: "var(--text-primary)",
+};
+
+export function StepBio({ bio, onBioChange, onNext, onBack }: StepBioProps) {
+  return (
+    <div className="animate-fade-in-up flex flex-col min-h-[38rem] space-y-10">
+      <div className="space-y-8">
+        <div>
+          <h1 className="mb-1 text-2xl sm:text-3xl font-bold" style={{ color: "var(--text-primary)" }}>
+            自己紹介を書きましょう
+          </h1>
+          <p className="mt-2 text-sm" style={{ color: "var(--text-secondary)" }}>
+            プレイスタイルや得意ジャンルを伝えると、仲間が見つかりやすくなります。
+          </p>
+        </div>
+
+        <div>
+          <label
+            className="mb-1.5 block text-sm font-medium"
+            style={{ color: "var(--text-primary)" }}
+          >
+            自己紹介{" "}
+            <span className="text-xs font-normal" style={{ color: "var(--text-muted)" }}>
+              （任意・500文字以内）
+            </span>
+          </label>
+          <textarea
+            rows={4}
+            placeholder="プレイスタイルや得意なゲームについて教えてください..."
+            value={bio}
+            onChange={(e) => onBioChange(e.target.value)}
+            maxLength={500}
+            className="w-full resize-none rounded-xl border px-4 py-2.5 text-sm outline-none focus:border-[var(--accent)] transition-colors"
+            style={inputStyle}
+          />
+          <p className="mt-1 text-right text-xs" style={{ color: "var(--text-muted)" }}>
+            {bio.length}/500
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={onBack}
+            className="flex flex-1 items-center justify-center gap-1 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
+            style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
+          >
+            <ArrowLeft className="h-4 w-4" />
+            戻る
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            className="flex flex-1 items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90"
+            style={{
+              background: "linear-gradient(135deg, var(--accent), #6d28d9)",
+              boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
+            }}
+          >
+            次へ
+            <CaretRight className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(onboarding)/onboarding/StepGames.tsx
+++ b/app/(onboarding)/onboarding/StepGames.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { ArrowLeft } from "@phosphor-icons/react";
+import { type Game } from "@/lib/mock-data";
+import { GridGamePicker } from "@/components/ui/GamePicker";
+
+interface StepGamesProps {
+  selectedGames: Game[];
+  onGamesChange: (games: Game[]) => void;
+  onBack: () => void;
+  onSubmit: () => void;
+  saving: boolean;
+  error: string | null;
+  status: "loading" | "authenticated" | "unauthenticated";
+}
+
+export function StepGames({
+  selectedGames,
+  onGamesChange,
+  onBack,
+  onSubmit,
+  saving,
+  error,
+  status,
+}: StepGamesProps) {
+  return (
+    <div className="animate-fade-in-up flex flex-col justify-between min-h-[38rem]">
+      <div className="space-y-8">
+        <div>
+          <h1 className="mb-1 text-2xl sm:text-3xl font-bold" style={{ color: "var(--text-primary)" }}>
+            プレイしているゲームを登録
+          </h1>
+          <p className="mt-2 text-sm" style={{ color: "var(--text-secondary)" }}>
+            プレイするゲームを登録すると、ゲーム仲間が見つかりやすくなります。
+          </p>
+        </div>
+
+        <GridGamePicker value={selectedGames} onChange={onGamesChange} max={20} />
+
+        {error && (
+          <p className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-400">
+            {error}
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex flex-1 items-center justify-center gap-1 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
+          style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
+        >
+          <ArrowLeft className="h-4 w-4" />
+          戻る
+        </button>
+        <button
+          type="button"
+          disabled={status === "loading" || saving}
+          onClick={onSubmit}
+          className="flex flex-1 items-center justify-center rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90 disabled:opacity-50"
+          style={{
+            background: "linear-gradient(135deg, var(--accent), #6d28d9)",
+            boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
+          }}
+        >
+          {saving ? "設定中..." : "はじめる"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/(onboarding)/onboarding/StepGames.tsx
+++ b/app/(onboarding)/onboarding/StepGames.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { ArrowLeft } from "@phosphor-icons/react";
 import { type Game } from "@/lib/mock-data";
 import { GridGamePicker } from "@/components/ui/GamePicker";
+import { OnboardingNavButtons } from "./OnboardingNavButtons";
 
 interface StepGamesProps {
   selectedGames: Game[];
@@ -44,29 +44,13 @@ export function StepGames({
         )}
       </div>
 
-      <div className="flex items-center gap-3">
-        <button
-          type="button"
-          onClick={onBack}
-          className="flex flex-1 items-center justify-center gap-1 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
-          style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
-        >
-          <ArrowLeft className="h-4 w-4" />
-          戻る
-        </button>
-        <button
-          type="button"
-          disabled={status === "loading" || saving}
-          onClick={onSubmit}
-          className="flex flex-1 items-center justify-center rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90 disabled:opacity-50"
-          style={{
-            background: "linear-gradient(135deg, var(--accent), #6d28d9)",
-            boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
-          }}
-        >
-          {saving ? "設定中..." : "はじめる"}
-        </button>
-      </div>
+      <OnboardingNavButtons
+        primaryLabel={saving ? "設定中..." : "はじめる"}
+        onPrimary={onSubmit}
+        primaryDisabled={status === "loading" || saving}
+        showPrimaryIcon={false}
+        onBack={onBack}
+      />
     </div>
   );
 }

--- a/app/(onboarding)/onboarding/StepUsername.tsx
+++ b/app/(onboarding)/onboarding/StepUsername.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { ArrowLeft, CaretRight } from "@phosphor-icons/react";
+
+interface StepUsernameProps {
+  username: string;
+  onUsernameChange: (value: string) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const inputStyle = {
+  backgroundColor: "var(--bg-input)",
+  borderColor: "var(--border)",
+  color: "var(--text-primary)",
+};
+
+export function StepUsername({ username, onUsernameChange, onNext, onBack }: StepUsernameProps) {
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (username.trim()) onNext();
+      }}
+      className="animate-fade-in-up flex flex-col min-h-[38rem] space-y-10"
+    >
+      <div className="space-y-8">
+        <div>
+          <h1 className="mb-1 text-2xl sm:text-3xl font-bold" style={{ color: "var(--text-primary)" }}>
+            ユーザー名を決めましょう
+          </h1>
+          <p className="mt-2 text-sm" style={{ color: "var(--text-secondary)" }}>
+            あなたを表す名前を設定してください。後から変更できます。
+          </p>
+        </div>
+
+        <div>
+          <label
+            className="mb-1.5 block text-sm font-medium"
+            style={{ color: "var(--text-primary)" }}
+          >
+            ユーザー名 <span className="text-red-400">*</span>
+          </label>
+          <input
+            type="text"
+            required
+            maxLength={50}
+            value={username}
+            onChange={(e) => onUsernameChange(e.target.value)}
+            className="w-full rounded-xl border px-4 py-2.5 text-sm outline-none focus:border-[var(--accent)] transition-colors"
+            style={inputStyle}
+          />
+          <p className="mt-1 text-xs" style={{ color: "var(--text-muted)" }}>
+            ユーザー名は後からいつでも変更できます
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex flex-1 items-center justify-center gap-1 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
+          style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
+        >
+          <ArrowLeft className="h-4 w-4" />
+          戻る
+        </button>
+        <button
+          type="submit"
+          disabled={username.trim() === ""}
+          className="flex flex-1 items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90 disabled:opacity-50"
+          style={{
+            background: "linear-gradient(135deg, var(--accent), #6d28d9)",
+            boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
+          }}
+        >
+          次へ
+          <CaretRight className="h-4 w-4" />
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/(onboarding)/onboarding/StepUsername.tsx
+++ b/app/(onboarding)/onboarding/StepUsername.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeft, CaretRight } from "@phosphor-icons/react";
+import { OnboardingNavButtons } from "./OnboardingNavButtons";
 
 interface StepUsernameProps {
   username: string;
@@ -56,29 +56,12 @@ export function StepUsername({ username, onUsernameChange, onNext, onBack }: Ste
         </div>
       </div>
 
-      <div className="flex items-center gap-3">
-        <button
-          type="button"
-          onClick={onBack}
-          className="flex flex-1 items-center justify-center gap-1 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
-          style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
-        >
-          <ArrowLeft className="h-4 w-4" />
-          戻る
-        </button>
-        <button
-          type="submit"
-          disabled={username.trim() === ""}
-          className="flex flex-1 items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90 disabled:opacity-50"
-          style={{
-            background: "linear-gradient(135deg, var(--accent), #6d28d9)",
-            boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
-          }}
-        >
-          次へ
-          <CaretRight className="h-4 w-4" />
-        </button>
-      </div>
+      <OnboardingNavButtons
+        primaryLabel="次へ"
+        primaryType="submit"
+        primaryDisabled={username.trim() === ""}
+        onBack={onBack}
+      />
     </form>
   );
 }

--- a/app/(onboarding)/onboarding/StepWelcome.tsx
+++ b/app/(onboarding)/onboarding/StepWelcome.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Check, CaretRight } from "@phosphor-icons/react";
+import { Check } from "@phosphor-icons/react";
+import { OnboardingNavButtons } from "./OnboardingNavButtons";
 
 interface StepWelcomeProps {
   onNext: () => void;
@@ -45,18 +46,11 @@ export function StepWelcome({ onNext }: StepWelcomeProps) {
         </ul>
       </div>
 
-      <button
-        type="button"
-        onClick={onNext}
-        className="flex w-full items-center justify-center gap-2 rounded-xl px-6 py-3.5 text-sm font-semibold text-white transition-all hover:opacity-90"
-        style={{
-          background: "linear-gradient(135deg, var(--accent), #6d28d9)",
-          boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
-        }}
-      >
-        次へ
-        <CaretRight className="h-4 w-4" />
-      </button>
+      <OnboardingNavButtons
+        primaryLabel="次へ"
+        onPrimary={onNext}
+        primaryWidth="full"
+      />
     </div>
   );
 }

--- a/app/(onboarding)/onboarding/StepWelcome.tsx
+++ b/app/(onboarding)/onboarding/StepWelcome.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Check, CaretRight } from "@phosphor-icons/react";
+
+interface StepWelcomeProps {
+  onNext: () => void;
+}
+
+const valueProps = [
+  "プレイしているゲームで相性の良い仲間を探せる",
+  "評価システムで安心して知らない人と組める",
+  "部屋作成・参加は30秒でできる",
+];
+
+export function StepWelcome({ onNext }: StepWelcomeProps) {
+  return (
+    <div className="animate-fade-in-up flex flex-col min-h-[38rem] space-y-12">
+      <div className="space-y-10">
+        <div>
+          <h1
+            className="mb-3 text-3xl font-bold leading-snug"
+            style={{ color: "var(--text-primary)" }}
+          >
+            今すぐ、ゲーム仲間と<br />繋がろう
+          </h1>
+          <p className="text-base" style={{ color: "var(--text-secondary)" }}>
+            知らない人と安心して組める、ゲーマー向けマッチングプラットフォーム。
+          </p>
+        </div>
+
+        <ul className="space-y-4">
+          {valueProps.map((prop) => (
+            <li key={prop} className="flex items-start gap-3">
+              <span
+                className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full"
+                style={{ backgroundColor: "rgba(124,58,237,0.25)" }}
+              >
+                <Check className="h-3 w-3" style={{ color: "var(--accent-light)" }} />
+              </span>
+              <span className="text-sm" style={{ color: "var(--text-secondary)" }}>
+                {prop}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <button
+        type="button"
+        onClick={onNext}
+        className="flex w-full items-center justify-center gap-2 rounded-xl px-6 py-3.5 text-sm font-semibold text-white transition-all hover:opacity-90"
+        style={{
+          background: "linear-gradient(135deg, var(--accent), #6d28d9)",
+          boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
+        }}
+      >
+        次へ
+        <CaretRight className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/app/(onboarding)/onboarding/page.tsx
+++ b/app/(onboarding)/onboarding/page.tsx
@@ -3,11 +3,15 @@
 import { useState, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { Check, ArrowLeft, CaretRight, Camera } from "@phosphor-icons/react";
-import { Logo } from "@/components/ui/Logo";
 import { type Game } from "@/lib/mock-data";
-import { UserAvatar } from "@/components/ui/UserAvatar";
-import { GridGamePicker } from "@/components/ui/GamePicker";
+import { Logo } from "@/components/ui/Logo";
+import { OnboardingProgressDots } from "./OnboardingProgressDots";
+import { StepWelcome } from "./StepWelcome";
+import { StepUsername } from "./StepUsername";
+import { StepBio } from "./StepBio";
+import { StepAvatar } from "./StepAvatar";
+import { StepGames } from "./StepGames";
+import { useOnboardingSubmit } from "./useOnboardingSubmit";
 
 const TOTAL_STEPS = 5;
 
@@ -15,25 +19,15 @@ export default function OnboardingPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get("callbackUrl");
-  const { data: session, update, status } = useSession();
-
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { data: session, status } = useSession();
 
   const [currentStep, setCurrentStep] = useState(1);
   const [username, setUsername] = useState("");
-  const [avatarFile, setAvatarFile] = useState<File | null>(null);
-  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const [bio, setBio] = useState("");
   const [selectedGames, setSelectedGames] = useState<Game[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
-
-  useEffect(() => {
-    if (!avatarFile) return;
-    const url = URL.createObjectURL(avatarFile);
-    setAvatarPreview(url);
-    return () => URL.revokeObjectURL(url);
-  }, [avatarFile]);
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const avatarPreviewUrlRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (status === "authenticated" && !session?.user?.needsProfileSetup) {
@@ -41,62 +35,29 @@ export default function OnboardingPage() {
     }
   }, [status, session, router]);
 
-  const handleSubmit = async () => {
-    setSaving(true);
-    setError(null);
+  // アンマウント時に Object URL を解放
+  useEffect(() => {
+    const ref = avatarPreviewUrlRef;
+    return () => {
+      if (ref.current) URL.revokeObjectURL(ref.current);
+    };
+  }, []);
 
-    try {
-      if (avatarFile) {
-        const formData = new FormData();
-        formData.append("file", avatarFile);
-        const uploadRes = await fetch("/api/v1/users/me/avatar", {
-          method: "POST",
-          body: formData,
-        });
-        if (!uploadRes.ok) {
-          setError("画像のアップロードに失敗しました");
-          return;
-        }
-      }
-
-      const res = await fetch("/api/v1/users/me", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          username: username.trim(),
-          bio: bio || null,
-          gameIds: selectedGames.map((g) => g.id),
-        }),
-      });
-
-      const json = (await res.json()) as { error?: string };
-
-      if (!res.ok) {
-        setError(json.error ?? "エラーが発生しました");
-        return;
-      }
-
-      await update({ username: username.trim() });
-      const dest = callbackUrl?.startsWith("/") ? callbackUrl : "/rooms";
-      router.push(dest);
-    } catch {
-      setError("通信エラーが発生しました。再度お試しください");
-    } finally {
-      setSaving(false);
-    }
+  const handleAvatarFileChange = (file: File) => {
+    if (avatarPreviewUrlRef.current) URL.revokeObjectURL(avatarPreviewUrlRef.current);
+    const url = URL.createObjectURL(file);
+    avatarPreviewUrlRef.current = url;
+    setAvatarPreview(url);
+    setAvatarFile(file);
   };
 
-  const inputStyle = {
-    backgroundColor: "var(--bg-input)",
-    borderColor: "var(--border)",
-    color: "var(--text-primary)",
-  };
-
-  const valueProps = [
-    "プレイしているゲームで相性の良い仲間を探せる",
-    "評価システムで安心して知らない人と組める",
-    "部屋作成・参加は30秒でできる",
-  ];
+  const { handleSubmit, saving, error } = useOnboardingSubmit({
+    avatarFile,
+    username,
+    bio,
+    selectedGames,
+    callbackUrl,
+  });
 
   return (
     <div
@@ -104,325 +65,47 @@ export default function OnboardingPage() {
       style={{ backgroundColor: "var(--bg-base)" }}
     >
       <div className="w-full max-w-md">
-
-        {/* Logo — 常に表示 */}
         <div className="mb-10 flex justify-center">
           <Logo height={64} />
         </div>
-
-        {/* Progress dots — 常にレンダリング（step 1 は invisible で高さ確保） */}
-        <div className={`mb-8 flex items-center justify-center gap-2 ${currentStep === 1 ? "invisible" : ""}`}>
-          {Array.from({ length: TOTAL_STEPS - 1 }, (_, i) => {
-            const step = i + 2;
-            const isCompleted = step < currentStep;
-            const isCurrent = step === currentStep;
-            return (
-              <div
-                key={step}
-                className="h-1.5 w-1.5 rounded-full transition-all"
-                style={
-                  isCompleted
-                    ? { backgroundColor: "var(--accent)" }
-                    : isCurrent
-                      ? { backgroundColor: "var(--accent-light)", transform: "scale(1.4)" }
-                      : { backgroundColor: "var(--border)" }
-                }
-              />
-            );
-          })}
-        </div>
-
-        {/* Step 1: ウェルカム */}
-        {currentStep === 1 && (
-          <div className="animate-fade-in-up flex flex-col min-h-[38rem] space-y-12">
-            <div className="space-y-10">
-              <div>
-                <h1
-                  className="mb-3 text-3xl font-bold leading-snug"
-                  style={{ color: "var(--text-primary)" }}
-                >
-                  今すぐ、ゲーム仲間と<br />繋がろう
-                </h1>
-                <p className="text-base" style={{ color: "var(--text-secondary)" }}>
-                  知らない人と安心して組める、ゲーマー向けマッチングプラットフォーム。
-                </p>
-              </div>
-
-              <ul className="space-y-4">
-                {valueProps.map((prop) => (
-                  <li key={prop} className="flex items-start gap-3">
-                    <span
-                      className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full"
-                      style={{ backgroundColor: "rgba(124,58,237,0.25)" }}
-                    >
-                      <Check className="h-3 w-3" style={{ color: "var(--accent-light)" }} />
-                    </span>
-                    <span className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                      {prop}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            <button
-              type="button"
-              onClick={() => setCurrentStep(2)}
-              className="flex w-full items-center justify-center gap-2 rounded-xl px-6 py-3.5 text-sm font-semibold text-white transition-all hover:opacity-90"
-              style={{
-                background: "linear-gradient(135deg, var(--accent), #6d28d9)",
-                boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
-              }}
-            >
-              次へ
-              <CaretRight className="h-4 w-4" />
-            </button>
-          </div>
-        )}
-
-        {/* Step 2: ユーザー名 */}
+        <OnboardingProgressDots currentStep={currentStep} totalSteps={TOTAL_STEPS} />
+        {currentStep === 1 && <StepWelcome onNext={() => setCurrentStep(2)} />}
         {currentStep === 2 && (
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              if (username.trim()) setCurrentStep(3);
-            }}
-            className="animate-fade-in-up flex flex-col min-h-[38rem] space-y-10"
-          >
-            <div className="space-y-8">
-              <div>
-                <h1 className="mb-1 text-2xl sm:text-3xl font-bold" style={{ color: "var(--text-primary)" }}>
-                  ユーザー名を決めましょう
-                </h1>
-                <p className="mt-2 text-sm" style={{ color: "var(--text-secondary)" }}>
-                  あなたを表す名前を設定してください。後から変更できます。
-                </p>
-              </div>
-
-              <div>
-                <label
-                  className="mb-1.5 block text-sm font-medium"
-                  style={{ color: "var(--text-primary)" }}
-                >
-                  ユーザー名 <span className="text-red-400">*</span>
-                </label>
-                <input
-                  type="text"
-                  required
-                  maxLength={50}
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  className="w-full rounded-xl border px-4 py-2.5 text-sm outline-none focus:border-[var(--accent)] transition-colors"
-                  style={inputStyle}
-                />
-                <p className="mt-1 text-xs" style={{ color: "var(--text-muted)" }}>
-                  ユーザー名は後からいつでも変更できます
-                </p>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-3">
-              <button
-                type="button"
-                onClick={() => setCurrentStep(1)}
-                className="flex flex-1 items-center justify-center gap-1 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
-                style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
-              >
-                <ArrowLeft className="h-4 w-4" />
-                戻る
-              </button>
-              <button
-                type="submit"
-                disabled={username.trim() === ""}
-                className="flex flex-1 items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90 disabled:opacity-50"
-                style={{
-                  background: "linear-gradient(135deg, var(--accent), #6d28d9)",
-                  boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
-                }}
-              >
-                次へ
-                <CaretRight className="h-4 w-4" />
-              </button>
-            </div>
-          </form>
+          <StepUsername
+            username={username}
+            onUsernameChange={setUsername}
+            onNext={() => setCurrentStep(3)}
+            onBack={() => setCurrentStep(1)}
+          />
         )}
-
-        {/* Step 3: 自己紹介 */}
         {currentStep === 3 && (
-          <div className="animate-fade-in-up flex flex-col min-h-[38rem] space-y-10">
-            <div className="space-y-8">
-              <div>
-                <h1 className="mb-1 text-2xl sm:text-3xl font-bold" style={{ color: "var(--text-primary)" }}>
-                  自己紹介を書きましょう
-                </h1>
-                <p className="mt-2 text-sm" style={{ color: "var(--text-secondary)" }}>
-                  プレイスタイルや得意ジャンルを伝えると、仲間が見つかりやすくなります。
-                </p>
-              </div>
-
-              <div>
-                <label
-                  className="mb-1.5 block text-sm font-medium"
-                  style={{ color: "var(--text-primary)" }}
-                >
-                  自己紹介{" "}
-                  <span className="text-xs font-normal" style={{ color: "var(--text-muted)" }}>
-                    （任意・500文字以内）
-                  </span>
-                </label>
-                <textarea
-                  rows={4}
-                  placeholder="プレイスタイルや得意なゲームについて教えてください..."
-                  value={bio}
-                  onChange={(e) => setBio(e.target.value)}
-                  maxLength={500}
-                  className="w-full resize-none rounded-xl border px-4 py-2.5 text-sm outline-none focus:border-[var(--accent)] transition-colors"
-                  style={inputStyle}
-                />
-                <p className="mt-1 text-right text-xs" style={{ color: "var(--text-muted)" }}>
-                  {bio.length}/500
-                </p>
-              </div>
-            </div>
-
-            <div className="space-y-3">
-              <div className="flex items-center gap-3">
-                <button
-                  type="button"
-                  onClick={() => setCurrentStep(2)}
-                  className="flex flex-1 items-center justify-center gap-1 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
-                  style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
-                >
-                  <ArrowLeft className="h-4 w-4" />
-                  戻る
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setCurrentStep(4)}
-                  className="flex flex-1 items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90"
-                  style={{
-                    background: "linear-gradient(135deg, var(--accent), #6d28d9)",
-                    boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
-                  }}
-                >
-                  次へ
-                  <CaretRight className="h-4 w-4" />
-                </button>
-              </div>
-            </div>
-          </div>
+          <StepBio
+            bio={bio}
+            onBioChange={setBio}
+            onNext={() => setCurrentStep(4)}
+            onBack={() => setCurrentStep(2)}
+          />
         )}
-
-        {/* Step 4: プロフィール画像 */}
         {currentStep === 4 && (
-          <div className="animate-fade-in-up flex flex-col min-h-[38rem] space-y-10">
-            <div className="space-y-8">
-              <div>
-                <h1 className="mb-1 text-2xl sm:text-3xl font-bold" style={{ color: "var(--text-primary)" }}>
-                  プロフィール画像を設定
-                </h1>
-                <p className="mt-2 text-sm" style={{ color: "var(--text-secondary)" }}>
-                  アイコン画像を設定してください。後から変更できます。
-                </p>
-              </div>
-
-              <div className="flex justify-center">
-                <button
-                  type="button"
-                  onClick={() => fileInputRef.current?.click()}
-                  className="group relative flex-shrink-0"
-                  aria-label="アイコン画像を選択"
-                >
-                  <UserAvatar username={username || "?"} iconUrl={avatarPreview} size="xl" />
-                  <div className="absolute inset-0 rounded-full bg-black/50 opacity-0 transition-opacity group-hover:opacity-100" />
-                  <div className="absolute bottom-0 right-0 flex h-6 w-6 items-center justify-center rounded-full bg-black/80">
-                    <Camera className="h-3.5 w-3.5 text-white" />
-                  </div>
-                </button>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="image/jpeg,image/png,image/webp,image/gif"
-                  onChange={(e) => { const f = e.target.files?.[0]; if (f) setAvatarFile(f); }}
-                  className="hidden"
-                />
-              </div>
-            </div>
-
-            <div className="flex items-center gap-3">
-              <button
-                type="button"
-                onClick={() => setCurrentStep(3)}
-                className="flex flex-1 items-center justify-center gap-1 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
-                style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
-              >
-                <ArrowLeft className="h-4 w-4" />
-                戻る
-              </button>
-              <button
-                type="button"
-                onClick={() => setCurrentStep(5)}
-                className="flex flex-1 items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90"
-                style={{
-                  background: "linear-gradient(135deg, var(--accent), #6d28d9)",
-                  boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
-                }}
-              >
-                次へ
-                <CaretRight className="h-4 w-4" />
-              </button>
-            </div>
-          </div>
+          <StepAvatar
+            username={username}
+            avatarPreview={avatarPreview}
+            onFileChange={handleAvatarFileChange}
+            onNext={() => setCurrentStep(5)}
+            onBack={() => setCurrentStep(3)}
+          />
         )}
-
-        {/* Step 5: ゲーム選択 */}
         {currentStep === 5 && (
-          <div className="animate-fade-in-up flex flex-col justify-between min-h-[38rem]">
-            <div className="space-y-8">
-              <div>
-                <h1 className="mb-1 text-2xl sm:text-3xl font-bold" style={{ color: "var(--text-primary)" }}>
-                  プレイしているゲームを登録
-                </h1>
-                <p className="mt-2 text-sm" style={{ color: "var(--text-secondary)" }}>
-                  プレイするゲームを登録すると、ゲーム仲間が見つかりやすくなります。
-                </p>
-              </div>
-
-              <GridGamePicker value={selectedGames} onChange={setSelectedGames} max={20} />
-
-              {error && (
-                <p className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-400">
-                  {error}
-                </p>
-              )}
-            </div>
-
-            <div className="flex items-center gap-3">
-              <button
-                type="button"
-                onClick={() => setCurrentStep(4)}
-                className="flex flex-1 items-center justify-center gap-1 rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80"
-                style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
-              >
-                <ArrowLeft className="h-4 w-4" />
-                戻る
-              </button>
-              <button
-                type="button"
-                disabled={status === "loading" || saving}
-                onClick={() => void handleSubmit()}
-                className="flex flex-1 items-center justify-center rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90 disabled:opacity-50"
-                style={{
-                  background: "linear-gradient(135deg, var(--accent), #6d28d9)",
-                  boxShadow: "0 4px 14px rgba(124,58,237,0.4)",
-                }}
-              >
-                {saving ? "設定中..." : "はじめる"}
-              </button>
-            </div>
-          </div>
+          <StepGames
+            selectedGames={selectedGames}
+            onGamesChange={setSelectedGames}
+            onBack={() => setCurrentStep(4)}
+            onSubmit={() => void handleSubmit()}
+            saving={saving}
+            error={error}
+            status={status}
+          />
         )}
-
       </div>
     </div>
   );

--- a/app/(onboarding)/onboarding/useOnboardingSubmit.test.ts
+++ b/app/(onboarding)/onboarding/useOnboardingSubmit.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockUpdate = vi.fn();
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ update: mockUpdate }),
+}));
+
+import { useOnboardingSubmit } from "./useOnboardingSubmit";
+import { type Game } from "@/lib/mock-data";
+
+const mockGame: Game = { id: "game-1", name: "Valorant", coverImageUrl: null };
+
+const defaultParams = {
+  avatarFile: null,
+  username: "testuser",
+  bio: "Hello",
+  selectedGames: [mockGame],
+  callbackUrl: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = vi.fn();
+  mockUpdate.mockResolvedValue(undefined);
+});
+
+describe("useOnboardingSubmit", () => {
+  describe("正常系", () => {
+    it("アバターなしで送信すると PATCH /api/v1/users/me を呼び /rooms にリダイレクトする", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      } as Response);
+
+      const { result } = renderHook(() => useOnboardingSubmit(defaultParams));
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/v1/users/me",
+        expect.objectContaining({
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            username: "testuser",
+            bio: "Hello",
+            gameIds: ["game-1"],
+          }),
+        })
+      );
+      expect(mockUpdate).toHaveBeenCalledWith({ username: "testuser" });
+      expect(mockPush).toHaveBeenCalledWith("/rooms");
+      expect(result.current.error).toBeNull();
+      expect(result.current.saving).toBe(false);
+    });
+
+    it("アバターありで送信すると POST /api/v1/users/me/avatar → PATCH の順に呼ばれる", async () => {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({ ok: true } as Response)
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) } as Response);
+
+      const file = new File(["img"], "avatar.png", { type: "image/png" });
+      const { result } = renderHook(() =>
+        useOnboardingSubmit({ ...defaultParams, avatarFile: file })
+      );
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(fetch).toHaveBeenNthCalledWith(
+        1,
+        "/api/v1/users/me/avatar",
+        expect.objectContaining({ method: "POST" })
+      );
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
+        "/api/v1/users/me",
+        expect.objectContaining({ method: "PATCH" })
+      );
+      expect(mockPush).toHaveBeenCalledWith("/rooms");
+    });
+
+    it("callbackUrl が / で始まる場合はそちらにリダイレクトする", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      } as Response);
+
+      const { result } = renderHook(() =>
+        useOnboardingSubmit({ ...defaultParams, callbackUrl: "/rooms/abc" })
+      );
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/rooms/abc");
+    });
+
+    it("callbackUrl が外部 URL の場合は /rooms にリダイレクトする", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      } as Response);
+
+      const { result } = renderHook(() =>
+        useOnboardingSubmit({ ...defaultParams, callbackUrl: "https://evil.com" })
+      );
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/rooms");
+    });
+  });
+
+  describe("エラー系", () => {
+    it("アバターアップロード失敗時にエラーをセットして PATCH を呼ばない", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false } as Response);
+
+      const file = new File(["img"], "avatar.png", { type: "image/png" });
+      const { result } = renderHook(() =>
+        useOnboardingSubmit({ ...defaultParams, avatarFile: file })
+      );
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(result.current.error).toBe("画像のアップロードに失敗しました");
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("PATCH 失敗時に API のエラーメッセージをセットする", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "ユーザー名が重複しています" }),
+      } as Response);
+
+      const { result } = renderHook(() => useOnboardingSubmit(defaultParams));
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(result.current.error).toBe("ユーザー名が重複しています");
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("PATCH 失敗で error フィールドがない場合はデフォルトメッセージを使う", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({}),
+      } as Response);
+
+      const { result } = renderHook(() => useOnboardingSubmit(defaultParams));
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(result.current.error).toBe("エラーが発生しました");
+    });
+
+    it("通信エラー時にデフォルトエラーメッセージをセットする", async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new Error("Network error"));
+
+      const { result } = renderHook(() => useOnboardingSubmit(defaultParams));
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(result.current.error).toBe("通信エラーが発生しました。再度お試しください");
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("saving フラグ", () => {
+    it("送信中は saving が true になり、完了後に false に戻る", async () => {
+      let resolveFetch!: (value: unknown) => void;
+      vi.mocked(fetch).mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }) as Promise<Response>
+      );
+
+      const { result } = renderHook(() => useOnboardingSubmit(defaultParams));
+
+      act(() => {
+        void result.current.handleSubmit();
+      });
+      expect(result.current.saving).toBe(true);
+
+      await act(async () => {
+        resolveFetch({ ok: true, json: async () => ({}) } as Response);
+      });
+      expect(result.current.saving).toBe(false);
+    });
+  });
+});

--- a/app/(onboarding)/onboarding/useOnboardingSubmit.ts
+++ b/app/(onboarding)/onboarding/useOnboardingSubmit.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { type Game } from "@/lib/mock-data";
+
+interface UseOnboardingSubmitParams {
+  avatarFile: File | null;
+  username: string;
+  bio: string;
+  selectedGames: Game[];
+  callbackUrl: string | null;
+}
+
+export function useOnboardingSubmit({
+  avatarFile,
+  username,
+  bio,
+  selectedGames,
+  callbackUrl,
+}: UseOnboardingSubmitParams) {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+  const { update } = useSession();
+
+  const handleSubmit = async () => {
+    setSaving(true);
+    setError(null);
+
+    try {
+      if (avatarFile) {
+        const formData = new FormData();
+        formData.append("file", avatarFile);
+        const uploadRes = await fetch("/api/v1/users/me/avatar", {
+          method: "POST",
+          body: formData,
+        });
+        if (!uploadRes.ok) {
+          setError("画像のアップロードに失敗しました");
+          return;
+        }
+      }
+
+      const res = await fetch("/api/v1/users/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: username.trim(),
+          bio: bio || null,
+          gameIds: selectedGames.map((g) => g.id),
+        }),
+      });
+
+      const json = (await res.json()) as { error?: string };
+
+      if (!res.ok) {
+        setError(json.error ?? "エラーが発生しました");
+        return;
+      }
+
+      await update({ username: username.trim() });
+      const dest = callbackUrl?.startsWith("/") ? callbackUrl : "/rooms";
+      router.push(dest);
+    } catch {
+      setError("通信エラーが発生しました。再度お試しください");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return { handleSubmit, saving, error };
+}


### PR DESCRIPTION
## 概要

`app/(onboarding)/onboarding/page.tsx`（429行）に混在していた5ステップ分のJSXとAPIロジックをコンポーネント・カスタムフックに分割し、`page.tsx` を状態管理とステップルーティングのみの約80行に縮小した。

## 変更内容

### 新規作成
- `useOnboardingSubmit.ts` — アバターアップロード → PATCH /api/v1/users/me → セッション更新 → リダイレクトの非同期ロジックを抽出。戻り値: `{ handleSubmit, saving, error }`
- `OnboardingProgressDots.tsx` — ステップ進捗ドット（共通）
- `StepWelcome.tsx` — Step 1
- `StepUsername.tsx` — Step 2
- `StepBio.tsx` — Step 3
- `StepAvatar.tsx` — Step 4（`fileInputRef` と プレビューURL生成を内部管理）
- `StepGames.tsx` — Step 5
- `useOnboardingSubmit.test.ts` — 正常系・エラー系・saving フラグを網羅する 9 ケース

### 変更
- `page.tsx` — 429行 → 約80行に縮小

## 実装上の補足

`useEffect` 内での `setState` を禁止する lint ルール（`react-hooks/set-state-in-effect`）に対応するため、アバタープレビュー URL の生成を `useEffect` ではなくイベントハンドラ（`handleAvatarFileChange`）で行うよう変更した。

Closes #116