### PR TITLE
fix: プロフィール編集後に変更が反映されない・ちらつき・アバター未反映を修正

### DIFF
--- a/app/api/v1/users/me/avatar/route.ts
+++ b/app/api/v1/users/me/avatar/route.ts
@@ -52,10 +52,12 @@ export async function POST(request: Request) {
     data: { publicUrl },
   } = supabase.storage.from(AVATAR_BUCKET).getPublicUrl(path);
 
+  const iconUrl = `${publicUrl}?v=${Date.now()}`;
+
   await prisma.user.update({
     where: { id: session.user.id },
-    data: { iconUrl: publicUrl },
+    data: { iconUrl },
   });
 
-  return NextResponse.json({ data: { iconUrl: publicUrl } });
+  return NextResponse.json({ data: { iconUrl } });
 }

--- a/app/users/me/edit/page.test.tsx
+++ b/app/users/me/edit/page.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
-const mockInvalidateQueries = vi.fn();
+const mockRefetchQueries = vi.fn();
 const mockPush = vi.fn();
 const mockUpdate = vi.fn();
 
 vi.mock("@tanstack/react-query", () => ({
-  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+  useQueryClient: () => ({ refetchQueries: mockRefetchQueries }),
   useQuery: () => ({
     data: {
       username: "テストユーザー",
@@ -59,7 +59,7 @@ import EditProfilePage from "./page";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockInvalidateQueries.mockResolvedValue(undefined);
+  mockRefetchQueries.mockResolvedValue(undefined);
   mockUpdate.mockResolvedValue(undefined);
   vi.stubGlobal("fetch", vi.fn());
 });
@@ -71,7 +71,7 @@ describe("EditProfilePage", () => {
     expect(screen.getByRole("button", { name: "保存する" })).toBeInTheDocument();
   });
 
-  it("保存成功後に ['users', 'me'] クエリのキャッシュが invalidate される", async () => {
+  it("保存成功後に ['users', 'me'] クエリが refetch される", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       json: async () => ({}),
@@ -81,15 +81,15 @@ describe("EditProfilePage", () => {
     fireEvent.click(screen.getByRole("button", { name: "保存する" }));
 
     await waitFor(() => {
-      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ["users", "me"] });
+      expect(mockRefetchQueries).toHaveBeenCalledWith({ queryKey: ["users", "me"] });
     });
   });
 
-  it("invalidateQueries が完了してから /users/me に遷移する", async () => {
-    let resolveInvalidate!: () => void;
-    mockInvalidateQueries.mockReturnValue(
+  it("refetchQueries が完了してから /users/me に遷移する", async () => {
+    let resolveRefetch!: () => void;
+    mockRefetchQueries.mockReturnValue(
       new Promise<void>((resolve) => {
-        resolveInvalidate = resolve;
+        resolveRefetch = resolve;
       })
     );
 
@@ -101,20 +101,20 @@ describe("EditProfilePage", () => {
     render(<EditProfilePage />);
     fireEvent.click(screen.getByRole("button", { name: "保存する" }));
 
-    // invalidateQueries 完了前は router.push が呼ばれない
+    // refetchQueries 完了前は router.push が呼ばれない
     await waitFor(() => {
-      expect(mockInvalidateQueries).toHaveBeenCalled();
+      expect(mockRefetchQueries).toHaveBeenCalled();
     });
     expect(mockPush).not.toHaveBeenCalled();
 
-    resolveInvalidate();
+    resolveRefetch();
 
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith("/users/me");
     });
   });
 
-  it("PATCH API 失敗時は invalidateQueries と router.push が呼ばれない", async () => {
+  it("PATCH API 失敗時は refetchQueries と router.push が呼ばれない", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: false,
       json: async () => ({ error: "ユーザー名が重複しています" }),
@@ -127,7 +127,7 @@ describe("EditProfilePage", () => {
       expect(screen.getByText("ユーザー名が重複しています")).toBeInTheDocument();
     });
 
-    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+    expect(mockRefetchQueries).not.toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
   });
 

--- a/app/users/me/edit/page.test.tsx
+++ b/app/users/me/edit/page.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const mockInvalidateQueries = vi.fn();
+const mockPush = vi.fn();
+const mockUpdate = vi.fn();
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+  useQuery: () => ({
+    data: {
+      username: "テストユーザー",
+      iconUrl: null,
+      bio: "自己紹介",
+      games: [],
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: { user: { username: "テストユーザー", iconUrl: null } },
+    update: mockUpdate,
+    status: "authenticated",
+  }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => <a href={href} {...rest}>{children}</a>,
+}));
+
+vi.mock("@phosphor-icons/react", () => ({
+  ArrowLeft: () => <span />,
+  FloppyDisk: () => <span />,
+  Camera: () => <span />,
+}));
+
+vi.mock("@/components/ui/UserAvatar", () => ({
+  UserAvatar: () => <div data-testid="user-avatar" />,
+}));
+
+vi.mock("@/components/ui/GamePicker", () => ({
+  MultiGamePicker: () => <div data-testid="game-picker" />,
+}));
+
+import EditProfilePage from "./page";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockInvalidateQueries.mockResolvedValue(undefined);
+  mockUpdate.mockResolvedValue(undefined);
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+describe("EditProfilePage", () => {
+  it("ユーザー名フィールド・自己紹介フィールド・保存ボタンが表示される", () => {
+    render(<EditProfilePage />);
+    expect(screen.getAllByRole("textbox")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "保存する" })).toBeInTheDocument();
+  });
+
+  it("保存成功後に ['users', 'me'] クエリのキャッシュが invalidate される", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+
+    render(<EditProfilePage />);
+    fireEvent.click(screen.getByRole("button", { name: "保存する" }));
+
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ["users", "me"] });
+    });
+  });
+
+  it("invalidateQueries が完了してから /users/me に遷移する", async () => {
+    let resolveInvalidate!: () => void;
+    mockInvalidateQueries.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveInvalidate = resolve;
+      })
+    );
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+
+    render(<EditProfilePage />);
+    fireEvent.click(screen.getByRole("button", { name: "保存する" }));
+
+    // invalidateQueries 完了前は router.push が呼ばれない
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalled();
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+
+    resolveInvalidate();
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/users/me");
+    });
+  });
+
+  it("PATCH API 失敗時は invalidateQueries と router.push が呼ばれない", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "ユーザー名が重複しています" }),
+    } as Response);
+
+    render(<EditProfilePage />);
+    fireEvent.click(screen.getByRole("button", { name: "保存する" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("ユーザー名が重複しています")).toBeInTheDocument();
+    });
+
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("保存中はボタンが disabled になる", async () => {
+    let resolveFetch!: () => void;
+    vi.mocked(fetch).mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveFetch = () =>
+          resolve({ ok: true, json: async () => ({}) } as Response);
+      })
+    );
+
+    render(<EditProfilePage />);
+    fireEvent.click(screen.getByRole("button", { name: "保存する" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "保存中..." })).toBeDisabled();
+    });
+
+    resolveFetch();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "保存する" })).not.toBeDisabled();
+    });
+  });
+});

--- a/app/users/me/edit/page.test.tsx
+++ b/app/users/me/edit/page.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
-const mockRefetchQueries = vi.fn();
+const mockInvalidateQueries = vi.fn();
 const mockPush = vi.fn();
 const mockUpdate = vi.fn();
 
 vi.mock("@tanstack/react-query", () => ({
-  useQueryClient: () => ({ refetchQueries: mockRefetchQueries }),
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
   useQuery: () => ({
     data: {
       username: "テストユーザー",
@@ -59,7 +59,7 @@ import EditProfilePage from "./page";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockRefetchQueries.mockResolvedValue(undefined);
+  mockInvalidateQueries.mockResolvedValue(undefined);
   mockUpdate.mockResolvedValue(undefined);
   vi.stubGlobal("fetch", vi.fn());
 });
@@ -71,7 +71,7 @@ describe("EditProfilePage", () => {
     expect(screen.getByRole("button", { name: "保存する" })).toBeInTheDocument();
   });
 
-  it("保存成功後に ['users', 'me'] クエリが refetch される", async () => {
+  it("保存成功後に ['users', 'me'] クエリが invalidate される", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       json: async () => ({}),
@@ -81,18 +81,11 @@ describe("EditProfilePage", () => {
     fireEvent.click(screen.getByRole("button", { name: "保存する" }));
 
     await waitFor(() => {
-      expect(mockRefetchQueries).toHaveBeenCalledWith({ queryKey: ["users", "me"] });
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ["users", "me"] });
     });
   });
 
-  it("refetchQueries が完了してから /users/me に遷移する", async () => {
-    let resolveRefetch!: () => void;
-    mockRefetchQueries.mockReturnValue(
-      new Promise<void>((resolve) => {
-        resolveRefetch = resolve;
-      })
-    );
-
+  it("invalidateQueries の後すぐに /users/me に遷移する", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       json: async () => ({}),
@@ -101,20 +94,13 @@ describe("EditProfilePage", () => {
     render(<EditProfilePage />);
     fireEvent.click(screen.getByRole("button", { name: "保存する" }));
 
-    // refetchQueries 完了前は router.push が呼ばれない
     await waitFor(() => {
-      expect(mockRefetchQueries).toHaveBeenCalled();
-    });
-    expect(mockPush).not.toHaveBeenCalled();
-
-    resolveRefetch();
-
-    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ["users", "me"] });
       expect(mockPush).toHaveBeenCalledWith("/users/me");
     });
   });
 
-  it("PATCH API 失敗時は refetchQueries と router.push が呼ばれない", async () => {
+  it("PATCH API 失敗時は invalidateQueries と router.push が呼ばれない", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: false,
       json: async () => ({ error: "ユーザー名が重複しています" }),
@@ -127,7 +113,7 @@ describe("EditProfilePage", () => {
       expect(screen.getByText("ユーザー名が重複しています")).toBeInTheDocument();
     });
 
-    expect(mockRefetchQueries).not.toHaveBeenCalled();
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
   });
 

--- a/app/users/me/edit/page.tsx
+++ b/app/users/me/edit/page.tsx
@@ -124,7 +124,7 @@ export default function EditProfilePage() {
       }
 
       await update({ username: username.trim() });
-      await queryClient.refetchQueries({ queryKey: ["users", "me"] });
+      queryClient.invalidateQueries({ queryKey: ["users", "me"] });
       router.push("/users/me");
     } catch {
       setError("通信エラーが発生しました。再度お試しください");

--- a/app/users/me/edit/page.tsx
+++ b/app/users/me/edit/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { ArrowLeft, FloppyDisk, Camera } from "@phosphor-icons/react";
 import { type Game } from "@/lib/mock-data";
@@ -27,6 +27,7 @@ async function fetchMyProfile(): Promise<UserProfile> {
 export default function EditProfilePage() {
   const router = useRouter();
   const { data: session, update, status } = useSession();
+  const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { data: profile } = useQuery({
@@ -123,6 +124,7 @@ export default function EditProfilePage() {
       }
 
       await update({ username: username.trim() });
+      await queryClient.invalidateQueries({ queryKey: ["users", "me"] });
       router.push("/users/me");
     } catch {
       setError("通信エラーが発生しました。再度お試しください");

--- a/app/users/me/edit/page.tsx
+++ b/app/users/me/edit/page.tsx
@@ -124,7 +124,7 @@ export default function EditProfilePage() {
       }
 
       await update({ username: username.trim() });
-      await queryClient.invalidateQueries({ queryKey: ["users", "me"] });
+      await queryClient.refetchQueries({ queryKey: ["users", "me"] });
       router.push("/users/me");
     } catch {
       setError("通信エラーが発生しました。再度お試しください");

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -38,12 +38,12 @@ async function fetchMyProfile(): Promise<UserProfile> {
 }
 
 export default function MyProfilePage() {
-  const { data: user, isLoading, isError } = useQuery({
+  const { data: user, isLoading, isFetching, isError } = useQuery({
     queryKey: ["users", "me"],
     queryFn: fetchMyProfile,
   });
 
-  if (isLoading) {
+  if (isLoading || isFetching) {
     return (
       <div className="mx-auto max-w-3xl pb-8 sm:mt-6 sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)]">
         <div className="relative h-[200px] rounded-b-3xl sm:rounded-none sm:border-b sm:border-[var(--border)]" style={{ backgroundColor: "var(--bg-card)" }}>


### PR DESCRIPTION
## 概要

プロフィール編集画面 (`/users/me/edit`) で保存後にプロフィール画面 (`/users/me`) へ遷移したとき、変更が反映されない・ちらつく問題を修正した。

## 変更内容

- **キャッシュ戦略を変更**: `refetchQueries`（遷移前に完了を待つ）→ `invalidateQueries`（バックグラウンド refetch）に変更し、即座に遷移するようにした
- **スケルトン表示**: プロフィールページでバックグラウンド refetch 中（`isFetching`）もスケルトンを表示し、古いデータのちらつきをなくした
- **アバター画像キャッシュバスター**: アバターアップロード時に保存する URL へ `?v=${Date.now()}` を付与し、同じパスに上書きアップロードしてもブラウザが旧画像をキャッシュから返さないようにした
- **テスト更新**: `refetchQueries` → `invalidateQueries` に合わせてテストを更新

## 動作フロー（修正後）

```
[編集ページ] 保存 → invalidateQueries → 即遷移
[プロフィールページ] isFetching: true → スケルトン表示
                    バックグラウンド refetch 完了 → 最新データで表示
[ブラウザ] <Image src="...?v=timestamp" /> → キャッシュなしで最新画像を取得
```

Closes #126