### PR TITLE
fix: 全画面でログイン必須化 + ゲスト・招待リンク例外対応

### DIFF
--- a/app/rooms/current/chat/page.test.tsx
+++ b/app/rooms/current/chat/page.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/auth", () => ({ auth: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn().mockImplementation(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+}));
+vi.mock("next/headers", () => ({ cookies: vi.fn() }));
+vi.mock("@/lib/prisma", () => ({
+  prisma: { roomParticipant: { findFirst: vi.fn() } },
+}));
+
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
+import { prisma } from "@/lib/prisma";
+import CurrentRoomChatPage from "./page";
+
+const mockAuth = vi.mocked(auth);
+const mockRedirect = vi.mocked(redirect);
+const mockCookies = vi.mocked(cookies);
+const mockFindFirst = vi.mocked(prisma.roomParticipant.findFirst);
+
+function setupCookies(guestSessionId: string | null) {
+  mockCookies.mockResolvedValue({
+    get: vi.fn().mockReturnValue(guestSessionId ? { value: guestSessionId } : undefined),
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue(null);
+  setupCookies(null);
+});
+
+describe("CurrentRoomChatPage", () => {
+  describe("認証チェック", () => {
+    it("userId・guestSessionId が両方なければ /login へリダイレクトする", async () => {
+      await expect(CurrentRoomChatPage()).rejects.toThrow("NEXT_REDIRECT");
+      expect(mockRedirect).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  describe("ログイン済みユーザー", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    });
+
+    it("参加中の部屋がある場合 /rooms/{roomId}/chat へリダイレクトする", async () => {
+      mockFindFirst.mockResolvedValue({ roomId: "room-abc" } as never);
+      await expect(CurrentRoomChatPage()).rejects.toThrow("NEXT_REDIRECT");
+      expect(mockRedirect).toHaveBeenCalledWith("/rooms/room-abc/chat");
+    });
+
+    it("参加中の部屋がない場合「参加中の部屋がありません」を表示する", async () => {
+      mockFindFirst.mockResolvedValue(null);
+      render(await CurrentRoomChatPage());
+      expect(screen.getByText("参加中の部屋がありません")).toBeTruthy();
+    });
+
+    it("userId で roomParticipant を検索する", async () => {
+      mockFindFirst.mockResolvedValue(null);
+      await CurrentRoomChatPage();
+      expect(mockFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ userId: "user-1" }) })
+      );
+    });
+  });
+
+  describe("ゲストセッション", () => {
+    beforeEach(() => {
+      setupCookies("guest_abc123");
+    });
+
+    it("参加中の部屋がある場合 /rooms/{roomId}/chat へリダイレクトする", async () => {
+      mockFindFirst.mockResolvedValue({ roomId: "room-abc" } as never);
+      await expect(CurrentRoomChatPage()).rejects.toThrow("NEXT_REDIRECT");
+      expect(mockRedirect).toHaveBeenCalledWith("/rooms/room-abc/chat");
+    });
+
+    it("参加中の部屋がない場合「参加中の部屋がありません」を表示する", async () => {
+      mockFindFirst.mockResolvedValue(null);
+      render(await CurrentRoomChatPage());
+      expect(screen.getByText("参加中の部屋がありません")).toBeTruthy();
+    });
+
+    it("guestSessionId で roomParticipant を検索する", async () => {
+      mockFindFirst.mockResolvedValue(null);
+      await CurrentRoomChatPage();
+      expect(mockFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ guestSessionId: "guest_abc123" }),
+        })
+      );
+    });
+  });
+});

--- a/app/rooms/current/chat/page.tsx
+++ b/app/rooms/current/chat/page.tsx
@@ -1,15 +1,22 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
+import { cookies } from "next/headers";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 
 export default async function CurrentRoomChatPage() {
   const session = await auth();
   const userId = session?.user?.id;
-  if (!userId) redirect("/login");
+
+  const cookieStore = await cookies();
+  const guestSessionId = cookieStore.get("quest_link_guest_session")?.value ?? null;
+
+  if (!userId && !guestSessionId) redirect("/login");
 
   const participant = await prisma.roomParticipant.findFirst({
-    where: { userId, leftAt: null, room: { status: { not: "closed" } } },
+    where: userId
+      ? { userId, leftAt: null, room: { status: { not: "closed" } } }
+      : { guestSessionId, leftAt: null, room: { status: { not: "closed" } } },
     select: { roomId: true },
   });
 

--- a/app/rooms/current/page.test.tsx
+++ b/app/rooms/current/page.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/auth", () => ({ auth: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn().mockImplementation(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+}));
+vi.mock("next/headers", () => ({ cookies: vi.fn() }));
+vi.mock("@/lib/prisma", () => ({
+  prisma: { roomParticipant: { findFirst: vi.fn() } },
+}));
+
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
+import { prisma } from "@/lib/prisma";
+import CurrentRoomPage from "./page";
+
+const mockAuth = vi.mocked(auth);
+const mockRedirect = vi.mocked(redirect);
+const mockCookies = vi.mocked(cookies);
+const mockFindFirst = vi.mocked(prisma.roomParticipant.findFirst);
+
+function setupCookies(guestSessionId: string | null) {
+  mockCookies.mockResolvedValue({
+    get: vi.fn().mockReturnValue(guestSessionId ? { value: guestSessionId } : undefined),
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue(null);
+  setupCookies(null);
+});
+
+describe("CurrentRoomPage", () => {
+  describe("認証チェック", () => {
+    it("userId・guestSessionId が両方なければ /login へリダイレクトする", async () => {
+      await expect(CurrentRoomPage()).rejects.toThrow("NEXT_REDIRECT");
+      expect(mockRedirect).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  describe("ログイン済みユーザー", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    });
+
+    it("参加中の部屋がある場合 /rooms/{roomId} へリダイレクトする", async () => {
+      mockFindFirst.mockResolvedValue({ roomId: "room-abc" } as never);
+      await expect(CurrentRoomPage()).rejects.toThrow("NEXT_REDIRECT");
+      expect(mockRedirect).toHaveBeenCalledWith("/rooms/room-abc");
+    });
+
+    it("参加中の部屋がない場合「参加中の部屋がありません」を表示する", async () => {
+      mockFindFirst.mockResolvedValue(null);
+      render(await CurrentRoomPage());
+      expect(screen.getByText("参加中の部屋がありません")).toBeTruthy();
+    });
+
+    it("userId で roomParticipant を検索する", async () => {
+      mockFindFirst.mockResolvedValue(null);
+      await CurrentRoomPage();
+      expect(mockFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ userId: "user-1" }) })
+      );
+    });
+  });
+
+  describe("ゲストセッション", () => {
+    beforeEach(() => {
+      setupCookies("guest_abc123");
+    });
+
+    it("参加中の部屋がある場合 /rooms/{roomId} へリダイレクトする", async () => {
+      mockFindFirst.mockResolvedValue({ roomId: "room-abc" } as never);
+      await expect(CurrentRoomPage()).rejects.toThrow("NEXT_REDIRECT");
+      expect(mockRedirect).toHaveBeenCalledWith("/rooms/room-abc");
+    });
+
+    it("参加中の部屋がない場合「参加中の部屋がありません」を表示する", async () => {
+      mockFindFirst.mockResolvedValue(null);
+      render(await CurrentRoomPage());
+      expect(screen.getByText("参加中の部屋がありません")).toBeTruthy();
+    });
+
+    it("guestSessionId で roomParticipant を検索する", async () => {
+      mockFindFirst.mockResolvedValue(null);
+      await CurrentRoomPage();
+      expect(mockFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ guestSessionId: "guest_abc123" }),
+        })
+      );
+    });
+  });
+});

--- a/app/rooms/current/page.tsx
+++ b/app/rooms/current/page.tsx
@@ -1,15 +1,22 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
+import { cookies } from "next/headers";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 
 export default async function CurrentRoomPage() {
   const session = await auth();
   const userId = session?.user?.id;
-  if (!userId) redirect("/login");
+
+  const cookieStore = await cookies();
+  const guestSessionId = cookieStore.get("quest_link_guest_session")?.value ?? null;
+
+  if (!userId && !guestSessionId) redirect("/login");
 
   const participant = await prisma.roomParticipant.findFirst({
-    where: { userId, leftAt: null, room: { status: { not: "closed" } } },
+    where: userId
+      ? { userId, leftAt: null, room: { status: { not: "closed" } } }
+      : { guestSessionId, leftAt: null, room: { status: { not: "closed" } } },
     select: { roomId: true },
   });
 

--- a/auth.config.test.ts
+++ b/auth.config.test.ts
@@ -51,13 +51,39 @@ describe("authorized コールバック", () => {
       expect(result).toBe(false);
     });
 
-    it("/rooms/abc-123 に未ログインでアクセスすると false を返す", async () => {
+    it("/rooms/abc-123（inviteToken なし）に未ログインでアクセスすると false を返す", async () => {
       const result = await authorized({ auth: null, request: makeRequest("/rooms/abc-123") });
       expect(result).toBe(false);
     });
 
     it("/users/me に未ログインでアクセスすると false を返す", async () => {
       const result = await authorized({ auth: null, request: makeRequest("/users/me") });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("招待リンク経由の部屋詳細（未ログインアクセス許可）", () => {
+    it("inviteToken あり → 未ログインでも true を返す", async () => {
+      const result = await authorized({
+        auth: null,
+        request: makeRequest("/rooms/abc-123", { inviteToken: "tok" }),
+      });
+      expect(result).toBe(true);
+    });
+
+    it("inviteToken + guestFlow=true → 未ログインでも true を返す", async () => {
+      const result = await authorized({
+        auth: null,
+        request: makeRequest("/rooms/abc-123", { inviteToken: "tok", guestFlow: "true" }),
+      });
+      expect(result).toBe(true);
+    });
+
+    it("サブパス /rooms/abc-123/chat は inviteToken があっても未ログインは false を返す", async () => {
+      const result = await authorized({
+        auth: null,
+        request: makeRequest("/rooms/abc-123/chat", { inviteToken: "tok" }),
+      });
       expect(result).toBe(false);
     });
   });

--- a/auth.config.test.ts
+++ b/auth.config.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import type { Session } from "next-auth";
+import type { NextRequest } from "next/server";
+import { authConfig } from "./auth.config";
+
+const authorized = authConfig.callbacks!.authorized!;
+
+function makeRequest(pathname: string, params: Record<string, string> = {}) {
+  const url = new URL(`http://localhost${pathname}`);
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return { nextUrl: url } as unknown as NextRequest;
+}
+
+function makeAuth(needsProfileSetup = false): Session {
+  return {
+    user: {
+      id: "user-1",
+      name: "Test User",
+      email: "test@example.com",
+      username: "testuser",
+      iconUrl: null,
+      avgRating: 0,
+      needsProfileSetup,
+    },
+    expires: new Date(Date.now() + 3600 * 1000).toISOString(),
+  };
+}
+
+describe("authorized コールバック", () => {
+  describe("ログインページ (/login)", () => {
+    it("未ログインの場合 true を返す", async () => {
+      const result = await authorized({ auth: null, request: makeRequest("/login") });
+      expect(result).toBe(true);
+    });
+
+    it("ログイン済みの場合 / へリダイレクトする", async () => {
+      const result = await authorized({ auth: makeAuth(), request: makeRequest("/login") });
+      expect(result).toBeInstanceOf(Response);
+      expect((result as Response).headers.get("location")).toBe("http://localhost/");
+    });
+  });
+
+  describe("未ログイン保護（全画面ログイン必須化）", () => {
+    it("/ に未ログインでアクセスすると false を返す", async () => {
+      const result = await authorized({ auth: null, request: makeRequest("/") });
+      expect(result).toBe(false);
+    });
+
+    it("/rooms に未ログインでアクセスすると false を返す", async () => {
+      const result = await authorized({ auth: null, request: makeRequest("/rooms") });
+      expect(result).toBe(false);
+    });
+
+    it("/rooms/abc-123 に未ログインでアクセスすると false を返す", async () => {
+      const result = await authorized({ auth: null, request: makeRequest("/rooms/abc-123") });
+      expect(result).toBe(false);
+    });
+
+    it("/users/me に未ログインでアクセスすると false を返す", async () => {
+      const result = await authorized({ auth: null, request: makeRequest("/users/me") });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("ログイン済み・通常アクセス", () => {
+    it("/ にログイン済みでアクセスすると true を返す", async () => {
+      const result = await authorized({ auth: makeAuth(), request: makeRequest("/") });
+      expect(result).toBe(true);
+    });
+
+    it("/rooms にログイン済みでアクセスすると true を返す", async () => {
+      const result = await authorized({ auth: makeAuth(), request: makeRequest("/rooms") });
+      expect(result).toBe(true);
+    });
+
+    it("/rooms/abc-123 にログイン済みでアクセスすると true を返す", async () => {
+      const result = await authorized({ auth: makeAuth(), request: makeRequest("/rooms/abc-123") });
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("プロフィール未設定フロー (needsProfileSetup=true)", () => {
+    it("通常ページへのアクセスは /onboarding へリダイレクトする", async () => {
+      const result = await authorized({ auth: makeAuth(true), request: makeRequest("/rooms") });
+      expect(result).toBeInstanceOf(Response);
+      expect((result as Response).headers.get("location")).toBe("http://localhost/onboarding");
+    });
+
+    it("/onboarding 自体は needsProfileSetup=true でもアクセス可能", async () => {
+      const result = await authorized({ auth: makeAuth(true), request: makeRequest("/onboarding") });
+      expect(result).toBe(true);
+    });
+
+    it("招待URL + error なし → error=new_user 付きで同URLへリダイレクトする", async () => {
+      const result = await authorized({
+        auth: makeAuth(true),
+        request: makeRequest("/rooms/abc", { inviteToken: "xxx" }),
+      });
+      expect(result).toBeInstanceOf(Response);
+      const location = new URL((result as Response).headers.get("location")!);
+      expect(location.pathname).toBe("/rooms/abc");
+      expect(location.searchParams.get("inviteToken")).toBe("xxx");
+      expect(location.searchParams.get("error")).toBe("new_user");
+    });
+
+    it("招待URL + error=new_user あり → true を返す（無限ループ防止）", async () => {
+      const result = await authorized({
+        auth: makeAuth(true),
+        request: makeRequest("/rooms/abc", { inviteToken: "xxx", error: "new_user" }),
+      });
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/auth.config.test.ts
+++ b/auth.config.test.ts
@@ -147,6 +147,30 @@ describe("authorized コールバック", () => {
       });
       expect(result).toBe(false);
     });
+
+    it("/rooms/new は inviteToken があっても false を返す", async () => {
+      const result = await authorized({
+        auth: null,
+        request: makeRequest("/rooms/new", { inviteToken: "tok" }),
+      });
+      expect(result).toBe(false);
+    });
+
+    it("/rooms/current にゲストセッションがあれば未ログインでも true を返す", async () => {
+      const result = await authorized({
+        auth: null,
+        request: makeRequest("/rooms/current", {}, guestCookie),
+      });
+      expect(result).toBe(true);
+    });
+
+    it("/rooms/current/chat にゲストセッションがあれば未ログインでも true を返す", async () => {
+      const result = await authorized({
+        auth: null,
+        request: makeRequest("/rooms/current/chat", {}, guestCookie),
+      });
+      expect(result).toBe(true);
+    });
   });
 
   describe("ログイン済み・通常アクセス", () => {

--- a/auth.config.test.ts
+++ b/auth.config.test.ts
@@ -79,12 +79,28 @@ describe("authorized コールバック", () => {
       expect(result).toBe(true);
     });
 
-    it("サブパス /rooms/abc-123/chat は inviteToken があっても未ログインは false を返す", async () => {
+    it("サブパス /rooms/abc-123/chat は inviteToken があれば未ログインでも true を返す", async () => {
       const result = await authorized({
         auth: null,
         request: makeRequest("/rooms/abc-123/chat", { inviteToken: "tok" }),
       });
-      expect(result).toBe(false);
+      expect(result).toBe(true);
+    });
+
+    it("サブパス /rooms/abc-123/chat は inviteToken なしでも未ログインで true を返す", async () => {
+      const result = await authorized({
+        auth: null,
+        request: makeRequest("/rooms/abc-123/chat"),
+      });
+      expect(result).toBe(true);
+    });
+
+    it("サブパス /rooms/abc-123/ratings は未ログインでも true を返す", async () => {
+      const result = await authorized({
+        auth: null,
+        request: makeRequest("/rooms/abc-123/ratings"),
+      });
+      expect(result).toBe(true);
     });
   });
 

--- a/auth.config.test.ts
+++ b/auth.config.test.ts
@@ -139,6 +139,14 @@ describe("authorized コールバック", () => {
       });
       expect(result).toBe(false);
     });
+
+    it("/rooms/new はゲストセッションがあっても false を返す", async () => {
+      const result = await authorized({
+        auth: null,
+        request: makeRequest("/rooms/new", {}, guestCookie),
+      });
+      expect(result).toBe(false);
+    });
   });
 
   describe("ログイン済み・通常アクセス", () => {

--- a/auth.config.test.ts
+++ b/auth.config.test.ts
@@ -5,10 +5,19 @@ import { authConfig } from "./auth.config";
 
 const authorized = authConfig.callbacks!.authorized!;
 
-function makeRequest(pathname: string, params: Record<string, string> = {}) {
+function makeRequest(
+  pathname: string,
+  params: Record<string, string> = {},
+  cookieMap: Record<string, string> = {}
+) {
   const url = new URL(`http://localhost${pathname}`);
   Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
-  return { nextUrl: url } as unknown as NextRequest;
+  return {
+    nextUrl: url,
+    cookies: {
+      get: (name: string) => (cookieMap[name] ? { value: cookieMap[name] } : undefined),
+    },
+  } as unknown as NextRequest;
 }
 
 function makeAuth(needsProfileSetup = false): Session {
@@ -79,28 +88,56 @@ describe("authorized コールバック", () => {
       expect(result).toBe(true);
     });
 
-    it("サブパス /rooms/abc-123/chat は inviteToken があれば未ログインでも true を返す", async () => {
+    it("サブパス /rooms/abc-123/chat は inviteToken があっても未ログインは false を返す", async () => {
       const result = await authorized({
         auth: null,
         request: makeRequest("/rooms/abc-123/chat", { inviteToken: "tok" }),
       });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("ゲストセッション経由のアクセス許可", () => {
+    const guestCookie = { quest_link_guest_session: "guest_abc123" };
+
+    it("/rooms/abc-123 にゲストセッションがあれば未ログインでも true を返す", async () => {
+      const result = await authorized({
+        auth: null,
+        request: makeRequest("/rooms/abc-123", {}, guestCookie),
+      });
       expect(result).toBe(true);
     });
 
-    it("サブパス /rooms/abc-123/chat は inviteToken なしでも未ログインで true を返す", async () => {
+    it("/rooms/abc-123/chat にゲストセッションがあれば未ログインでも true を返す", async () => {
+      const result = await authorized({
+        auth: null,
+        request: makeRequest("/rooms/abc-123/chat", {}, guestCookie),
+      });
+      expect(result).toBe(true);
+    });
+
+    it("/rooms/abc-123/ratings にゲストセッションがあれば未ログインでも true を返す", async () => {
+      const result = await authorized({
+        auth: null,
+        request: makeRequest("/rooms/abc-123/ratings", {}, guestCookie),
+      });
+      expect(result).toBe(true);
+    });
+
+    it("/rooms/abc-123/chat にゲストセッションなし・inviteToken なしは false を返す", async () => {
       const result = await authorized({
         auth: null,
         request: makeRequest("/rooms/abc-123/chat"),
       });
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
 
-    it("サブパス /rooms/abc-123/ratings は未ログインでも true を返す", async () => {
+    it("/rooms/abc-123/chat は inviteToken のみでは false を返す（サブパスは inviteToken 不可）", async () => {
       const result = await authorized({
         auth: null,
-        request: makeRequest("/rooms/abc-123/ratings"),
+        request: makeRequest("/rooms/abc-123/chat", { inviteToken: "tok" }),
       });
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
   });
 

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -34,12 +34,6 @@ export const authConfig = {
         return true;
       }
 
-      const isPublicPage =
-        pathname === "/" ||
-        pathname === "/rooms" ||
-        pathname.startsWith("/rooms/");
-      if (!isLoggedIn && isPublicPage) return true;
-
       if (!isLoggedIn) return false;
 
       // 初回ログイン未設定 → プロフィール設定画面へ強制

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -39,7 +39,13 @@ export const authConfig = {
         pathname.startsWith("/rooms/") &&
         !pathname.slice("/rooms/".length).includes("/") &&
         nextUrl.searchParams.has("inviteToken");
-      if (!isLoggedIn && isRoomDetailWithInvite) return true;
+
+      // /rooms/[roomId]/ 配下（/chat, /guest 等）は未ログインでもアクセス可（ゲスト参加フローのため）
+      const isRoomSubPath =
+        pathname.startsWith("/rooms/") &&
+        pathname.slice("/rooms/".length).includes("/");
+
+      if (!isLoggedIn && (isRoomDetailWithInvite || isRoomSubPath)) return true;
 
       if (!isLoggedIn) return false;
 

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -23,7 +23,7 @@ export const authConfig = {
       session.user.needsProfileSetup = (token["needsProfileSetup"] as boolean | undefined) ?? false;
       return session;
     },
-    authorized({ auth, request: { nextUrl } }) {
+    authorized({ auth, request: { nextUrl, cookies } }) {
       const isLoggedIn = !!auth?.user;
       const pathname = nextUrl.pathname;
       const isLoginPage = pathname === "/login";
@@ -34,20 +34,17 @@ export const authConfig = {
         return true;
       }
 
-      // 招待リンク経由の部屋詳細（/rooms/[roomId]?inviteToken=...）は未ログインでもアクセス可
-      const isRoomDetailWithInvite =
-        pathname.startsWith("/rooms/") &&
-        !pathname.slice("/rooms/".length).includes("/") &&
-        nextUrl.searchParams.has("inviteToken");
+      const hasGuestSession = !!cookies.get("quest_link_guest_session");
+      const isRoomPath = pathname.startsWith("/rooms/");
+      const isRoomDetail = isRoomPath && !pathname.slice("/rooms/".length).includes("/");
 
-      // /rooms/[roomId]/ 配下（/chat, /guest 等）は未ログインでもアクセス可（ゲスト参加フローのため）
-      const isRoomSubPath =
-        pathname.startsWith("/rooms/") &&
-        pathname.slice("/rooms/".length).includes("/");
-
-      if (!isLoggedIn && (isRoomDetailWithInvite || isRoomSubPath)) return true;
-
-      if (!isLoggedIn) return false;
+      if (!isLoggedIn) {
+        // ゲストセッションがあれば /rooms/[roomId] 配下すべてアクセス可
+        if (isRoomPath && hasGuestSession) return true;
+        // 招待リンク経由の部屋詳細（サブパスなし）もアクセス可
+        if (isRoomDetail && nextUrl.searchParams.has("inviteToken")) return true;
+        return false;
+      }
 
       // 初回ログイン未設定 → プロフィール設定画面へ強制
       const needsProfileSetup = auth?.user?.needsProfileSetup ?? false;

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -34,6 +34,13 @@ export const authConfig = {
         return true;
       }
 
+      // 招待リンク経由の部屋詳細（/rooms/[roomId]?inviteToken=...）は未ログインでもアクセス可
+      const isRoomDetailWithInvite =
+        pathname.startsWith("/rooms/") &&
+        !pathname.slice("/rooms/".length).includes("/") &&
+        nextUrl.searchParams.has("inviteToken");
+      if (!isLoggedIn && isRoomDetailWithInvite) return true;
+
       if (!isLoggedIn) return false;
 
       // 初回ログイン未設定 → プロフィール設定画面へ強制

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -36,11 +36,13 @@ export const authConfig = {
 
       const hasGuestSession = !!cookies.get("quest_link_guest_session");
       const isRoomPath = pathname.startsWith("/rooms/");
-      const isRoomDetail = isRoomPath && !pathname.slice("/rooms/".length).includes("/");
+      // /rooms/new は部屋作成ページのためゲストセッション・招待リンクの対象外
+      const isRoomNew = pathname === "/rooms/new";
+      const isRoomDetail = isRoomPath && !isRoomNew && !pathname.slice("/rooms/".length).includes("/");
 
       if (!isLoggedIn) {
-        // ゲストセッションがあれば /rooms/[roomId] 配下すべてアクセス可
-        if (isRoomPath && hasGuestSession) return true;
+        // ゲストセッションがあれば /rooms/new 以外の /rooms/* すべてアクセス可
+        if (isRoomPath && !isRoomNew && hasGuestSession) return true;
         // 招待リンク経由の部屋詳細（サブパスなし）もアクセス可
         if (isRoomDetail && nextUrl.searchParams.has("inviteToken")) return true;
         return false;

--- a/docs/06_sitemap.md
+++ b/docs/06_sitemap.md
@@ -66,10 +66,10 @@
 | `/rooms/current` | 参加中の部屋リダイレクト | サーバーサイドで参加中の roomId を取得し `/rooms/{roomId}` へリダイレクト。参加中の部屋がない場合は「参加中の部屋がありません」メッセージと「部屋を探す」リンクを表示 | Prisma 直接アクセス |
 | `/rooms/current/chat` | 参加中の部屋チャット | サーバーサイドで参加中の roomId を取得し `/rooms/{roomId}/chat` へリダイレクト。参加中の部屋がない場合は「参加中の部屋がありません」メッセージと「部屋を探す」リンクを表示 | Prisma 直接アクセス（リダイレクト後は `GET /rooms/{roomId}/messages`、WebSocket `chat:send` / `chat:message`） |
 | `/rooms/new` | 部屋作成 | タイトル・ゲーム（IGDB連携検索で選択）・最大人数・説明・タグを入力して部屋を作成 | `GET /play-style-tags`、`GET /games/search`、`POST /rooms` |
-| `/rooms/[roomId]` | 部屋詳細 | 部屋情報・参加者一覧表示、参加 / 退室 / 解散、ホストによる部屋情報編集、SNS シェア、リアルタイム参加者更新（WebSocket）。ログイン済みで自分が参加中の場合は `/rooms/current` へリダイレクト。**`inviteToken` パラメータ付きの招待リンク経由でのアクセスは未ログインでも可**（Modal A 表示） | `GET /rooms/{roomId}`、`POST /rooms/{roomId}/join`、`POST /rooms/{roomId}/leave`、`POST /rooms/{roomId}/close`、`PATCH /rooms/{roomId}`、`POST /rooms/{roomId}/share`、`GET /play-style-tags`（ホスト編集用）、`GET /rooms/current`（自分の参加中部屋かの判定用） |
+| `/rooms/[roomId]` | 部屋詳細 | 部屋情報・参加者一覧表示、参加 / 退室 / 解散、ホストによる部屋情報編集、SNS シェア、リアルタイム参加者更新（WebSocket）。ログイン済みで自分が参加中の場合は `/rooms/current` へリダイレクト。**未ログインでも `inviteToken` パラメータ付き招待リンク経由またはゲストセッション保持時はアクセス可**（Modal A 表示） | `GET /rooms/{roomId}`、`POST /rooms/{roomId}/join`、`POST /rooms/{roomId}/leave`、`POST /rooms/{roomId}/close`、`PATCH /rooms/{roomId}`、`POST /rooms/{roomId}/share`、`GET /play-style-tags`（ホスト編集用）、`GET /rooms/current`（自分の参加中部屋かの判定用） |
 | `/rooms/[roomId]?inviteToken=xxx` | 部屋詳細（招待URL経由） | 招待トークン付きURLで部屋詳細にアクセスした場合の追加モーダル表示。**Modal A（認証誘導）**：未ログイン＋guestFlowなし → 「ログインして参加」「ゲストで参加」ボタン。**Modal A（新規ユーザーエラー）**：OAuth後に新規ユーザーと判定 → 「招待リンクでの新規登録はできません」メッセージ＋「ゲストで参加」「プロフィール設定」ボタン。**Modal B（表示名入力）**：guestFlow=true＋未ログイン → 表示名入力でゲスト参加・チャットへ遷移 | `POST /invite/{inviteToken}/join` |
 | `/rooms/[roomId]/guest` | ゲスト参加フロー（旧） | 募集リンク経由でアクセスした未ログインユーザー向け。表示名（任意）を入力してゲストセッションを発行し、そのまま部屋に参加。ログインを促すボタンも併設 | `POST /auth/guest`、`POST /rooms/{roomId}/join` |
-| `/rooms/[roomId]/chat` | チャット | リアルタイムチャット送受信（WebSocket、ゲスト参加者も利用可）、過去ログのスクロール読み込み（カーソルページネーション） | `GET /rooms/{roomId}/messages`、WebSocket `chat:send` / `chat:message` |
+| `/rooms/[roomId]/chat` | チャット | リアルタイムチャット送受信（WebSocket、ゲスト参加者も利用可）、過去ログのスクロール読み込み（カーソルページネーション）。**ゲストセッション保持時は未ログインでもアクセス可** | `GET /rooms/{roomId}/messages`、WebSocket `chat:send` / `chat:message` |
 | `/rooms/[roomId]/ratings` | セッション評価 | 部屋クローズ後に同室メンバーを評価（スコア・コメント）、評価期限（24時間）表示 | `GET /rooms/{roomId}/pending-ratings`、`POST /ratings` |
 
 ---
@@ -90,7 +90,9 @@
 
 ```
 未ログインでいずれかのページにアクセス
-    └─→ /login へリダイレクト（例外: 招待リンク /rooms/[roomId]?inviteToken=... は通過）
+    └─→ /login へリダイレクト
+        例外1: /rooms/[roomId]?inviteToken=... （招待リンク）は通過
+        例外2: ゲストセッション Cookie 保持時は /rooms/[roomId] 配下すべて通過
 
 ログイン済みユーザー
     └─→ /（トップ）※おすすめゲームカテゴリ上段 + 部屋一覧下段
@@ -186,7 +188,7 @@
 | ver 6.1 | 2026年3月 | ユーザータグ廃止に伴い、オンボーディング・プロフィール・プロフィール編集・他ユーザープロフィール画面からプレイスタイルタグ関連記述を削除 |
 | ver 6.2 | 2026年3月 | オンボーディング画面を5ステップウィザード形式に刷新。ゲーム選択を `GET /games`（全件取得）に変更し `GridGamePicker` コンポーネントで全タイトルをグリッド表示。ヘッダー・ボトムナビを非表示化しロゴのみ表示。`needsProfileSetup` JWT フラグによるリダイレクト制御を追加 |
 | ver 6.3 | 2026年4月 | 招待URL経由の参加フロー刷新。Modal A（認証誘導）・Modal B（表示名入力）の2段階モーダルを実装。招待URL経由の新規OAuthユーザーを招待ページに戻し `error=new_user` でエラー表示。ログインページに招待バナーとゲスト参加リンクを追加 |
-| ver 6.4 | 2026年4月 | 全画面ログイン必須化。`/login` 以外のすべての画面でログインを必須とし、未ログイン時は `/login` へリダイレクト。例外として `inviteToken` パラメータ付きの `/rooms/[roomId]` は未ログインでもアクセス可（招待リンク経由での Modal A 表示のため） |
+| ver 6.4 | 2026年4月 | 全画面ログイン必須化。`/login` 以外のすべての画面でログインを必須とし、未ログイン時は `/login` へリダイレクト。例外: ①`inviteToken` 付き `/rooms/[roomId]` は未ログインでもアクセス可（招待リンク Modal A 表示）、②ゲストセッション Cookie 保持時は `/rooms/[roomId]` 配下すべてアクセス可 |
 
 ---
 

--- a/docs/06_sitemap.md
+++ b/docs/06_sitemap.md
@@ -66,7 +66,7 @@
 | `/rooms/current` | 参加中の部屋リダイレクト | サーバーサイドで参加中の roomId を取得し `/rooms/{roomId}` へリダイレクト。参加中の部屋がない場合は「参加中の部屋がありません」メッセージと「部屋を探す」リンクを表示 | Prisma 直接アクセス |
 | `/rooms/current/chat` | 参加中の部屋チャット | サーバーサイドで参加中の roomId を取得し `/rooms/{roomId}/chat` へリダイレクト。参加中の部屋がない場合は「参加中の部屋がありません」メッセージと「部屋を探す」リンクを表示 | Prisma 直接アクセス（リダイレクト後は `GET /rooms/{roomId}/messages`、WebSocket `chat:send` / `chat:message`） |
 | `/rooms/new` | 部屋作成 | タイトル・ゲーム（IGDB連携検索で選択）・最大人数・説明・タグを入力して部屋を作成 | `GET /play-style-tags`、`GET /games/search`、`POST /rooms` |
-| `/rooms/[roomId]` | 部屋詳細 | 部屋情報・参加者一覧表示、参加 / 退室 / 解散、ホストによる部屋情報編集、SNS シェア、リアルタイム参加者更新（WebSocket）。ログイン済みで自分が参加中の場合は `/rooms/current` へリダイレクト | `GET /rooms/{roomId}`、`POST /rooms/{roomId}/join`、`POST /rooms/{roomId}/leave`、`POST /rooms/{roomId}/close`、`PATCH /rooms/{roomId}`、`POST /rooms/{roomId}/share`、`GET /play-style-tags`（ホスト編集用）、`GET /rooms/current`（自分の参加中部屋かの判定用） |
+| `/rooms/[roomId]` | 部屋詳細 | 部屋情報・参加者一覧表示、参加 / 退室 / 解散、ホストによる部屋情報編集、SNS シェア、リアルタイム参加者更新（WebSocket）。ログイン済みで自分が参加中の場合は `/rooms/current` へリダイレクト。**`inviteToken` パラメータ付きの招待リンク経由でのアクセスは未ログインでも可**（Modal A 表示） | `GET /rooms/{roomId}`、`POST /rooms/{roomId}/join`、`POST /rooms/{roomId}/leave`、`POST /rooms/{roomId}/close`、`PATCH /rooms/{roomId}`、`POST /rooms/{roomId}/share`、`GET /play-style-tags`（ホスト編集用）、`GET /rooms/current`（自分の参加中部屋かの判定用） |
 | `/rooms/[roomId]?inviteToken=xxx` | 部屋詳細（招待URL経由） | 招待トークン付きURLで部屋詳細にアクセスした場合の追加モーダル表示。**Modal A（認証誘導）**：未ログイン＋guestFlowなし → 「ログインして参加」「ゲストで参加」ボタン。**Modal A（新規ユーザーエラー）**：OAuth後に新規ユーザーと判定 → 「招待リンクでの新規登録はできません」メッセージ＋「ゲストで参加」「プロフィール設定」ボタン。**Modal B（表示名入力）**：guestFlow=true＋未ログイン → 表示名入力でゲスト参加・チャットへ遷移 | `POST /invite/{inviteToken}/join` |
 | `/rooms/[roomId]/guest` | ゲスト参加フロー（旧） | 募集リンク経由でアクセスした未ログインユーザー向け。表示名（任意）を入力してゲストセッションを発行し、そのまま部屋に参加。ログインを促すボタンも併設 | `POST /auth/guest`、`POST /rooms/{roomId}/join` |
 | `/rooms/[roomId]/chat` | チャット | リアルタイムチャット送受信（WebSocket、ゲスト参加者も利用可）、過去ログのスクロール読み込み（カーソルページネーション） | `GET /rooms/{roomId}/messages`、WebSocket `chat:send` / `chat:message` |
@@ -90,7 +90,7 @@
 
 ```
 未ログインでいずれかのページにアクセス
-    └─→ /login へリダイレクト
+    └─→ /login へリダイレクト（例外: 招待リンク /rooms/[roomId]?inviteToken=... は通過）
 
 ログイン済みユーザー
     └─→ /（トップ）※おすすめゲームカテゴリ上段 + 部屋一覧下段
@@ -186,7 +186,7 @@
 | ver 6.1 | 2026年3月 | ユーザータグ廃止に伴い、オンボーディング・プロフィール・プロフィール編集・他ユーザープロフィール画面からプレイスタイルタグ関連記述を削除 |
 | ver 6.2 | 2026年3月 | オンボーディング画面を5ステップウィザード形式に刷新。ゲーム選択を `GET /games`（全件取得）に変更し `GridGamePicker` コンポーネントで全タイトルをグリッド表示。ヘッダー・ボトムナビを非表示化しロゴのみ表示。`needsProfileSetup` JWT フラグによるリダイレクト制御を追加 |
 | ver 6.3 | 2026年4月 | 招待URL経由の参加フロー刷新。Modal A（認証誘導）・Modal B（表示名入力）の2段階モーダルを実装。招待URL経由の新規OAuthユーザーを招待ページに戻し `error=new_user` でエラー表示。ログインページに招待バナーとゲスト参加リンクを追加 |
-| ver 6.4 | 2026年4月 | 全画面ログイン必須化。`/login` 以外のすべての画面でログインを必須とし、未ログイン時は `/login` へリダイレクト。「認証不要」だったページ（`/`・`/games`・`/games/[gameId]/rooms`・`/rooms/[roomId]`・`/users/[userId]`）もログイン必須に変更 |
+| ver 6.4 | 2026年4月 | 全画面ログイン必須化。`/login` 以外のすべての画面でログインを必須とし、未ログイン時は `/login` へリダイレクト。例外として `inviteToken` パラメータ付きの `/rooms/[roomId]` は未ログインでもアクセス可（招待リンク経由での Modal A 表示のため） |
 
 ---
 

--- a/docs/06_sitemap.md
+++ b/docs/06_sitemap.md
@@ -1,7 +1,7 @@
 # サイトマップ
 ## ゲーマー向けリアルタイムマッチングプラットフォーム
 
-**ver 6.0 | 2026年3月**
+**ver 6.4 | 2026年4月**
 
 ---
 
@@ -46,7 +46,7 @@
 
 | パス | 画面名 | 主な機能 | 使用 API |
 |------|--------|---------|---------|
-| `/` | トップ | おすすめゲームカテゴリを上段に表示し、部屋一覧を下段に表示するトップページ。ゲームカテゴリを選択すると `/games/{gameId}/rooms` へ遷移。**認証不要**。 | `GET /games/search`（`q` 省略で人気ゲーム一覧取得）、`GET /rooms`（認証不要） |
+| `/` | トップ | おすすめゲームカテゴリを上段に表示し、部屋一覧を下段に表示するトップページ。ゲームカテゴリを選択すると `/games/{gameId}/rooms` へ遷移。 | `GET /games/search`（`q` 省略で人気ゲーム一覧取得）、`GET /rooms` |
 
 ---
 
@@ -54,7 +54,7 @@
 
 | パス | 画面名 | 主な機能 | 使用 API |
 |------|--------|---------|---------|
-| `/games` | ゲーム選択 | マスター登録済みゲームをカード形式（サムネイル＋ゲーム名）でグリッド表示。ゲームを選択すると `/games/{gameId}/rooms` へ遷移。**認証不要**。MVP では20〜30タイトルをフラット表示（ジャンルタブ等の絞り込みは将来対応） | `GET /games/search`（`q` 省略で人気ゲーム一覧取得、認証必要） |
+| `/games` | ゲーム選択 | マスター登録済みゲームをカード形式（サムネイル＋ゲーム名）でグリッド表示。ゲームを選択すると `/games/{gameId}/rooms` へ遷移。MVP では20〜30タイトルをフラット表示（ジャンルタブ等の絞り込みは将来対応） | `GET /games/search`（`q` 省略で人気ゲーム一覧取得） |
 
 ---
 
@@ -62,11 +62,11 @@
 
 | パス | 画面名 | 主な機能 | 使用 API |
 |------|--------|---------|---------|
-| `/games/[gameId]/rooms` | ゲーム別部屋一覧 | 選択したゲームで絞り込んだ部屋を新着順で一覧表示（**認証不要で閲覧可**）。フィルター：プレイスタイルタグ（OR 検索）・空き枠あり/なし（`vacant`）・フリーワード（`q`、部屋名・募集文）。URL パラメータでフィルター条件を保持（ブックマーク・共有可）。ログイン済みかつ参加中の部屋がある場合はヘッダーに「参加中の部屋へ」ボタンを表示 | `GET /rooms`（`gameId` パラメータ付き、認証不要）、`GET /rooms/current`（参加中チェック用、ログイン時のみ） |
+| `/games/[gameId]/rooms` | ゲーム別部屋一覧 | 選択したゲームで絞り込んだ部屋を新着順で一覧表示。フィルター：プレイスタイルタグ（OR 検索）・空き枠あり/なし（`vacant`）・フリーワード（`q`、部屋名・募集文）。URL パラメータでフィルター条件を保持（ブックマーク・共有可）。ログイン済みかつ参加中の部屋がある場合はヘッダーに「参加中の部屋へ」ボタンを表示 | `GET /rooms`（`gameId` パラメータ付き）、`GET /rooms/current`（参加中チェック用） |
 | `/rooms/current` | 参加中の部屋リダイレクト | サーバーサイドで参加中の roomId を取得し `/rooms/{roomId}` へリダイレクト。参加中の部屋がない場合は「参加中の部屋がありません」メッセージと「部屋を探す」リンクを表示 | Prisma 直接アクセス |
 | `/rooms/current/chat` | 参加中の部屋チャット | サーバーサイドで参加中の roomId を取得し `/rooms/{roomId}/chat` へリダイレクト。参加中の部屋がない場合は「参加中の部屋がありません」メッセージと「部屋を探す」リンクを表示 | Prisma 直接アクセス（リダイレクト後は `GET /rooms/{roomId}/messages`、WebSocket `chat:send` / `chat:message`） |
 | `/rooms/new` | 部屋作成 | タイトル・ゲーム（IGDB連携検索で選択）・最大人数・説明・タグを入力して部屋を作成 | `GET /play-style-tags`、`GET /games/search`、`POST /rooms` |
-| `/rooms/[roomId]` | 部屋詳細 | 部屋情報・参加者一覧表示（**認証不要で閲覧可**）、参加 / 退室 / 解散（認証必要）、ホストによる部屋情報編集、SNS シェア、リアルタイム参加者更新（WebSocket）。ログイン済みで自分が参加中の場合は `/rooms/current` へリダイレクト | `GET /rooms/{roomId}`（認証不要）、`POST /rooms/{roomId}/join`、`POST /rooms/{roomId}/leave`、`POST /rooms/{roomId}/close`、`PATCH /rooms/{roomId}`、`POST /rooms/{roomId}/share`、`GET /play-style-tags`（ホスト編集用）、`GET /rooms/current`（自分の参加中部屋かの判定用、ログイン時のみ） |
+| `/rooms/[roomId]` | 部屋詳細 | 部屋情報・参加者一覧表示、参加 / 退室 / 解散、ホストによる部屋情報編集、SNS シェア、リアルタイム参加者更新（WebSocket）。ログイン済みで自分が参加中の場合は `/rooms/current` へリダイレクト | `GET /rooms/{roomId}`、`POST /rooms/{roomId}/join`、`POST /rooms/{roomId}/leave`、`POST /rooms/{roomId}/close`、`PATCH /rooms/{roomId}`、`POST /rooms/{roomId}/share`、`GET /play-style-tags`（ホスト編集用）、`GET /rooms/current`（自分の参加中部屋かの判定用） |
 | `/rooms/[roomId]?inviteToken=xxx` | 部屋詳細（招待URL経由） | 招待トークン付きURLで部屋詳細にアクセスした場合の追加モーダル表示。**Modal A（認証誘導）**：未ログイン＋guestFlowなし → 「ログインして参加」「ゲストで参加」ボタン。**Modal A（新規ユーザーエラー）**：OAuth後に新規ユーザーと判定 → 「招待リンクでの新規登録はできません」メッセージ＋「ゲストで参加」「プロフィール設定」ボタン。**Modal B（表示名入力）**：guestFlow=true＋未ログイン → 表示名入力でゲスト参加・チャットへ遷移 | `POST /invite/{inviteToken}/join` |
 | `/rooms/[roomId]/guest` | ゲスト参加フロー（旧） | 募集リンク経由でアクセスした未ログインユーザー向け。表示名（任意）を入力してゲストセッションを発行し、そのまま部屋に参加。ログインを促すボタンも併設 | `POST /auth/guest`、`POST /rooms/{roomId}/join` |
 | `/rooms/[roomId]/chat` | チャット | リアルタイムチャット送受信（WebSocket、ゲスト参加者も利用可）、過去ログのスクロール読み込み（カーソルページネーション） | `GET /rooms/{roomId}/messages`、WebSocket `chat:send` / `chat:message` |
@@ -82,21 +82,24 @@
 | `/users/me/edit` | プロフィール編集 | ユーザー名・アイコン URL・自己紹介・プレイゲームを編集（ゲームは IGDB 連携検索で選択、最大20件）。Discord Webhook URL の登録、連携済みプロバイダ（Google / X / Discord）の確認・追加・解除も行う | `GET /games/search`、`GET /games/{gameId}`、`PATCH /users/me`、`POST /auth/{provider}/link`、`DELETE /auth/{provider}/unlink` |
 | `/users/me/history` | 参加履歴 | 過去に参加した部屋の一覧をページネーション付きで表示 | `GET /users/me/rooms` |
 | `/users/me/delete` | アカウント削除 | 退会の確認・実行（MVP対象） | （退会 API：未定義、要追加） |
-| `/users/[userId]` | 他ユーザープロフィール | 他ユーザーのユーザー名・アイコン・自己紹介・平均評価・プレイゲーム一覧・受け取った評価一覧を表示（**認証不要**）。評価は完全匿名（評価者非表示） | `GET /users/{userId}`、`GET /users/{userId}/ratings`（いずれも認証不要） |
+| `/users/[userId]` | 他ユーザープロフィール | 他ユーザーのユーザー名・アイコン・自己紹介・平均評価・プレイゲーム一覧・受け取った評価一覧を表示。評価は完全匿名（評価者非表示） | `GET /users/{userId}`、`GET /users/{userId}/ratings` |
 
 ---
 
 ## 画面遷移フロー
 
 ```
-全ユーザー（ログイン状態問わず）
+未ログインでいずれかのページにアクセス
+    └─→ /login へリダイレクト
+
+ログイン済みユーザー
     └─→ /（トップ）※おすすめゲームカテゴリ上段 + 部屋一覧下段
             └─→ ゲームカテゴリ選択 → /games/{gameId}/rooms（ゲーム別部屋一覧）
 
     └─→ /games（ゲーム選択）
             └─→ ゲーム選択 → /games/{gameId}/rooms（ゲーム別部屋一覧）
 
-未ログインで「ログイン」クリック / 要認証操作を実行
+未ログインで「ログイン」クリック / 未ログインによるリダイレクト
     └─→ /login
             └─→ Google / X / Discord 認証
                     └─→ /auth/callback（JWT取得）
@@ -112,7 +115,7 @@
     │       └─→ Prisma で roomId を取得し /rooms/{roomId}/chat へサーバーサイドリダイレクト
     │               └─→ 参加中なし → 「参加中の部屋がありません」メッセージ画面を表示
     │
-    └─→ /rooms/[roomId]（部屋詳細）※認証不要で閲覧可
+    └─→ /rooms/[roomId]（部屋詳細）
             ├─→ ログイン済みの場合: GET /rooms/current で自分の参加中 roomId を確認
             │       └─→ 一致する場合: そのまま部屋詳細を表示（リダイレクトなし）
             ├─→ 招待URL（?inviteToken=xxx）経由でアクセス
@@ -183,6 +186,7 @@
 | ver 6.1 | 2026年3月 | ユーザータグ廃止に伴い、オンボーディング・プロフィール・プロフィール編集・他ユーザープロフィール画面からプレイスタイルタグ関連記述を削除 |
 | ver 6.2 | 2026年3月 | オンボーディング画面を5ステップウィザード形式に刷新。ゲーム選択を `GET /games`（全件取得）に変更し `GridGamePicker` コンポーネントで全タイトルをグリッド表示。ヘッダー・ボトムナビを非表示化しロゴのみ表示。`needsProfileSetup` JWT フラグによるリダイレクト制御を追加 |
 | ver 6.3 | 2026年4月 | 招待URL経由の参加フロー刷新。Modal A（認証誘導）・Modal B（表示名入力）の2段階モーダルを実装。招待URL経由の新規OAuthユーザーを招待ページに戻し `error=new_user` でエラー表示。ログインページに招待バナーとゲスト参加リンクを追加 |
+| ver 6.4 | 2026年4月 | 全画面ログイン必須化。`/login` 以外のすべての画面でログインを必須とし、未ログイン時は `/login` へリダイレクト。「認証不要」だったページ（`/`・`/games`・`/games/[gameId]/rooms`・`/rooms/[roomId]`・`/users/[userId]`）もログイン必須に変更 |
 
 ---
 


### PR DESCRIPTION
## 概要

全画面でログインを必須とし、未ログインユーザーは `/login` へリダイレクトする。
ゲストセッション・招待リンク経由のアクセスについては適切な例外を設けた。

## 変更内容

### 認証ルール（`auth.config.ts`）

| パス | 未ログイン | 招待トークン | ゲストセッション |
|------|:----------:|:------------:|:---------------:|
| `/login` | ✅ 許可 | - | - |
| `/rooms/[roomId]` | ❌ | ✅ 許可 | ✅ 許可 |
| `/rooms/[roomId]/*` | ❌ | ❌ | ✅ 許可 |
| `/rooms/new` | ❌ | ❌ | ❌ |
| その他すべて | ❌ | - | - |

### ページ修正（`app/rooms/current/`）

- `page.tsx` / `chat/page.tsx` でページレベルの `auth()` チェックにゲストセッション（`quest_link_guest_session` Cookie）を考慮。未ログインかつゲストセッションがある場合は `guestSessionId` で参加中の部屋を検索してリダイレクト。

### ドキュメント（`docs/06_sitemap.md` → ver 6.4）

- 全画面での「認証不要」記述を削除
- 招待リンク・ゲストセッション例外を反映

## テスト

- `auth.config.test.ts` — 25件（authorized コールバック全パスを網羅）
- `app/rooms/current/page.test.tsx` — 新規 7件
- `app/rooms/current/chat/page.test.tsx` — 新規 7件

## チェックリスト

- [ ] 未ログインで `/rooms` にアクセスすると `/login` へリダイレクトされる
- [ ] 未ログインで `/rooms/[roomId]` にアクセスすると `/login` へリダイレクトされる
- [ ] 招待リンク（`?inviteToken=xxx`）経由で `/rooms/[roomId]` にアクセスすると Modal A が表示される
- [ ] ゲストセッションがある状態で `/rooms/[roomId]/chat` にアクセスできる
- [ ] ゲストセッションがある状態で `/rooms/current` にアクセスできる
- [ ] ゲストセッションがあっても `/rooms/new` にはアクセスできない
- [ ] ログイン済みの場合は従来通りアクセスできる

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)