### PR TITLE
refactor: RoomDetailViewをRoomHeaderCardとParticipantSidebarに分割

### DIFF
--- a/app/rooms/[roomId]/ParticipantSidebar.test.tsx
+++ b/app/rooms/[roomId]/ParticipantSidebar.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@phosphor-icons/react", () => ({
+  Crown: () => <span data-testid="icon-crown" />,
+  Users: () => <span data-testid="icon-users" />,
+}));
+
+vi.mock("@/components/ui/UserAvatar", () => ({
+  UserAvatar: ({ username }: { username: string }) => (
+    <div data-testid="user-avatar">{username}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/StarRating", () => ({
+  RatingDisplay: () => <div data-testid="rating-display" />,
+}));
+
+import { ParticipantSidebar } from "./ParticipantSidebar";
+import type { RoomParticipant } from "@/lib/api/rooms";
+
+const makeUser = (override: Partial<RoomParticipant> = {}): RoomParticipant => ({
+  userId: "user-1",
+  guestSessionId: null,
+  username: "TestUser",
+  iconUrl: null,
+  avgRating: null,
+  isHost: false,
+  joinedAt: "2026-04-12T10:00:00.000Z",
+  ...override,
+});
+
+const makeGuest = (override: Partial<RoomParticipant> = {}): RoomParticipant => ({
+  userId: null,
+  guestSessionId: "gs-1",
+  username: "GuestUser",
+  iconUrl: null,
+  avgRating: null,
+  isHost: false,
+  joinedAt: "2026-04-12T10:00:00.000Z",
+  ...override,
+});
+
+describe("ParticipantSidebar", () => {
+  it("参加者数と最大人数が表示される", () => {
+    render(
+      <ParticipantSidebar
+        participants={[makeUser()]}
+        maxPlayers={4}
+        currentPlayers={1}
+        currentUserId={null}
+        currentGuestSessionId={null}
+      />
+    );
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("/4")).toBeInTheDocument();
+  });
+
+  it("空枠が (maxPlayers - currentPlayers) 個表示される", () => {
+    render(
+      <ParticipantSidebar
+        participants={[makeUser()]}
+        maxPlayers={4}
+        currentPlayers={1}
+        currentUserId={null}
+        currentGuestSessionId={null}
+      />
+    );
+    expect(screen.getAllByText("募集中...")).toHaveLength(3);
+  });
+
+  it("ホストには Crown アイコンが表示される", () => {
+    render(
+      <ParticipantSidebar
+        participants={[makeUser({ isHost: true })]}
+        maxPlayers={2}
+        currentPlayers={1}
+        currentUserId={null}
+        currentGuestSessionId={null}
+      />
+    );
+    expect(screen.getByTestId("icon-crown")).toBeInTheDocument();
+  });
+
+  it("非ホストには Crown アイコンが表示されない", () => {
+    render(
+      <ParticipantSidebar
+        participants={[makeUser({ isHost: false })]}
+        maxPlayers={2}
+        currentPlayers={1}
+        currentUserId={null}
+        currentGuestSessionId={null}
+      />
+    );
+    expect(screen.queryByTestId("icon-crown")).toBeNull();
+  });
+
+  it("ゲスト参加者には「ゲスト」バッジが表示される", () => {
+    render(
+      <ParticipantSidebar
+        participants={[makeGuest()]}
+        maxPlayers={2}
+        currentPlayers={1}
+        currentUserId={null}
+        currentGuestSessionId={null}
+      />
+    );
+    expect(screen.getByText("ゲスト")).toBeInTheDocument();
+  });
+
+  it("ユーザー参加者には「ゲスト」バッジが表示されない", () => {
+    render(
+      <ParticipantSidebar
+        participants={[makeUser()]}
+        maxPlayers={2}
+        currentPlayers={1}
+        currentUserId={null}
+        currentGuestSessionId={null}
+      />
+    );
+    expect(screen.queryByText("ゲスト")).toBeNull();
+  });
+
+  it("自分のユーザーには「あなた」ラベルが表示される", () => {
+    render(
+      <ParticipantSidebar
+        participants={[makeUser({ userId: "me" })]}
+        maxPlayers={2}
+        currentPlayers={1}
+        currentUserId="me"
+        currentGuestSessionId={null}
+      />
+    );
+    expect(screen.getByText("(あなた)")).toBeInTheDocument();
+  });
+
+  it("自分以外のユーザーには「あなた」ラベルが表示されない", () => {
+    render(
+      <ParticipantSidebar
+        participants={[makeUser({ userId: "other" })]}
+        maxPlayers={2}
+        currentPlayers={1}
+        currentUserId="me"
+        currentGuestSessionId={null}
+      />
+    );
+    expect(screen.queryByText("(あなた)")).toBeNull();
+  });
+
+  it("ユーザー参加者のアバターにプロフィールページへのリンクが付く", () => {
+    render(
+      <ParticipantSidebar
+        participants={[makeUser({ userId: "user-99" })]}
+        maxPlayers={2}
+        currentPlayers={1}
+        currentUserId={null}
+        currentGuestSessionId={null}
+      />
+    );
+    const links = screen.getAllByRole("link");
+    expect(links.some((l) => l.getAttribute("href") === "/users/user-99")).toBe(true);
+  });
+
+  it("自分のアバターのリンク先は /users/me", () => {
+    render(
+      <ParticipantSidebar
+        participants={[makeUser({ userId: "me" })]}
+        maxPlayers={2}
+        currentPlayers={1}
+        currentUserId="me"
+        currentGuestSessionId={null}
+      />
+    );
+    const links = screen.getAllByRole("link");
+    expect(links.every((l) => l.getAttribute("href") === "/users/me")).toBe(true);
+  });
+
+  it("参加者がいない場合は空枠のみ表示される", () => {
+    render(
+      <ParticipantSidebar
+        participants={[]}
+        maxPlayers={3}
+        currentPlayers={0}
+        currentUserId={null}
+        currentGuestSessionId={null}
+      />
+    );
+    expect(screen.getAllByText("募集中...")).toHaveLength(3);
+    expect(screen.queryByTestId("user-avatar")).toBeNull();
+  });
+});

--- a/app/rooms/[roomId]/ParticipantSidebar.tsx
+++ b/app/rooms/[roomId]/ParticipantSidebar.tsx
@@ -1,0 +1,152 @@
+import Link from "next/link";
+import { Crown, Users } from "@phosphor-icons/react";
+import { UserAvatar } from "@/components/ui/UserAvatar";
+import { RatingDisplay } from "@/components/ui/StarRating";
+import type { RoomParticipant } from "@/lib/api/rooms";
+
+type ParticipantSidebarProps = {
+  participants: RoomParticipant[];
+  maxPlayers: number;
+  currentPlayers: number;
+  currentUserId: string | null;
+  currentGuestSessionId: string | null;
+};
+
+export function ParticipantSidebar({
+  participants,
+  maxPlayers,
+  currentPlayers,
+  currentUserId,
+  currentGuestSessionId,
+}: ParticipantSidebarProps) {
+  return (
+    <div className="space-y-4 animate-fade-in-up" style={{ animationDelay: "160ms" }}>
+      <div
+        className="rounded-2xl border p-4 sm:p-5"
+        style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4" style={{ color: "var(--text-muted)" }} />
+            <span className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+              参加者
+            </span>
+          </div>
+          <span className="text-sm" style={{ color: "var(--text-secondary)" }}>
+            <span className="font-bold" style={{ color: "var(--text-primary)" }}>
+              {currentPlayers}
+            </span>
+            /{maxPlayers}
+          </span>
+        </div>
+
+        {/* Progress bar */}
+        <div
+          className="mb-4 h-2 w-full rounded-full overflow-hidden"
+          style={{ backgroundColor: "var(--border)" }}
+        >
+          <div
+            className="h-full rounded-full transition-all"
+            style={{
+              width: `${(currentPlayers / maxPlayers) * 100}%`,
+              background: "linear-gradient(90deg, var(--accent), var(--accent-light))",
+            }}
+          />
+        </div>
+
+        <ul className="space-y-3">
+          {participants.map((p, idx) => (
+            <li
+              key={p.userId ?? p.guestSessionId ?? `participant-${idx}`}
+              className="flex items-center gap-3"
+            >
+              {p.userId != null ? (
+                <Link
+                  href={p.userId === currentUserId ? "/users/me" : `/users/${p.userId}`}
+                  className="shrink-0"
+                >
+                  <UserAvatar username={p.username} iconUrl={p.iconUrl} size="md" />
+                </Link>
+              ) : (
+                <span className="shrink-0">
+                  <UserAvatar username={p.username} iconUrl={p.iconUrl} size="md" />
+                </span>
+              )}
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5">
+                  {p.isHost && (
+                    <Crown className="h-3.5 w-3.5 shrink-0" style={{ color: "#eab308" }} />
+                  )}
+                  {p.userId != null ? (
+                    <Link
+                      href={p.userId === currentUserId ? "/users/me" : `/users/${p.userId}`}
+                      className="truncate text-sm font-medium hover:underline"
+                      style={{
+                        color:
+                          p.userId === currentUserId
+                            ? "var(--accent-light)"
+                            : "var(--text-primary)",
+                      }}
+                    >
+                      {p.username}
+                      {p.userId === currentUserId && (
+                        <span className="ml-1 text-xs" style={{ color: "var(--text-muted)" }}>
+                          (あなた)
+                        </span>
+                      )}
+                    </Link>
+                  ) : (
+                    <span
+                      className="truncate text-sm font-medium"
+                      style={{
+                        color:
+                          currentGuestSessionId !== null &&
+                          p.guestSessionId === currentGuestSessionId
+                            ? "var(--accent-light)"
+                            : "var(--text-primary)",
+                      }}
+                    >
+                      {p.username}
+                    </span>
+                  )}
+                  {p.userId == null && (
+                    <span
+                      className="shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none"
+                      style={{
+                        backgroundColor: "rgba(34, 197, 94, 0.15)",
+                        color: "#4ade80",
+                        border: "1px solid rgba(34, 197, 94, 0.3)",
+                      }}
+                    >
+                      ゲスト
+                    </span>
+                  )}
+                </div>
+                <RatingDisplay
+                  avgRating={p.avgRating}
+                  ratingCount={p.avgRating != null ? 10 : 3}
+                  size="sm"
+                />
+              </div>
+            </li>
+          ))}
+          {Array.from({ length: maxPlayers - currentPlayers }).map((_, i) => (
+            <li
+              key={`empty-${i}`}
+              className="flex items-center gap-3 rounded-lg border border-dashed px-3 py-2"
+              style={{ borderColor: "var(--border)" }}
+            >
+              <div
+                className="h-9 w-9 rounded-full border-2 border-dashed"
+                style={{ borderColor: "var(--border)" }}
+              />
+              <span className="text-xs" style={{ color: "var(--text-muted)" }}>
+                募集中...
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/app/rooms/[roomId]/RoomDetailView.tsx
+++ b/app/rooms/[roomId]/RoomDetailView.tsx
@@ -2,20 +2,16 @@
 
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
-import Image from "next/image";
 import { useSearchParams } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
-import { ArrowLeft, Crown, Chat, Users } from "@phosphor-icons/react";
+import { ArrowLeft, Chat } from "@phosphor-icons/react";
 import { fetchRoom, joinRoom } from "@/lib/api/rooms";
-import { roomStatusConfig, fallbackStatusConfig } from "@/lib/room-status";
-import { UserAvatar } from "@/components/ui/UserAvatar";
-import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
-import { RatingDisplay } from "@/components/ui/StarRating";
-import { GameCover } from "@/components/ui/GamePicker";
 import { GuestJoinModal } from "@/components/rooms/GuestJoinModal";
 import { RoomActions } from "./RoomActions";
 import { InvitePanel } from "./InvitePanel";
+import { RoomHeaderCard } from "./RoomHeaderCard";
+import { ParticipantSidebar } from "./ParticipantSidebar";
 
 type Props = { roomId: string };
 
@@ -112,7 +108,6 @@ export function RoomDetailView({ roomId }: Props) {
   }
 
   const room = data.data;
-  const status = roomStatusConfig[room.status as keyof typeof roomStatusConfig] ?? fallbackStatusConfig;
   const currentGuestSessionId = room.currentGuestSessionId ?? null;
   const isParticipant =
     (currentUserId != null && room.participants.some((p) => p.userId === currentUserId)) ||
@@ -142,74 +137,7 @@ export function RoomDetailView({ roomId }: Props) {
         {/* Main content */}
         <div className="lg:col-span-2 flex flex-col gap-4 sm:gap-6">
           {/* Room Info */}
-          <div
-            className="rounded-2xl border overflow-hidden animate-fade-in-up"
-            style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
-          >
-            {/* Game cover header */}
-            <div
-              className="relative h-32 flex items-end px-4 pb-3 sm:px-6 sm:pb-4 overflow-hidden"
-              style={{ backgroundColor: "rgba(124,58,237,0.08)" }}
-            >
-              {room.game.coverImageUrl && (
-                <Image
-                  src={room.game.coverImageUrl}
-                  alt=""
-                  aria-hidden
-                  fill
-                  className="pointer-events-none object-cover opacity-25 blur-sm scale-110"
-                  sizes="800px"
-                />
-              )}
-              <div
-                className="absolute inset-0"
-                style={{ background: "linear-gradient(to top, var(--bg-card) 20%, transparent 80%)" }}
-              />
-              <div className="relative z-10 flex items-center gap-4">
-                <GameCover game={room.game} size="lg" />
-                <div>
-                  <p className="text-sm font-semibold" style={{ color: "var(--accent-light)" }}>
-                    {room.game.name}
-                  </p>
-                  <div className="flex flex-wrap items-center gap-2 mt-1">
-                    <span
-                      className="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium"
-                      style={{ backgroundColor: status.bg, color: status.color, border: `1px solid ${status.border}` }}
-                    >
-                      {status.label}
-                    </span>
-                    <span className="text-xs" style={{ color: "var(--text-muted)" }}>
-                      {new Date(room.createdAt).toLocaleString("ja-JP", {
-                        month: "numeric",
-                        day: "numeric",
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      })}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Room details */}
-            <div className="px-4 py-4 sm:px-6 sm:py-5">
-              <h1 className="text-lg sm:text-xl font-bold" style={{ color: "var(--text-primary)" }}>
-                {room.title}
-              </h1>
-              {room.description && (
-                <p className="mt-2 text-sm leading-relaxed" style={{ color: "var(--text-secondary)" }}>
-                  {room.description}
-                </p>
-              )}
-              {room.playStyleTags.length > 0 && (
-                <div className="mt-3 flex flex-wrap gap-2">
-                  {room.playStyleTags.map((tag) => (
-                    <PlayStyleTag key={tag.id} tag={tag} />
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
+          <RoomHeaderCard room={room} />
 
           {/* Chat shortcut */}
           {isParticipant && (
@@ -256,125 +184,13 @@ export function RoomDetailView({ roomId }: Props) {
         </div>
 
         {/* Sidebar: Participants */}
-        <div className="space-y-4 animate-fade-in-up" style={{ animationDelay: "160ms" }}>
-          <div
-            className="rounded-2xl border p-4 sm:p-5"
-            style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
-          >
-            <div className="flex items-center justify-between mb-4">
-              <div className="flex items-center gap-2">
-                <Users className="h-4 w-4" style={{ color: "var(--text-muted)" }} />
-                <span className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
-                  参加者
-                </span>
-              </div>
-              <span className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                <span className="font-bold" style={{ color: "var(--text-primary)" }}>
-                  {room.currentPlayers}
-                </span>
-                /{room.maxPlayers}
-              </span>
-            </div>
-
-            {/* Progress bar */}
-            <div className="mb-4 h-2 w-full rounded-full overflow-hidden" style={{ backgroundColor: "var(--border)" }}>
-              <div
-                className="h-full rounded-full transition-all"
-                style={{
-                  width: `${(room.currentPlayers / room.maxPlayers) * 100}%`,
-                  background: "linear-gradient(90deg, var(--accent), var(--accent-light))",
-                }}
-              />
-            </div>
-
-            <ul className="space-y-3">
-              {room.participants.map((p, idx) => (
-                <li key={p.userId ?? p.guestSessionId ?? `participant-${idx}`} className="flex items-center gap-3">
-                  {p.userId != null ? (
-                    <Link
-                      href={p.userId === currentUserId ? "/users/me" : `/users/${p.userId}`}
-                      className="shrink-0"
-                    >
-                      <UserAvatar username={p.username} iconUrl={p.iconUrl} size="md" />
-                    </Link>
-                  ) : (
-                    <span className="shrink-0">
-                      <UserAvatar username={p.username} iconUrl={p.iconUrl} size="md" />
-                    </span>
-                  )}
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-1.5">
-                      {p.isHost && (
-                        <Crown className="h-3.5 w-3.5 shrink-0" style={{ color: "#eab308" }} />
-                      )}
-                      {p.userId != null ? (
-                        <Link
-                          href={p.userId === currentUserId ? "/users/me" : `/users/${p.userId}`}
-                          className="truncate text-sm font-medium hover:underline"
-                          style={{
-                            color: p.userId === currentUserId ? "var(--accent-light)" : "var(--text-primary)",
-                          }}
-                        >
-                          {p.username}
-                          {p.userId === currentUserId && (
-                            <span className="ml-1 text-xs" style={{ color: "var(--text-muted)" }}>
-                              (あなた)
-                            </span>
-                          )}
-                        </Link>
-                      ) : (
-                        <span
-                          className="truncate text-sm font-medium"
-                          style={{
-                            color:
-                              currentGuestSessionId !== null &&
-                              p.guestSessionId === currentGuestSessionId
-                                ? "var(--accent-light)"
-                                : "var(--text-primary)",
-                          }}
-                        >
-                          {p.username}
-                        </span>
-                      )}
-                      {p.userId == null && (
-                        <span
-                          className="shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none"
-                          style={{
-                            backgroundColor: "rgba(34, 197, 94, 0.15)",
-                            color: "#4ade80",
-                            border: "1px solid rgba(34, 197, 94, 0.3)",
-                          }}
-                        >
-                          ゲスト
-                        </span>
-                      )}
-                    </div>
-                    <RatingDisplay
-                      avgRating={p.avgRating}
-                      ratingCount={p.avgRating != null ? 10 : 3}
-                      size="sm"
-                    />
-                  </div>
-                </li>
-              ))}
-              {Array.from({ length: room.maxPlayers - room.currentPlayers }).map((_, i) => (
-                <li
-                  key={`empty-${i}`}
-                  className="flex items-center gap-3 rounded-lg border border-dashed px-3 py-2"
-                  style={{ borderColor: "var(--border)" }}
-                >
-                  <div
-                    className="h-9 w-9 rounded-full border-2 border-dashed"
-                    style={{ borderColor: "var(--border)" }}
-                  />
-                  <span className="text-xs" style={{ color: "var(--text-muted)" }}>
-                    募集中...
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
+        <ParticipantSidebar
+          participants={room.participants}
+          maxPlayers={room.maxPlayers}
+          currentPlayers={room.currentPlayers}
+          currentUserId={currentUserId}
+          currentGuestSessionId={currentGuestSessionId}
+        />
       </div>
 
       {/* 統合ダイアログ: 参加ボタン押下時に表示 */}

--- a/app/rooms/[roomId]/RoomHeaderCard.test.tsx
+++ b/app/rooms/[roomId]/RoomHeaderCard.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
+}));
+
+vi.mock("@/components/ui/GamePicker", () => ({
+  GameCover: ({ game }: { game: { name: string } }) => (
+    <div data-testid="game-cover">{game.name}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/PlayStyleTag", () => ({
+  PlayStyleTag: ({ tag }: { tag: { name: string } }) => (
+    <span data-testid="play-style-tag">{tag.name}</span>
+  ),
+}));
+
+import { RoomHeaderCard } from "./RoomHeaderCard";
+
+const baseRoom = {
+  game: { id: "g1", name: "Valorant", coverImageUrl: null },
+  title: "一緒にランク上げましょう",
+  description: null,
+  playStyleTags: [],
+  createdAt: "2026-04-12T10:00:00.000Z",
+  status: "waiting" as const,
+};
+
+describe("RoomHeaderCard", () => {
+  it("ゲーム名とルームタイトルが表示される", () => {
+    render(<RoomHeaderCard room={baseRoom} />);
+    // ゲーム名は GameCover モックと <p> の両方に出るため getAllByText で確認
+    expect(screen.getAllByText("Valorant").length).toBeGreaterThan(0);
+    expect(screen.getByText("一緒にランク上げましょう")).toBeInTheDocument();
+  });
+
+  it("waiting ステータスで「募集中」バッジが表示される", () => {
+    render(<RoomHeaderCard room={baseRoom} />);
+    expect(screen.getByText("募集中")).toBeInTheDocument();
+  });
+
+  it("playing ステータスで「プレイ中」バッジが表示される", () => {
+    render(<RoomHeaderCard room={{ ...baseRoom, status: "playing" }} />);
+    expect(screen.getByText("プレイ中")).toBeInTheDocument();
+  });
+
+  it("closed ステータスで「終了」バッジが表示される", () => {
+    render(<RoomHeaderCard room={{ ...baseRoom, status: "closed" }} />);
+    expect(screen.getByText("終了")).toBeInTheDocument();
+  });
+
+  it("description が null のときは説明文が表示されない", () => {
+    const { container } = render(<RoomHeaderCard room={baseRoom} />);
+    expect(container.querySelector("p.mt-2")).toBeNull();
+  });
+
+  it("description がある場合は表示される", () => {
+    render(<RoomHeaderCard room={{ ...baseRoom, description: "初心者歓迎です" }} />);
+    expect(screen.getByText("初心者歓迎です")).toBeInTheDocument();
+  });
+
+  it("playStyleTags がある場合はタグが表示される", () => {
+    const tags = [
+      { id: "t1", name: "カジュアル", slug: "casual" },
+      { id: "t2", name: "初心者OK", slug: "beginner-ok" },
+    ];
+    render(<RoomHeaderCard room={{ ...baseRoom, playStyleTags: tags }} />);
+    const tagElements = screen.getAllByTestId("play-style-tag");
+    expect(tagElements).toHaveLength(2);
+    expect(tagElements[0]).toHaveTextContent("カジュアル");
+    expect(tagElements[1]).toHaveTextContent("初心者OK");
+  });
+
+  it("coverImageUrl がある場合は背景画像が描画される", () => {
+    const { container } = render(
+      <RoomHeaderCard
+        room={{ ...baseRoom, game: { ...baseRoom.game, coverImageUrl: "/cover.jpg" } }}
+      />
+    );
+    // aria-hidden な img のため container.querySelector で確認
+    expect(container.querySelector("img")).toBeInTheDocument();
+  });
+
+  it("coverImageUrl が null の場合は背景画像が描画されない", () => {
+    const { container } = render(<RoomHeaderCard room={baseRoom} />);
+    expect(container.querySelector("img")).toBeNull();
+  });
+});

--- a/app/rooms/[roomId]/RoomHeaderCard.tsx
+++ b/app/rooms/[roomId]/RoomHeaderCard.tsx
@@ -1,0 +1,93 @@
+import Image from "next/image";
+import { GameCover } from "@/components/ui/GamePicker";
+import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
+import { roomStatusConfig, fallbackStatusConfig } from "@/lib/room-status";
+import type { RoomDetail } from "@/lib/api/rooms";
+
+type RoomHeaderCardProps = {
+  room: Pick<
+    RoomDetail,
+    "game" | "title" | "description" | "playStyleTags" | "createdAt" | "status"
+  >;
+};
+
+export function RoomHeaderCard({ room }: RoomHeaderCardProps) {
+  const status =
+    roomStatusConfig[room.status as keyof typeof roomStatusConfig] ??
+    fallbackStatusConfig;
+
+  return (
+    <div
+      className="rounded-2xl border overflow-hidden animate-fade-in-up"
+      style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
+    >
+      {/* Game cover header */}
+      <div
+        className="relative h-32 flex items-end px-4 pb-3 sm:px-6 sm:pb-4 overflow-hidden"
+        style={{ backgroundColor: "rgba(124,58,237,0.08)" }}
+      >
+        {room.game.coverImageUrl && (
+          <Image
+            src={room.game.coverImageUrl}
+            alt=""
+            aria-hidden
+            fill
+            className="pointer-events-none object-cover opacity-25 blur-sm scale-110"
+            sizes="800px"
+          />
+        )}
+        <div
+          className="absolute inset-0"
+          style={{ background: "linear-gradient(to top, var(--bg-card) 20%, transparent 80%)" }}
+        />
+        <div className="relative z-10 flex items-center gap-4">
+          <GameCover game={room.game} size="lg" />
+          <div>
+            <p className="text-sm font-semibold" style={{ color: "var(--accent-light)" }}>
+              {room.game.name}
+            </p>
+            <div className="flex flex-wrap items-center gap-2 mt-1">
+              <span
+                className="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium"
+                style={{
+                  backgroundColor: status.bg,
+                  color: status.color,
+                  border: `1px solid ${status.border}`,
+                }}
+              >
+                {status.label}
+              </span>
+              <span className="text-xs" style={{ color: "var(--text-muted)" }}>
+                {new Date(room.createdAt).toLocaleString("ja-JP", {
+                  month: "numeric",
+                  day: "numeric",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Room details */}
+      <div className="px-4 py-4 sm:px-6 sm:py-5">
+        <h1 className="text-lg sm:text-xl font-bold" style={{ color: "var(--text-primary)" }}>
+          {room.title}
+        </h1>
+        {room.description && (
+          <p className="mt-2 text-sm leading-relaxed" style={{ color: "var(--text-secondary)" }}>
+            {room.description}
+          </p>
+        )}
+        {room.playStyleTags.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {room.playStyleTags.map((tag) => (
+              <PlayStyleTag key={tag.id} tag={tag} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

`app/rooms/[roomId]/RoomDetailView.tsx`（395行）に混在していたゲームカバーヘッダーと参加者サイドバーをそれぞれ独立したコンポーネントに切り出しました。

- `RoomHeaderCard.tsx`（新規）— ゲームカバー背景・ゲーム名・ステータスバッジ・タイトル・説明・プレイスタイルタグ
- `ParticipantSidebar.tsx`（新規）— 参加者リスト・プログレスバー・空枠
- `RoomDetailView.tsx`（395行 → 165行）— 上記2コンポーネントに委譲

ロジック・表示の変更はありません。

## テスト

- `RoomHeaderCard.test.tsx`（新規、9テスト）
- `ParticipantSidebar.test.tsx`（新規、11テスト）
- `pnpm lint` エラーなし

## AC確認

- [x] `RoomHeaderCard` がゲームカバー・ステータスバッジ・タイトル・説明・タグを正しく表示する
- [x] `ParticipantSidebar` が参加者リスト・空枠・進捗バーを正しく表示する
- [x] `RoomDetailView.tsx` から対応する JSX が削除され、各コンポーネントに委譲されている
- [x] `pnpm lint` がエラーなしで通る

Closes #118