### PR TITLE
fix: 部屋一覧カードの高さがタグ・説明なしで小さくなる (#127)

### DIFF
--- a/components/ui/RoomCard.test.tsx
+++ b/components/ui/RoomCard.test.tsx
@@ -83,4 +83,15 @@ describe("RoomCard", () => {
     const link = screen.getByRole("link");
     expect(link).toHaveAttribute("href", "/rooms/room-1");
   });
+
+  it("説明・タグなしでも card-body コンテナが DOM に存在する", () => {
+    render(<RoomCard room={{ ...mockRoom, description: null, playStyleTags: [] }} />);
+    expect(screen.getByTestId("card-body")).toBeInTheDocument();
+  });
+
+  it("説明・タグなしのとき説明文とタグが表示されない", () => {
+    render(<RoomCard room={{ ...mockRoom, description: null, playStyleTags: [] }} />);
+    expect(screen.queryByText("説明文")).not.toBeInTheDocument();
+    expect(screen.queryByText("ガチ")).not.toBeInTheDocument();
+  });
 });

--- a/components/ui/RoomCard.tsx
+++ b/components/ui/RoomCard.tsx
@@ -92,20 +92,21 @@ export const RoomCard = memo(function RoomCard({ room }: Props) {
         >
           {room.title}
         </h3>
-        {room.description && (
-          <p className="mt-1 text-sm line-clamp-1 leading-snug" style={{ color: "var(--text-secondary)" }}>
-            {room.description}
-          </p>
-        )}
-
-        {/* Tags */}
-        {room.playStyleTags.length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-1">
-            {room.playStyleTags.map((tag) => (
-              <PlayStyleTag key={tag.id} tag={tag} size="sm" />
-            ))}
-          </div>
-        )}
+        {/* Description + Tags: min-h でタグ・説明なしでもカード高さを統一 */}
+        <div className="min-h-[52px]" data-testid="card-body">
+          {room.description && (
+            <p className="mt-1 text-sm line-clamp-1 leading-snug" style={{ color: "var(--text-secondary)" }}>
+              {room.description}
+            </p>
+          )}
+          {room.playStyleTags.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1">
+              {room.playStyleTags.map((tag) => (
+                <PlayStyleTag key={tag.id} tag={tag} size="sm" />
+              ))}
+            </div>
+          )}
+        </div>
 
         {/* Host */}
         <div className="mt-3 flex items-center gap-2 border-t pt-3" style={{ borderColor: "var(--border)" }}>


### PR DESCRIPTION
## 概要

- `RoomCard` の description + tags エリアを `min-h-[52px]` のラッパー div で囲み、タグ・説明の有無にかかわらずカード高さを統一した
- 条件レンダリングの表示ロジックは変更なし。コンテナに最小高を持たせるだけの最小変更

## 変更ファイル

- `components/ui/RoomCard.tsx` — ラッパー `div.min-h-[52px]` を追加
- `components/ui/RoomCard.test.tsx` — 説明・タグなし時のテストケース 2 件追加

## テスト

- 既存テスト 10 件 + 新規テスト 2 件、全件パス
- `pnpm lint` エラーなし

Closes #127