### PR TITLE
fix: タグボタンにtype="button"を追加してフォームの意図しないsubmitを防ぐ

### DIFF
--- a/components/ui/TagFilterPanel.test.tsx
+++ b/components/ui/TagFilterPanel.test.tsx
@@ -66,4 +66,14 @@ describe("TagFilterPanel", () => {
     fireEvent.click(screen.getByText("絞り込む"));
     expect(onApply).toHaveBeenCalledOnce();
   });
+
+  it("全ボタンが type='button' を持つ（フォーム内でのsubmit防止）", () => {
+    render(
+      <TagFilterPanel tags={tags} selectedTags={[]} onToggle={vi.fn()} open={true} onApply={vi.fn()} />
+    );
+    const buttons = screen.getAllByRole("button");
+    buttons.forEach((btn) => {
+      expect(btn).toHaveAttribute("type", "button");
+    });
+  });
 });

--- a/components/ui/TagFilterPanel.tsx
+++ b/components/ui/TagFilterPanel.tsx
@@ -58,6 +58,7 @@ export function TagFilterPanel({ tags, selectedTags, onToggle, open, onApply, ap
                 return (
                   <button
                     key={tag.id}
+                    type="button"
                     onClick={() => onToggle(tag.slug)}
                     className={clsx(
                       "rounded-full px-3 py-1.5 text-xs font-medium transition-all min-h-[2rem]"
@@ -88,6 +89,7 @@ export function TagFilterPanel({ tags, selectedTags, onToggle, open, onApply, ap
       {onApply && (
         <div className="mt-6 flex justify-start">
           <button
+            type="button"
             onClick={onApply}
             className="rounded-xl px-4 py-2 text-sm font-semibold text-white transition-all hover:opacity-90 active:scale-[0.97]"
             style={{ background: "linear-gradient(135deg, var(--accent), #6d28d9)" }}

--- a/components/ui/TagFilterToggle.test.tsx
+++ b/components/ui/TagFilterToggle.test.tsx
@@ -37,4 +37,9 @@ describe("TagFilterToggle", () => {
     const chevron = container.querySelector("svg:last-child");
     expect(chevron).toHaveStyle({ transform: "rotate(180deg)" });
   });
+
+  it("ボタンが type='button' を持つ（フォーム内でのsubmit防止）", () => {
+    render(<TagFilterToggle selectedCount={0} panelOpen={false} onPanelToggle={() => {}} />);
+    expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+  });
 });

--- a/components/ui/TagFilterToggle.tsx
+++ b/components/ui/TagFilterToggle.tsx
@@ -12,6 +12,7 @@ type Props = {
 export function TagFilterToggle({ selectedCount, panelOpen, onPanelToggle, label = "タグで絞り込み" }: Props) {
   return (
     <button
+      type="button"
       onClick={onPanelToggle}
       className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors"
       style={{


### PR DESCRIPTION
## 概要

部屋作成フォーム（`/rooms/new`）でプレイスタイルタグを選択しただけで部屋が作成されてしまうバグを修正。

**根本原因:** `TagFilterPanel.tsx` / `TagFilterToggle.tsx` 内のボタンに `type="button"` が設定されておらず、HTML仕様のデフォルト `type="submit"` により `<form>` 内でクリックするとフォームが送信されていた。

## 変更内容

- `components/ui/TagFilterPanel.tsx` — タグボタンと「決定」ボタンに `type="button"` を追加
- `components/ui/TagFilterToggle.tsx` — トグルボタンに `type="button"` を追加
- `components/ui/TagFilterPanel.test.tsx` — `type="button"` の検証テストを追加
- `components/ui/TagFilterToggle.test.tsx` — `type="button"` の検証テストを追加

## AC確認

- [x] タグボタンをクリックしても部屋は作成されない（タグの選択状態のみ変わる）
- [x] 「決定」ボタンをクリックしてもフォームは送信されない（パネルが閉じるだけ）
- [x] 「作成する」ボタンを押したときのみ部屋が作成される

Closes #129