### PR TITLE
feat: 部屋解散確認ダイアログをカスタムモーダルに変更 (#128)

### DIFF
--- a/app/rooms/[roomId]/RoomActions.tsx
+++ b/app/rooms/[roomId]/RoomActions.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { DoorOpen, SignOut, CircleNotch, Trash } from "@phosphor-icons/react";
 import { joinRoom, leaveRoom, closeRoom } from "@/lib/api/rooms";
+import { ConfirmModal } from "@/components/ui/ConfirmModal";
 
 type Props = {
   roomId: string;
@@ -17,6 +19,7 @@ type Props = {
 export function RoomActions({ roomId, isParticipant, isHost, isGuest, status, onInviteJoinClick }: Props) {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
   const joinMutation = useMutation({
     mutationFn: () => joinRoom(roomId),
@@ -107,10 +110,7 @@ export function RoomActions({ roomId, isParticipant, isHost, isGuest, status, on
         </button>
         {isHost && (
           <button
-            onClick={() => {
-              if (!window.confirm("本当に部屋を解散しますか？この操作は取り消せません。")) return;
-              closeMutation.mutate();
-            }}
+            onClick={() => setIsConfirmOpen(true)}
             disabled={closeMutation.isPending}
             className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-red-500/30 px-4 py-3 text-sm font-medium text-red-400 transition-all hover:bg-red-500/10 active:scale-[0.97] disabled:opacity-50 disabled:cursor-not-allowed"
             style={{ backgroundColor: "rgba(239,68,68,0.05)" }}
@@ -133,6 +133,19 @@ export function RoomActions({ roomId, isParticipant, isHost, isGuest, status, on
         <p className="text-center text-xs animate-slide-in-bottom" style={{ color: "#f87171" }}>
           {closeMutation.error.message}
         </p>
+      )}
+      {isConfirmOpen && (
+        <ConfirmModal
+          title="部屋を解散しますか？"
+          description="この操作は取り消せません。"
+          confirmLabel="解散する"
+          isPending={closeMutation.isPending}
+          onConfirm={() => {
+            closeMutation.mutate();
+            setIsConfirmOpen(false);
+          }}
+          onCancel={() => setIsConfirmOpen(false)}
+        />
       )}
     </div>
   );

--- a/components/ui/ConfirmModal.tsx
+++ b/components/ui/ConfirmModal.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { CircleNotch } from "@phosphor-icons/react";
+
+type Props = {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isPending?: boolean;
+};
+
+export function ConfirmModal({ title, description, confirmLabel, onConfirm, onCancel, isPending }: Props) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4 animate-fade-in"
+      onClick={onCancel}
+    >
+      <div
+        className="w-full max-w-sm rounded-2xl border p-6 space-y-5 animate-scale-in"
+        style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="space-y-1">
+          <h2 className="text-lg font-bold" style={{ color: "var(--text-primary)" }}>
+            {title}
+          </h2>
+          <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+            {description}
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            disabled={isPending}
+            className="flex flex-1 items-center justify-center rounded-xl border px-4 py-3 text-sm font-medium transition-all hover:opacity-80 active:scale-[0.97] disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{ borderColor: "var(--border)", color: "var(--text-secondary)", backgroundColor: "var(--bg-card)" }}
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isPending}
+            className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-red-500/30 px-4 py-3 text-sm font-medium text-red-400 transition-all hover:bg-red-500/10 active:scale-[0.97] disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{ backgroundColor: "rgba(239,68,68,0.05)" }}
+          >
+            {isPending ? <CircleNotch className="h-4 w-4 animate-spin" /> : null}
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

`window.confirm()` によるネイティブブラウザダイアログを、アプリのダーク×パープルテーマに沿ったカスタムモーダルに置き換えます。

## 変更内容

- `components/ui/ConfirmModal.tsx` を新規作成（汎用確認モーダル）
- `app/rooms/[roomId]/RoomActions.tsx` の `window.confirm()` を `ConfirmModal` に差し替え

## 動作

- 解散ボタンクリック → アプリ内モーダルが表示される
- 「キャンセル」 → モーダルが閉じ、部屋は解散されない
- 「解散する」 → 部屋が解散され `/rooms` にリダイレクト（既存動作を維持）
- モーダル外クリックでキャンセル
- API 通信中はスピナー表示＆ボタン無効化

Closes #128