### PR TITLE
feat: ChatViewのコンポーネント・フック分割

### DIFF
--- a/app/rooms/[roomId]/chat/ChatMessageList.test.tsx
+++ b/app/rooms/[roomId]/chat/ChatMessageList.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { useChatStore, type ChatMessage } from "@/lib/stores/chatStore";
+
+vi.mock("@/components/ui/UserAvatar", () => ({
+  UserAvatar: ({ username }: { username: string }) => (
+    <span data-testid="user-avatar" aria-label={username} />
+  ),
+}));
+
+// jsdom は scrollIntoView を実装していないためモックする
+Element.prototype.scrollIntoView = vi.fn();
+
+import { ChatMessageList } from "./ChatMessageList";
+
+const makeMsg = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
+  id: "m1",
+  roomId: "room-1",
+  user: { id: "u1", username: "Alice", iconUrl: null },
+  content: "こんにちは",
+  isSystem: false,
+  createdAt: new Date("2026-01-01T12:00:00Z"),
+  ...overrides,
+});
+
+beforeEach(() => {
+  useChatStore.setState({ messages: [], participants: [], connectionStatus: "disconnected" });
+});
+
+describe("ChatMessageList", () => {
+  describe("空状態", () => {
+    it("メッセージがない場合に案内文が表示される", () => {
+      render(<ChatMessageList currentUserId="u1" currentGuestSessionId={null} />);
+      expect(
+        screen.getByText("まだメッセージはありません。最初のメッセージを送りましょう！")
+      ).toBeInTheDocument();
+    });
+
+    it("メッセージがある場合は案内文が表示されない", () => {
+      useChatStore.setState({ messages: [makeMsg()] });
+      render(<ChatMessageList currentUserId="u1" currentGuestSessionId={null} />);
+      expect(
+        screen.queryByText("まだメッセージはありません。最初のメッセージを送りましょう！")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("システムメッセージ", () => {
+    it("isSystem=true のメッセージが表示される", () => {
+      useChatStore.setState({
+        messages: [makeMsg({ id: "s1", isSystem: true, content: "Aliceが参加しました", user: null })],
+      });
+      render(<ChatMessageList currentUserId="u1" currentGuestSessionId={null} />);
+      expect(screen.getByText("Aliceが参加しました")).toBeInTheDocument();
+    });
+
+    it("isSystem=true のメッセージにアバターが表示されない", () => {
+      useChatStore.setState({
+        messages: [makeMsg({ id: "s1", isSystem: true, content: "システム通知", user: null })],
+      });
+      render(<ChatMessageList currentUserId="u1" currentGuestSessionId={null} />);
+      expect(screen.queryByTestId("user-avatar")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("ユーザーメッセージ", () => {
+    it("メッセージ本文が表示される", () => {
+      useChatStore.setState({ messages: [makeMsg()] });
+      render(<ChatMessageList currentUserId="u2" currentGuestSessionId={null} />);
+      expect(screen.getByText("こんにちは")).toBeInTheDocument();
+    });
+
+    it("他人のメッセージでは送信者名が表示される", () => {
+      useChatStore.setState({
+        messages: [makeMsg({ user: { id: "u2", username: "Bob", iconUrl: null } })],
+      });
+      render(<ChatMessageList currentUserId="u1" currentGuestSessionId={null} />);
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+    });
+
+    it("他人のメッセージではアバターが表示される", () => {
+      useChatStore.setState({
+        messages: [makeMsg({ user: { id: "u2", username: "Bob", iconUrl: null } })],
+      });
+      render(<ChatMessageList currentUserId="u1" currentGuestSessionId={null} />);
+      expect(screen.getByTestId("user-avatar")).toBeInTheDocument();
+    });
+
+    it("自分（currentUserId 一致）のメッセージでは送信者名が表示されない", () => {
+      useChatStore.setState({
+        messages: [makeMsg({ user: { id: "u1", username: "Alice", iconUrl: null } })],
+      });
+      render(<ChatMessageList currentUserId="u1" currentGuestSessionId={null} />);
+      expect(screen.queryByText("Alice")).not.toBeInTheDocument();
+    });
+
+    it("自分のメッセージではアバターが表示されない", () => {
+      useChatStore.setState({
+        messages: [makeMsg({ user: { id: "u1", username: "Alice", iconUrl: null } })],
+      });
+      render(<ChatMessageList currentUserId="u1" currentGuestSessionId={null} />);
+      expect(screen.queryByTestId("user-avatar")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("ゲストメッセージ", () => {
+    it("user=null のメッセージには「ゲスト」バッジが表示される", () => {
+      useChatStore.setState({
+        messages: [
+          makeMsg({
+            user: null,
+            guestSessionId: "gs1",
+            displayName: "ゲストさん",
+            isSystem: false,
+          }),
+        ],
+      });
+      render(<ChatMessageList currentUserId="u1" currentGuestSessionId={null} />);
+      expect(screen.getByText("ゲスト")).toBeInTheDocument();
+    });
+
+    it("ゲストメッセージに displayName が表示される", () => {
+      useChatStore.setState({
+        messages: [
+          makeMsg({ user: null, guestSessionId: "gs1", displayName: "ゲストA", isSystem: false }),
+        ],
+      });
+      render(<ChatMessageList currentUserId="u1" currentGuestSessionId={null} />);
+      expect(screen.getByText("ゲストA")).toBeInTheDocument();
+    });
+
+    it("currentGuestSessionId が一致するゲストのメッセージは自分として扱われ送信者名が表示されない", () => {
+      useChatStore.setState({
+        messages: [
+          makeMsg({ user: null, guestSessionId: "gs-me", displayName: "私", isSystem: false }),
+        ],
+      });
+      render(<ChatMessageList currentUserId={null} currentGuestSessionId="gs-me" />);
+      expect(screen.queryByText("私")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("複数メッセージ", () => {
+    it("複数のメッセージがすべて表示される", () => {
+      useChatStore.setState({
+        messages: [
+          makeMsg({ id: "1", content: "メッセージ1" }),
+          makeMsg({ id: "2", content: "メッセージ2", user: { id: "u2", username: "Bob", iconUrl: null } }),
+          makeMsg({ id: "3", isSystem: true, content: "Bobが参加しました", user: null }),
+        ],
+      });
+      render(<ChatMessageList currentUserId="u1" currentGuestSessionId={null} />);
+      expect(screen.getByText("メッセージ1")).toBeInTheDocument();
+      expect(screen.getByText("メッセージ2")).toBeInTheDocument();
+      expect(screen.getByText("Bobが参加しました")).toBeInTheDocument();
+    });
+  });
+});

--- a/app/rooms/[roomId]/chat/ChatMessageList.tsx
+++ b/app/rooms/[roomId]/chat/ChatMessageList.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { UserAvatar } from "@/components/ui/UserAvatar";
+import { useChatStore } from "@/lib/stores/chatStore";
+
+type Props = {
+  currentUserId: string | null;
+  currentGuestSessionId: string | null;
+};
+
+export function ChatMessageList({ currentUserId, currentGuestSessionId }: Props) {
+  const messages = useChatStore((s) => s.messages);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  // メッセージ追加時に自動スクロール
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "instant" });
+  }, [messages]);
+
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+      {messages.length === 0 && (
+        <div className="flex h-full items-center justify-center">
+          <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+            まだメッセージはありません。最初のメッセージを送りましょう！
+          </p>
+        </div>
+      )}
+      {messages.map((msg) => {
+        if (msg.isSystem) {
+          return (
+            <div key={msg.id} className={`flex items-center gap-3 ${msg.isNew ? "animate-fade-in" : ""}`}>
+              <div className="h-px flex-1" style={{ backgroundColor: "var(--border)" }} />
+              <span className="shrink-0 text-xs" style={{ color: "var(--text-muted)" }}>
+                {msg.content}
+              </span>
+              <div className="h-px flex-1" style={{ backgroundColor: "var(--border)" }} />
+            </div>
+          );
+        }
+
+        const isMe =
+          (currentUserId !== null && msg.user?.id === currentUserId) ||
+          (currentGuestSessionId !== null && msg.guestSessionId === currentGuestSessionId);
+        const isGuest = msg.user === null && !msg.isSystem;
+        const senderName = isGuest ? (msg.displayName ?? "ゲスト") : (msg.user?.username ?? "");
+        return (
+          <div
+            key={msg.id}
+            className={`flex flex-col gap-1 ${isMe ? "items-end" : "items-start"} ${msg.isNew ? "animate-slide-in-bottom" : ""}`}
+          >
+            <div className={`flex items-end gap-2 max-w-[70%] ${isMe ? "flex-row-reverse" : "flex-row"}`}>
+              {!isMe && !isGuest && msg.user && (
+                <UserAvatar
+                  username={msg.user.username}
+                  iconUrl={msg.user.iconUrl}
+                  size="sm"
+                />
+              )}
+              <div
+                className={`min-w-0 ${isMe ? "items-end" : "items-start"} flex flex-col gap-1`}
+              >
+                {!isMe && (isGuest || msg.user) && (
+                  <span className="flex items-center gap-1 truncate text-xs" style={{ color: "var(--text-muted)" }}>
+                    {senderName}
+                    {isGuest && (
+                      <span
+                        className="inline-block rounded px-1 text-[10px] font-semibold leading-4"
+                        style={{
+                          backgroundColor: "rgba(139, 92, 246, 0.15)",
+                          color: "#a78bfa",
+                          border: "1px solid rgba(139, 92, 246, 0.3)",
+                        }}
+                      >
+                        ゲスト
+                      </span>
+                    )}
+                  </span>
+                )}
+                <div
+                  className="rounded-2xl px-3 py-2 text-sm leading-relaxed break-words"
+                  style={
+                    isMe
+                      ? {
+                          backgroundColor: "var(--accent)",
+                          color: "#fff",
+                          borderBottomRightRadius: "4px",
+                        }
+                      : {
+                          backgroundColor: "var(--bg-card)",
+                          color: "var(--text-primary)",
+                          border: "1px solid var(--border)",
+                          borderBottomLeftRadius: "4px",
+                        }
+                  }
+                >
+                  {msg.content}
+                </div>
+              </div>
+            </div>
+            <span
+              className="text-xs"
+              style={{
+                color: "var(--text-muted)",
+                paddingLeft: isMe || isGuest ? undefined : "40px",
+              }}
+            >
+              {new Date(msg.createdAt).toLocaleTimeString("ja-JP", {
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </span>
+          </div>
+        );
+      })}
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/app/rooms/[roomId]/chat/ChatParticipantList.test.tsx
+++ b/app/rooms/[roomId]/chat/ChatParticipantList.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@phosphor-icons/react", () => ({
+  ArrowLeft: () => <span data-testid="icon-arrow-left" />,
+  Crown: () => <span data-testid="icon-crown" />,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/components/ui/UserAvatar", () => ({
+  UserAvatar: ({ username }: { username: string }) => (
+    <span data-testid="user-avatar" aria-label={username} />
+  ),
+}));
+
+vi.mock("@/components/ui/PlayStyleTag", () => ({
+  PlayStyleTag: ({ tag }: { tag: { name: string } }) => <span>{tag.name}</span>,
+}));
+
+vi.mock("@/components/ui/StarRating", () => ({
+  RatingDisplay: () => <span data-testid="rating-display" />,
+}));
+
+import { useChatStore } from "@/lib/stores/chatStore";
+import { ChatParticipantList } from "./ChatParticipantList";
+
+const defaultProps = {
+  roomId: "room-1",
+  currentUserId: "u1",
+  currentGuestSessionId: null,
+  maxPlayers: 4,
+  roomTitle: "テストルーム",
+  gameName: "Valorant",
+  tags: [],
+};
+
+beforeEach(() => {
+  useChatStore.setState({ messages: [], participants: [], connectionStatus: "disconnected" });
+});
+
+describe("ChatParticipantList", () => {
+  describe("ルーム情報", () => {
+    it("ルームタイトルが表示される", () => {
+      render(<ChatParticipantList {...defaultProps} />);
+      expect(screen.getByText("テストルーム")).toBeInTheDocument();
+    });
+
+    it("ゲーム名が表示される", () => {
+      render(<ChatParticipantList {...defaultProps} />);
+      expect(screen.getByText("Valorant")).toBeInTheDocument();
+    });
+
+    it("「部屋の詳細へ」リンクが正しい href を持つ", () => {
+      render(<ChatParticipantList {...defaultProps} />);
+      expect(screen.getByRole("link", { name: /部屋の詳細へ/ })).toHaveAttribute(
+        "href",
+        "/rooms/room-1"
+      );
+    });
+
+    it("tags が渡されると PlayStyleTag が表示される", () => {
+      const tags = [
+        { id: "t1", name: "まったり", slug: "casual" },
+        { id: "t2", name: "がっつり", slug: "serious" },
+      ];
+      render(<ChatParticipantList {...defaultProps} tags={tags} />);
+      expect(screen.getByText("まったり")).toBeInTheDocument();
+      expect(screen.getByText("がっつり")).toBeInTheDocument();
+    });
+
+    it("tags が空の場合は PlayStyleTag が表示されない", () => {
+      render(<ChatParticipantList {...defaultProps} tags={[]} />);
+      // tags セクション自体が非表示（PlayStyleTag が 0 件）
+      expect(screen.queryByText("まったり")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("参加者数", () => {
+    it("参加者数が 0 の場合に「参加者 0/4」が表示される", () => {
+      render(<ChatParticipantList {...defaultProps} />);
+      expect(screen.getByText("参加者 0/4")).toBeInTheDocument();
+    });
+
+    it("参加者数がストアと連動して表示される", () => {
+      useChatStore.setState({
+        participants: [
+          { userId: "u1", isHost: false, user: { username: "Alice", iconUrl: null, avgRating: null } },
+          { userId: "u2", isHost: false, user: { username: "Bob", iconUrl: null, avgRating: null } },
+        ],
+      });
+      render(<ChatParticipantList {...defaultProps} />);
+      expect(screen.getByText("参加者 2/4")).toBeInTheDocument();
+    });
+  });
+
+  describe("ホスト表示", () => {
+    it("isHost=true の参加者には Crown アイコンが表示される", () => {
+      useChatStore.setState({
+        participants: [
+          { userId: "u1", isHost: true, user: { username: "Alice", iconUrl: null, avgRating: null } },
+        ],
+      });
+      render(<ChatParticipantList {...defaultProps} />);
+      expect(screen.getByTestId("icon-crown")).toBeInTheDocument();
+    });
+
+    it("isHost=false の参加者には Crown アイコンが表示されない", () => {
+      useChatStore.setState({
+        participants: [
+          { userId: "u1", isHost: false, user: { username: "Alice", iconUrl: null, avgRating: null } },
+        ],
+      });
+      render(<ChatParticipantList {...defaultProps} />);
+      expect(screen.queryByTestId("icon-crown")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("ゲストバッジ", () => {
+    it("user=null の参加者（ゲスト）には「ゲスト」バッジが表示される", () => {
+      useChatStore.setState({
+        participants: [
+          {
+            userId: null,
+            isHost: false,
+            displayName: "ゲストさん",
+            guestSessionId: "gs1",
+            user: null,
+          },
+        ],
+      });
+      render(<ChatParticipantList {...defaultProps} />);
+      expect(screen.getByText("ゲスト")).toBeInTheDocument();
+    });
+
+    it("認証済みユーザーには「ゲスト」バッジが表示されない", () => {
+      useChatStore.setState({
+        participants: [
+          { userId: "u1", isHost: false, user: { username: "Alice", iconUrl: null, avgRating: null } },
+        ],
+      });
+      render(<ChatParticipantList {...defaultProps} />);
+      expect(screen.queryByText("ゲスト")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("自分の参加者", () => {
+    it("currentUserId が一致する参加者の名前が表示される", () => {
+      useChatStore.setState({
+        participants: [
+          { userId: "u1", isHost: false, user: { username: "Alice", iconUrl: null, avgRating: null } },
+        ],
+      });
+      render(<ChatParticipantList {...defaultProps} currentUserId="u1" />);
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+    });
+
+    it("currentGuestSessionId が一致するゲスト参加者の名前が表示される", () => {
+      useChatStore.setState({
+        participants: [
+          {
+            userId: null,
+            isHost: false,
+            displayName: "私",
+            guestSessionId: "gs-me",
+            user: null,
+          },
+        ],
+      });
+      render(
+        <ChatParticipantList
+          {...defaultProps}
+          currentUserId={null}
+          currentGuestSessionId="gs-me"
+        />
+      );
+      expect(screen.getByText("私")).toBeInTheDocument();
+    });
+  });
+});

--- a/app/rooms/[roomId]/chat/ChatParticipantList.tsx
+++ b/app/rooms/[roomId]/chat/ChatParticipantList.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, Crown } from "@phosphor-icons/react";
+import { UserAvatar } from "@/components/ui/UserAvatar";
+import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
+import { RatingDisplay } from "@/components/ui/StarRating";
+import { useChatStore } from "@/lib/stores/chatStore";
+
+type Tag = { id: string; name: string; slug: string };
+
+type Props = {
+  roomId: string;
+  currentUserId: string | null;
+  currentGuestSessionId: string | null;
+  maxPlayers: number;
+  roomTitle: string;
+  gameName: string;
+  tags: Tag[];
+};
+
+export function ChatParticipantList({
+  roomId,
+  currentUserId,
+  currentGuestSessionId,
+  maxPlayers,
+  roomTitle,
+  gameName,
+  tags,
+}: Props) {
+  const participants = useChatStore((s) => s.participants);
+  const currentPlayers = participants.length;
+
+  return (
+    <aside
+      className="hidden w-64 shrink-0 flex-col border-r md:flex"
+      style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
+    >
+      {/* Room info */}
+      <div className="border-b p-4" style={{ borderColor: "var(--border)" }}>
+        <Link
+          href={`/rooms/${roomId}`}
+          className="mb-3 flex items-center gap-2 text-xs transition-colors hover:text-white"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          部屋の詳細へ
+        </Link>
+        <h2 className="text-sm font-bold leading-snug" style={{ color: "var(--text-primary)" }}>
+          {roomTitle}
+        </h2>
+        <p className="mt-1 text-xs" style={{ color: "var(--text-muted)" }}>
+          {gameName}
+        </p>
+        {tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {tags.map((tag) => (
+              <PlayStyleTag key={tag.id} tag={tag} size="sm" />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Participants */}
+      <div className="flex-1 overflow-y-auto p-4">
+        <p
+          className="mb-3 text-xs font-semibold uppercase tracking-wider"
+          style={{ color: "var(--text-muted)" }}
+        >
+          参加者 {currentPlayers}/{maxPlayers}
+        </p>
+        <ul className="space-y-2.5">
+          {participants.map((p, idx) => {
+            const name = p.user?.username ?? p.displayName ?? "ゲスト";
+            const iconUrl = p.user?.iconUrl ?? null;
+            const avgRating = p.user?.avgRating ?? null;
+            const isMe =
+              (p.userId != null && p.userId === currentUserId) ||
+              (currentGuestSessionId !== null && p.guestSessionId === currentGuestSessionId);
+            const isGuest = p.user === null;
+            return (
+              <li key={p.userId ?? `guest-${idx}`} className="flex items-center gap-2.5">
+                <div className="relative">
+                  <UserAvatar username={name} iconUrl={iconUrl} size="sm" />
+                  {!isGuest && (
+                    <span
+                      className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2"
+                      style={{ backgroundColor: "#22c55e", borderColor: "var(--bg-card)" }}
+                    />
+                  )}
+                </div>
+                <div className="min-w-0">
+                  <div className="flex items-center gap-1">
+                    {p.isHost && <Crown className="h-3 w-3" style={{ color: "#eab308" }} />}
+                    <span
+                      className="truncate text-xs font-medium"
+                      style={{ color: isMe ? "var(--accent-light)" : "var(--text-primary)" }}
+                    >
+                      {name}
+                    </span>
+                    {isGuest && (
+                      <span
+                        className="shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none"
+                        style={{
+                          backgroundColor: "rgba(34, 197, 94, 0.15)",
+                          color: "#4ade80",
+                          border: "1px solid rgba(34, 197, 94, 0.3)",
+                        }}
+                      >
+                        ゲスト
+                      </span>
+                    )}
+                  </div>
+                  <RatingDisplay
+                    avgRating={avgRating !== null ? Number(avgRating) : null}
+                    ratingCount={avgRating != null ? 10 : 3}
+                    size="sm"
+                  />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </aside>
+  );
+}

--- a/app/rooms/[roomId]/chat/ChatView.tsx
+++ b/app/rooms/[roomId]/chat/ChatView.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { useEffect, useRef } from "react";
 import Link from "next/link";
-import { ArrowLeft, Crown } from "@phosphor-icons/react";
-import { UserAvatar } from "@/components/ui/UserAvatar";
-import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
-import { RatingDisplay } from "@/components/ui/StarRating";
-import { getSocket, disconnectSocket } from "@/lib/socket";
+import { ArrowLeft } from "@phosphor-icons/react";
 import { useChatStore, type ChatMessage, type Participant } from "@/lib/stores/chatStore";
+import { useSocketRoom } from "./useSocketRoom";
+import { ChatParticipantList } from "./ChatParticipantList";
+import { ChatMessageList } from "./ChatMessageList";
 import { ChatInput } from "./ChatInput";
 
 type Tag = { id: string; name: string; slug: string };
@@ -34,186 +32,25 @@ export function ChatView({
   initialParticipants,
   roomInfo,
 }: Props) {
-  const { messages, participants, connectionStatus, setInitial, addMessage, addParticipant, removeParticipant, setConnectionStatus } =
-    useChatStore();
-  const bottomRef = useRef<HTMLDivElement>(null);
+  useSocketRoom({ roomId, initialMessages, initialParticipants });
 
-  // 初期データをストアへ注入
-  useEffect(() => {
-    setInitial(initialMessages, initialParticipants);
-  }, [initialMessages, initialParticipants, setInitial]);
-
-  // Socket 接続ライフサイクル
-  useEffect(() => {
-    const socket = getSocket();
-
-    setConnectionStatus("connecting");
-    socket.connect();
-
-    socket.on("connect", () => {
-      setConnectionStatus("connected");
-      socket.emit("room:join", { roomId });
-    });
-
-    socket.on("connect_error", () => {
-      setConnectionStatus("error");
-    });
-
-    socket.on("reconnect_failed", () => {
-      setConnectionStatus("failed");
-    });
-
-    socket.on("disconnect", () => {
-      setConnectionStatus("disconnected");
-    });
-
-    socket.on("chat:message", (msg: ChatMessage) => {
-      addMessage({ ...msg, createdAt: new Date(msg.createdAt) });
-    });
-
-    socket.on(
-      "room:user_joined",
-      (p: { userId: string; username: string; iconUrl: string | null; avgRating: number }) => {
-        addParticipant(p);
-      }
-    );
-
-    socket.on("room:user_left", ({ userId }: { userId: string }) => {
-      removeParticipant(userId);
-    });
-
-    socket.on("room:host_changed", ({ newHostId }: { newHostId: string }) => {
-      useChatStore.setState((state) => ({
-        participants: state.participants.map((p) => ({
-          ...p,
-          isHost: p.userId != null && p.userId === newHostId,
-        })),
-      }));
-    });
-
-    socket.on("room:closed", () => {
-      // 部屋が閉じられたときの処理は page レベルで対応（ここではシステムメッセージで通知）
-    });
-
-    return () => {
-      socket.emit("room:leave", { roomId });
-      socket.off("connect");
-      socket.off("connect_error");
-      socket.off("reconnect_failed");
-      socket.off("disconnect");
-      socket.off("chat:message");
-      socket.off("room:user_joined");
-      socket.off("room:user_left");
-      socket.off("room:host_changed");
-      socket.off("room:closed");
-      disconnectSocket();
-    };
-  }, [roomId, addMessage, addParticipant, removeParticipant, setConnectionStatus]);
-
-  // メッセージ追加時に自動スクロール
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "instant" });
-  }, [messages]);
-
-  const currentPlayers = participants.length;
+  const connectionStatus = useChatStore((s) => s.connectionStatus);
+  const currentPlayers = useChatStore((s) => s.participants.length);
 
   return (
     <div
       className="fixed inset-x-0 top-0 bottom-[calc(60px_+_env(safe-area-inset-bottom))] z-30 flex flex-col md:top-16 md:bottom-0 md:flex-row"
       style={{ backgroundColor: "var(--bg-base)" }}
     >
-      {/* Sidebar */}
-      <aside
-        className="hidden w-64 shrink-0 flex-col border-r md:flex"
-        style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
-      >
-        {/* Room info */}
-        <div className="border-b p-4" style={{ borderColor: "var(--border)" }}>
-          <Link
-            href={`/rooms/${roomId}`}
-            className="mb-3 flex items-center gap-2 text-xs transition-colors hover:text-white"
-            style={{ color: "var(--text-secondary)" }}
-          >
-            <ArrowLeft className="h-3.5 w-3.5" />
-            部屋の詳細へ
-          </Link>
-          <h2 className="text-sm font-bold leading-snug" style={{ color: "var(--text-primary)" }}>
-            {roomInfo.title}
-          </h2>
-          <p className="mt-1 text-xs" style={{ color: "var(--text-muted)" }}>
-            {roomInfo.game.name}
-          </p>
-          {roomInfo.tags.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-1">
-              {roomInfo.tags.map((tag) => (
-                <PlayStyleTag key={tag.id} tag={tag} size="sm" />
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Participants */}
-        <div className="flex-1 overflow-y-auto p-4">
-          <p
-            className="mb-3 text-xs font-semibold uppercase tracking-wider"
-            style={{ color: "var(--text-muted)" }}
-          >
-            参加者 {currentPlayers}/{roomInfo.maxPlayers}
-          </p>
-          <ul className="space-y-2.5">
-            {participants.map((p, idx) => {
-              const name = p.user?.username ?? p.displayName ?? "ゲスト";
-              const iconUrl = p.user?.iconUrl ?? null;
-              const avgRating = p.user?.avgRating ?? null;
-              const isMe =
-                (p.userId != null && p.userId === currentUserId) ||
-                (currentGuestSessionId !== null && p.guestSessionId === currentGuestSessionId);
-              const isGuest = p.user === null;
-              return (
-                <li key={p.userId ?? `guest-${idx}`} className="flex items-center gap-2.5">
-                  <div className="relative">
-                    <UserAvatar username={name} iconUrl={iconUrl} size="sm" />
-                    {!isGuest && (
-                      <span
-                        className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2"
-                        style={{ backgroundColor: "#22c55e", borderColor: "var(--bg-card)" }}
-                      />
-                    )}
-                  </div>
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-1">
-                      {p.isHost && <Crown className="h-3 w-3" style={{ color: "#eab308" }} />}
-                      <span
-                        className="truncate text-xs font-medium"
-                        style={{ color: isMe ? "var(--accent-light)" : "var(--text-primary)" }}
-                      >
-                        {name}
-                      </span>
-                      {isGuest && (
-                        <span
-                          className="shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none"
-                          style={{
-                            backgroundColor: "rgba(34, 197, 94, 0.15)",
-                            color: "#4ade80",
-                            border: "1px solid rgba(34, 197, 94, 0.3)",
-                          }}
-                        >
-                          ゲスト
-                        </span>
-                      )}
-                    </div>
-                    <RatingDisplay
-                      avgRating={avgRating !== null ? Number(avgRating) : null}
-                      ratingCount={avgRating != null ? 10 : 3}
-                      size="sm"
-                    />
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      </aside>
+      <ChatParticipantList
+        roomId={roomId}
+        currentUserId={currentUserId}
+        currentGuestSessionId={currentGuestSessionId}
+        maxPlayers={roomInfo.maxPlayers}
+        roomTitle={roomInfo.title}
+        gameName={roomInfo.game.name}
+        tags={roomInfo.tags}
+      />
 
       {/* Chat area */}
       <div className="flex flex-1 flex-col min-w-0 min-h-0">
@@ -252,106 +89,10 @@ export function ChatView({
           </div>
         )}
 
-        {/* Messages */}
-        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
-          {messages.length === 0 && (
-            <div className="flex h-full items-center justify-center">
-              <p className="text-sm" style={{ color: "var(--text-muted)" }}>
-                まだメッセージはありません。最初のメッセージを送りましょう！
-              </p>
-            </div>
-          )}
-          {messages.map((msg) => {
-            if (msg.isSystem) {
-              return (
-                <div key={msg.id} className={`flex items-center gap-3 ${msg.isNew ? "animate-fade-in" : ""}`}>
-                  <div className="h-px flex-1" style={{ backgroundColor: "var(--border)" }} />
-                  <span className="shrink-0 text-xs" style={{ color: "var(--text-muted)" }}>
-                    {msg.content}
-                  </span>
-                  <div className="h-px flex-1" style={{ backgroundColor: "var(--border)" }} />
-                </div>
-              );
-            }
-
-            const isMe =
-              (currentUserId !== null && msg.user?.id === currentUserId) ||
-              (currentGuestSessionId !== null && msg.guestSessionId === currentGuestSessionId);
-            const isGuest = msg.user === null && !msg.isSystem;
-            const senderName = isGuest ? (msg.displayName ?? "ゲスト") : (msg.user?.username ?? "");
-            return (
-              <div
-                key={msg.id}
-                className={`flex flex-col gap-1 ${isMe ? "items-end" : "items-start"} ${msg.isNew ? "animate-slide-in-bottom" : ""}`}
-              >
-                <div className={`flex items-end gap-2 max-w-[70%] ${isMe ? "flex-row-reverse" : "flex-row"}`}>
-                  {!isMe && !isGuest && msg.user && (
-                    <UserAvatar
-                      username={msg.user.username}
-                      iconUrl={msg.user.iconUrl}
-                      size="sm"
-                    />
-                  )}
-                  <div
-                    className={`min-w-0 ${isMe ? "items-end" : "items-start"} flex flex-col gap-1`}
-                  >
-                    {!isMe && (isGuest || msg.user) && (
-                      <span className="flex items-center gap-1 truncate text-xs" style={{ color: "var(--text-muted)" }}>
-                        {senderName}
-                        {isGuest && (
-                          <span
-                            className="inline-block rounded px-1 text-[10px] font-semibold leading-4"
-                            style={{
-                              backgroundColor: "rgba(139, 92, 246, 0.15)",
-                              color: "#a78bfa",
-                              border: "1px solid rgba(139, 92, 246, 0.3)",
-                            }}
-                          >
-                            ゲスト
-                          </span>
-                        )}
-                      </span>
-                    )}
-                    <div
-                      className="rounded-2xl px-3 py-2 text-sm leading-relaxed break-words"
-                      style={
-                        isMe
-                          ? {
-                              backgroundColor: "var(--accent)",
-                              color: "#fff",
-                              borderBottomRightRadius: "4px",
-                            }
-                          : {
-                              backgroundColor: "var(--bg-card)",
-                              color: "var(--text-primary)",
-                              border: "1px solid var(--border)",
-                              borderBottomLeftRadius: "4px",
-                            }
-                      }
-                    >
-                      {msg.content}
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="text-xs"
-                  style={{
-                    color: "var(--text-muted)",
-                    paddingLeft: isMe || isGuest ? undefined : "40px",
-                  }}
-                >
-                  {new Date(msg.createdAt).toLocaleTimeString("ja-JP", {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
-                </span>
-              </div>
-            );
-          })}
-          <div ref={bottomRef} />
-        </div>
-
-        {/* Input */}
+        <ChatMessageList
+          currentUserId={currentUserId}
+          currentGuestSessionId={currentGuestSessionId}
+        />
         <ChatInput roomId={roomId} />
       </div>
     </div>

--- a/app/rooms/[roomId]/chat/useSocketRoom.test.ts
+++ b/app/rooms/[roomId]/chat/useSocketRoom.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useChatStore } from "@/lib/stores/chatStore";
+
+const mockSocket = vi.hoisted(() => ({
+  connect: vi.fn(),
+  emit: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+}));
+
+const mockDisconnectSocket = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/socket", () => ({
+  getSocket: () => mockSocket,
+  disconnectSocket: mockDisconnectSocket,
+}));
+
+import { useSocketRoom } from "./useSocketRoom";
+
+const defaultOptions = {
+  roomId: "room-1",
+  initialMessages: [],
+  initialParticipants: [],
+};
+
+function getSocketHandler(event: string): ((...args: unknown[]) => void) | undefined {
+  return mockSocket.on.mock.calls.find(([e]) => e === event)?.[1] as
+    | ((...args: unknown[]) => void)
+    | undefined;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useChatStore.setState({
+    messages: [],
+    participants: [],
+    connectionStatus: "disconnected",
+  });
+});
+
+describe("useSocketRoom", () => {
+  describe("初期化", () => {
+    it("マウント時にストアへ initialMessages と initialParticipants が注入される", () => {
+      const initialMessages = [
+        {
+          id: "m1",
+          roomId: "room-1",
+          user: null,
+          content: "hi",
+          isSystem: true,
+          createdAt: new Date("2026-01-01T00:00:00Z"),
+        },
+      ];
+      const initialParticipants = [
+        {
+          userId: "u1",
+          isHost: false,
+          user: { username: "Alice", iconUrl: null, avgRating: null },
+        },
+      ];
+
+      // 安定した参照を renderHook コールバック外で宣言し無限ループを防ぐ
+      renderHook(() =>
+        useSocketRoom({ roomId: "room-1", initialMessages, initialParticipants })
+      );
+
+      const state = useChatStore.getState();
+      expect(state.messages).toEqual(initialMessages);
+      expect(state.participants).toEqual(initialParticipants);
+    });
+
+    it("マウント時に socket.connect() が呼ばれ connectionStatus が connecting になる", () => {
+      renderHook(() => useSocketRoom(defaultOptions));
+      expect(mockSocket.connect).toHaveBeenCalledOnce();
+      expect(useChatStore.getState().connectionStatus).toBe("connecting");
+    });
+  });
+
+  describe("接続イベント", () => {
+    it("connect イベントで connectionStatus が connected になり room:join を emit する", () => {
+      renderHook(() => useSocketRoom(defaultOptions));
+
+      act(() => getSocketHandler("connect")?.());
+
+      expect(useChatStore.getState().connectionStatus).toBe("connected");
+      expect(mockSocket.emit).toHaveBeenCalledWith("room:join", { roomId: "room-1" });
+    });
+
+    it("connect_error イベントで connectionStatus が error になる", () => {
+      renderHook(() => useSocketRoom(defaultOptions));
+
+      act(() => getSocketHandler("connect_error")?.());
+
+      expect(useChatStore.getState().connectionStatus).toBe("error");
+    });
+
+    it("reconnect_failed イベントで connectionStatus が failed になる", () => {
+      renderHook(() => useSocketRoom(defaultOptions));
+
+      act(() => getSocketHandler("reconnect_failed")?.());
+
+      expect(useChatStore.getState().connectionStatus).toBe("failed");
+    });
+
+    it("disconnect イベントで connectionStatus が disconnected になる", () => {
+      renderHook(() => useSocketRoom(defaultOptions));
+      useChatStore.setState({ connectionStatus: "connected" });
+
+      act(() => getSocketHandler("disconnect")?.());
+
+      expect(useChatStore.getState().connectionStatus).toBe("disconnected");
+    });
+  });
+
+  describe("チャットイベント", () => {
+    it("chat:message イベントでメッセージがストアに追加される", () => {
+      renderHook(() => useSocketRoom(defaultOptions));
+
+      act(() =>
+        getSocketHandler("chat:message")?.({
+          id: "m1",
+          roomId: "room-1",
+          user: null,
+          content: "hello",
+          isSystem: false,
+          createdAt: "2026-01-01T00:00:00Z",
+        })
+      );
+
+      const { messages } = useChatStore.getState();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].createdAt).toBeInstanceOf(Date);
+    });
+
+    it("chat:message の createdAt が Date オブジェクトに変換される", () => {
+      renderHook(() => useSocketRoom(defaultOptions));
+      const isoString = "2026-06-15T10:30:00Z";
+
+      act(() =>
+        getSocketHandler("chat:message")?.({
+          id: "m2",
+          roomId: "room-1",
+          user: null,
+          content: "test",
+          isSystem: false,
+          createdAt: isoString,
+        })
+      );
+
+      const { messages } = useChatStore.getState();
+      expect(messages[0].createdAt).toEqual(new Date(isoString));
+    });
+  });
+
+  describe("参加者イベント", () => {
+    it("room:user_joined イベントで参加者がストアに追加される", () => {
+      renderHook(() => useSocketRoom(defaultOptions));
+
+      act(() =>
+        getSocketHandler("room:user_joined")?.({
+          userId: "u1",
+          username: "Alice",
+          iconUrl: null,
+          avgRating: 4.0,
+        })
+      );
+
+      expect(useChatStore.getState().participants).toHaveLength(1);
+    });
+
+    it("room:user_left イベントで参加者がストアから除去される", () => {
+      // initialParticipants で設定する（setState だとマウント時の setInitial に上書きされるため）
+      const initialParticipants = [
+        { userId: "u1", isHost: false, user: { username: "Alice", iconUrl: null, avgRating: null } },
+        { userId: "u2", isHost: false, user: { username: "Bob", iconUrl: null, avgRating: null } },
+      ];
+
+      renderHook(() => useSocketRoom({ ...defaultOptions, initialParticipants }));
+
+      act(() => getSocketHandler("room:user_left")?.({ userId: "u1" }));
+
+      const { participants } = useChatStore.getState();
+      expect(participants).toHaveLength(1);
+      expect(participants[0].userId).toBe("u2");
+    });
+
+    it("room:host_changed イベントで isHost が正しく更新される", () => {
+      // initialParticipants で設定する（setState だとマウント時の setInitial に上書きされるため）
+      const initialParticipants = [
+        { userId: "u1", isHost: true, user: { username: "Alice", iconUrl: null, avgRating: null } },
+        { userId: "u2", isHost: false, user: { username: "Bob", iconUrl: null, avgRating: null } },
+      ];
+
+      renderHook(() => useSocketRoom({ ...defaultOptions, initialParticipants }));
+
+      act(() => getSocketHandler("room:host_changed")?.({ newHostId: "u2" }));
+
+      const { participants } = useChatStore.getState();
+      expect(participants.find((p) => p.userId === "u1")?.isHost).toBe(false);
+      expect(participants.find((p) => p.userId === "u2")?.isHost).toBe(true);
+    });
+  });
+
+  describe("クリーンアップ", () => {
+    it("アンマウント時に room:leave を emit する", () => {
+      const { unmount } = renderHook(() => useSocketRoom(defaultOptions));
+      unmount();
+      expect(mockSocket.emit).toHaveBeenCalledWith("room:leave", { roomId: "room-1" });
+    });
+
+    it("アンマウント時にすべてのイベントリスナーが off される", () => {
+      const { unmount } = renderHook(() => useSocketRoom(defaultOptions));
+      unmount();
+
+      const offEvents = mockSocket.off.mock.calls.map(([e]) => e);
+      expect(offEvents).toContain("connect");
+      expect(offEvents).toContain("connect_error");
+      expect(offEvents).toContain("reconnect_failed");
+      expect(offEvents).toContain("disconnect");
+      expect(offEvents).toContain("chat:message");
+      expect(offEvents).toContain("room:user_joined");
+      expect(offEvents).toContain("room:user_left");
+      expect(offEvents).toContain("room:host_changed");
+      expect(offEvents).toContain("room:closed");
+    });
+
+    it("アンマウント時に disconnectSocket が呼ばれる", () => {
+      const { unmount } = renderHook(() => useSocketRoom(defaultOptions));
+      unmount();
+      expect(mockDisconnectSocket).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/app/rooms/[roomId]/chat/useSocketRoom.ts
+++ b/app/rooms/[roomId]/chat/useSocketRoom.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect } from "react";
+import { getSocket, disconnectSocket } from "@/lib/socket";
+import { useChatStore, type ChatMessage, type Participant } from "@/lib/stores/chatStore";
+
+type UseSocketRoomOptions = {
+  roomId: string;
+  initialMessages: ChatMessage[];
+  initialParticipants: Participant[];
+};
+
+export function useSocketRoom({ roomId, initialMessages, initialParticipants }: UseSocketRoomOptions): void {
+  const { setInitial, addMessage, addParticipant, removeParticipant, setConnectionStatus } =
+    useChatStore();
+
+  // 初期データをストアへ注入
+  useEffect(() => {
+    setInitial(initialMessages, initialParticipants);
+  }, [initialMessages, initialParticipants, setInitial]);
+
+  // Socket 接続ライフサイクル
+  useEffect(() => {
+    const socket = getSocket();
+
+    setConnectionStatus("connecting");
+    socket.connect();
+
+    socket.on("connect", () => {
+      setConnectionStatus("connected");
+      socket.emit("room:join", { roomId });
+    });
+
+    socket.on("connect_error", () => {
+      setConnectionStatus("error");
+    });
+
+    socket.on("reconnect_failed", () => {
+      setConnectionStatus("failed");
+    });
+
+    socket.on("disconnect", () => {
+      setConnectionStatus("disconnected");
+    });
+
+    socket.on("chat:message", (msg: ChatMessage) => {
+      addMessage({ ...msg, createdAt: new Date(msg.createdAt) });
+    });
+
+    socket.on(
+      "room:user_joined",
+      (p: { userId: string; username: string; iconUrl: string | null; avgRating: number }) => {
+        addParticipant(p);
+      }
+    );
+
+    socket.on("room:user_left", ({ userId }: { userId: string }) => {
+      removeParticipant(userId);
+    });
+
+    socket.on("room:host_changed", ({ newHostId }: { newHostId: string }) => {
+      useChatStore.setState((state) => ({
+        participants: state.participants.map((p) => ({
+          ...p,
+          isHost: p.userId != null && p.userId === newHostId,
+        })),
+      }));
+    });
+
+    socket.on("room:closed", () => {
+      // 部屋が閉じられたときの処理は page レベルで対応
+    });
+
+    return () => {
+      socket.emit("room:leave", { roomId });
+      socket.off("connect");
+      socket.off("connect_error");
+      socket.off("reconnect_failed");
+      socket.off("disconnect");
+      socket.off("chat:message");
+      socket.off("room:user_joined");
+      socket.off("room:user_left");
+      socket.off("room:host_changed");
+      socket.off("room:closed");
+      disconnectSocket();
+    };
+  }, [roomId, addMessage, addParticipant, removeParticipant, setConnectionStatus]);
+}

--- a/lib/stores/chatStore.ts
+++ b/lib/stores/chatStore.ts
@@ -20,7 +20,7 @@ export type Participant = {
   user: { username: string; iconUrl: string | null; avgRating: number | null } | null;
 };
 
-type ConnectionStatus = "disconnected" | "connecting" | "connected" | "error" | "failed";
+export type ConnectionStatus = "disconnected" | "connecting" | "connected" | "error" | "failed";
 
 type ChatStore = {
   messages: ChatMessage[];


### PR DESCRIPTION
## 概要

`ChatView.tsx`（359行）にSocket接続ライフサイクル・参加者リスト・メッセージ描画が混在していたため、カスタムフックとコンポーネントに分割しView層をシンプルにした。

## 変更内容

| ファイル | 内容 |
|---------|------|
| `useSocketRoom.ts`（新規） | Socket接続の全ライフサイクルをカスタムフックに抽出。`connect`/`disconnect`/`chat:message`/`room:user_joined`/`room:user_left`/`room:host_changed` イベントを管理 |
| `ChatParticipantList.tsx`（新規） | サイドバーの参加者リスト（UserAvatar・ホストクラウン・ゲストバッジ・RatingDisplay）をコンポーネントに分離 |
| `ChatMessageList.tsx`（新規） | メッセージ描画・自動スクロールをコンポーネントに分離 |
| `ChatView.tsx`（変更） | 359行 → 91行にスリム化 |
| `chatStore.ts`（変更） | `ConnectionStatus` 型を `export` に変更 |

## テスト

各ファイルに対応するテストを追加（計40テスト）：
- `useSocketRoom.test.ts`：Socket全イベントハンドラ・クリーンアップを網羅（14テスト）
- `ChatParticipantList.test.tsx`：ホストクラウン・ゲストバッジ・自分の参加者識別など（13テスト）
- `ChatMessageList.test.tsx`：システムメッセージ・ユーザーバブル・ゲストバッジ・空状態など（13テスト）

Closes #117