### PR TITLE
fix: ナビメニューのアクティブ状態が2階層以上のルートで消える問題を修正

### DIFF
--- a/components/ui/BottomNav.test.tsx
+++ b/components/ui/BottomNav.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+const mockUsePathname = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "authenticated" }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+    style,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    style?: React.CSSProperties;
+  }) => (
+    <a href={href} className={className} style={style}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@phosphor-icons/react", () => ({
+  House: () => <span />,
+  PlusCircle: () => <span />,
+  Chat: () => <span />,
+  User: () => <span />,
+  Users: () => <span />,
+}));
+
+import { BottomNav } from "./BottomNav";
+
+afterEach(() => {
+  cleanup();
+});
+
+function getNavLink(label: string) {
+  return screen.getByRole("link", { name: new RegExp(label) });
+}
+
+function isActiveLink(label: string) {
+  const link = getNavLink(label);
+  return (link as HTMLElement).style.fontWeight === "500";
+}
+
+describe("BottomNav - ナビアクティブ状態", () => {
+  it("/ ではトップがアクティブ", () => {
+    mockUsePathname.mockReturnValue("/");
+    render(<BottomNav />);
+    expect(isActiveLink("トップ")).toBe(true);
+    expect(isActiveLink("探す")).toBe(false);
+  });
+
+  it("/games では探すがアクティブ", () => {
+    mockUsePathname.mockReturnValue("/games");
+    render(<BottomNav />);
+    expect(isActiveLink("探す")).toBe(true);
+    expect(isActiveLink("トップ")).toBe(false);
+  });
+
+  it("/games/[gameId]/rooms では探すがアクティブ (AC3)", () => {
+    mockUsePathname.mockReturnValue("/games/123/rooms");
+    render(<BottomNav />);
+    expect(isActiveLink("探す")).toBe(true);
+  });
+
+  it("/rooms/new では部屋作成がアクティブ", () => {
+    mockUsePathname.mockReturnValue("/rooms/new");
+    render(<BottomNav />);
+    expect(isActiveLink("部屋作成")).toBe(true);
+    expect(isActiveLink("参加中")).toBe(false);
+  });
+
+  it("/rooms/[roomId] では参加中がアクティブ (AC1)", () => {
+    mockUsePathname.mockReturnValue("/rooms/abc123");
+    render(<BottomNav />);
+    expect(isActiveLink("参加中")).toBe(true);
+    expect(isActiveLink("部屋作成")).toBe(false);
+  });
+
+  it("/rooms/[roomId]/chat では参加中がアクティブ", () => {
+    mockUsePathname.mockReturnValue("/rooms/abc123/chat");
+    render(<BottomNav />);
+    expect(isActiveLink("参加中")).toBe(true);
+  });
+
+  it("/rooms/[roomId]/ratings では参加中がアクティブ", () => {
+    mockUsePathname.mockReturnValue("/rooms/abc123/ratings");
+    render(<BottomNav />);
+    expect(isActiveLink("参加中")).toBe(true);
+  });
+
+  it("/rooms/current では参加中がアクティブ", () => {
+    mockUsePathname.mockReturnValue("/rooms/current");
+    render(<BottomNav />);
+    expect(isActiveLink("参加中")).toBe(true);
+  });
+
+  it("/users/me ではプロフィールがアクティブ", () => {
+    mockUsePathname.mockReturnValue("/users/me");
+    render(<BottomNav />);
+    expect(isActiveLink("プロフィール")).toBe(true);
+  });
+
+  it("/users/me/edit ではプロフィールがアクティブ (AC2)", () => {
+    mockUsePathname.mockReturnValue("/users/me/edit");
+    render(<BottomNav />);
+    expect(isActiveLink("プロフィール")).toBe(true);
+  });
+
+  it("/users/me/history ではプロフィールがアクティブ (AC2)", () => {
+    mockUsePathname.mockReturnValue("/users/me/history");
+    render(<BottomNav />);
+    expect(isActiveLink("プロフィール")).toBe(true);
+  });
+
+  it("/login では BottomNav が非表示", () => {
+    mockUsePathname.mockReturnValue("/login");
+    const { container } = render(<BottomNav />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/components/ui/BottomNav.tsx
+++ b/components/ui/BottomNav.tsx
@@ -14,11 +14,41 @@ export function BottomNav() {
   const isAuthenticated = status === "authenticated";
 
   const staticItems = [
-    { href: "/", label: "トップ", icon: House },
-    { href: "/games", label: "探す", icon: Users, requiresAuth: false },
-    { href: "/rooms/new", label: "部屋作成", icon: PlusCircle, requiresAuth: true },
-    { href: "/rooms/current/chat", label: "参加中", icon: Chat, requiresAuth: true },
-    { href: "/users/me", label: "プロフィール", icon: User, requiresAuth: true },
+    {
+      href: "/",
+      label: "トップ",
+      icon: House,
+      isActive: (p: string) => p === "/",
+    },
+    {
+      href: "/games",
+      label: "探す",
+      icon: Users,
+      requiresAuth: false,
+      isActive: (p: string) => p === "/games" || p.startsWith("/games/"),
+    },
+    {
+      href: "/rooms/new",
+      label: "部屋作成",
+      icon: PlusCircle,
+      requiresAuth: true,
+      isActive: (p: string) => p === "/rooms/new",
+    },
+    {
+      href: "/rooms/current/chat",
+      label: "参加中",
+      icon: Chat,
+      requiresAuth: true,
+      isActive: (p: string) =>
+        p.startsWith("/rooms/") && !p.startsWith("/rooms/new"),
+    },
+    {
+      href: "/users/me",
+      label: "プロフィール",
+      icon: User,
+      requiresAuth: true,
+      isActive: (p: string) => p.startsWith("/users/me"),
+    },
   ];
 
   return (
@@ -31,8 +61,8 @@ export function BottomNav() {
         borderTop: "1px solid var(--border)",
       }}
     >
-      {staticItems.map(({ href, label, icon: Icon, requiresAuth }) => {
-        const isActive = href === "/" || href === "/games" ? pathname === href : pathname.startsWith(href);
+      {staticItems.map(({ href, label, icon: Icon, requiresAuth, isActive: checkActive }) => {
+        const isActive = checkActive(pathname);
         const linkStyle = {
           color: isActive ? "var(--accent-light)" : "var(--text-secondary)",
           fontWeight: isActive ? 500 : 400,

--- a/components/ui/BottomNav.tsx
+++ b/components/ui/BottomNav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { House, PlusCircle, Chat, User, Users } from "@phosphor-icons/react";
+import { NAV_ITEMS } from "@/components/ui/nav-items";
 
 export function BottomNav() {
   const pathname = usePathname();
@@ -12,44 +12,6 @@ export function BottomNav() {
   if (pathname === "/login" || pathname === "/onboarding") return null;
 
   const isAuthenticated = status === "authenticated";
-
-  const staticItems = [
-    {
-      href: "/",
-      label: "トップ",
-      icon: House,
-      isActive: (p: string) => p === "/",
-    },
-    {
-      href: "/games",
-      label: "探す",
-      icon: Users,
-      requiresAuth: false,
-      isActive: (p: string) => p === "/games" || p.startsWith("/games/"),
-    },
-    {
-      href: "/rooms/new",
-      label: "部屋作成",
-      icon: PlusCircle,
-      requiresAuth: true,
-      isActive: (p: string) => p === "/rooms/new",
-    },
-    {
-      href: "/rooms/current/chat",
-      label: "参加中",
-      icon: Chat,
-      requiresAuth: true,
-      isActive: (p: string) =>
-        p.startsWith("/rooms/") && !p.startsWith("/rooms/new"),
-    },
-    {
-      href: "/users/me",
-      label: "プロフィール",
-      icon: User,
-      requiresAuth: true,
-      isActive: (p: string) => p.startsWith("/users/me"),
-    },
-  ];
 
   return (
     <nav
@@ -61,7 +23,7 @@ export function BottomNav() {
         borderTop: "1px solid var(--border)",
       }}
     >
-      {staticItems.map(({ href, label, icon: Icon, requiresAuth, isActive: checkActive }) => {
+      {NAV_ITEMS.map(({ href, shortLabel, icon: Icon, requiresAuth, isActive: checkActive }) => {
         const isActive = checkActive(pathname);
         const linkStyle = {
           color: isActive ? "var(--accent-light)" : "var(--text-secondary)",
@@ -76,7 +38,7 @@ export function BottomNav() {
               style={{ color: "var(--text-secondary)" }}
             >
               <Icon className="h-6 w-6" />
-              {label}
+              {shortLabel}
             </Link>
           );
         }
@@ -88,7 +50,7 @@ export function BottomNav() {
             style={linkStyle}
           >
             <Icon className="h-6 w-6" />
-            {label}
+            {shortLabel}
           </Link>
         );
       })}

--- a/components/ui/Header.test.tsx
+++ b/components/ui/Header.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+const mockUsePathname = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "authenticated" }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+    style,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    style?: React.CSSProperties;
+  }) => (
+    <a href={href} className={className} style={style}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@phosphor-icons/react", () => ({
+  House: () => <span />,
+  PlusCircle: () => <span />,
+  Chat: () => <span />,
+  User: () => <span />,
+  Users: () => <span />,
+}));
+
+vi.mock("@/components/ui/SignOutButton", () => ({
+  SignOutButton: () => <button>サインアウト</button>,
+}));
+
+vi.mock("@/components/ui/Logo", () => ({
+  Logo: () => <div data-testid="logo" />,
+}));
+
+import { Header } from "./Header";
+
+afterEach(() => {
+  cleanup();
+});
+
+function getNavLink(label: string) {
+  return screen.getByRole("link", { name: new RegExp(label) });
+}
+
+describe("Header - ナビアクティブ状態", () => {
+  it("/ ではトップがアクティブ", () => {
+    mockUsePathname.mockReturnValue("/");
+    render(<Header />);
+    expect(getNavLink("トップ")).toHaveClass("text-white");
+    expect(getNavLink("部屋を探す")).not.toHaveClass("text-white");
+  });
+
+  it("/games では部屋を探すがアクティブ", () => {
+    mockUsePathname.mockReturnValue("/games");
+    render(<Header />);
+    expect(getNavLink("部屋を探す")).toHaveClass("text-white");
+    expect(getNavLink("トップ")).not.toHaveClass("text-white");
+  });
+
+  it("/games/[gameId]/rooms では部屋を探すがアクティブ (AC3)", () => {
+    mockUsePathname.mockReturnValue("/games/123/rooms");
+    render(<Header />);
+    expect(getNavLink("部屋を探す")).toHaveClass("text-white");
+  });
+
+  it("/rooms/new では部屋作成がアクティブ", () => {
+    mockUsePathname.mockReturnValue("/rooms/new");
+    render(<Header />);
+    expect(getNavLink("部屋作成")).toHaveClass("text-white");
+    expect(getNavLink("参加中の部屋")).not.toHaveClass("text-white");
+  });
+
+  it("/rooms/[roomId] では参加中の部屋がアクティブ (AC1)", () => {
+    mockUsePathname.mockReturnValue("/rooms/abc123");
+    render(<Header />);
+    expect(getNavLink("参加中の部屋")).toHaveClass("text-white");
+    expect(getNavLink("部屋作成")).not.toHaveClass("text-white");
+  });
+
+  it("/rooms/[roomId]/chat では参加中の部屋がアクティブ", () => {
+    mockUsePathname.mockReturnValue("/rooms/abc123/chat");
+    render(<Header />);
+    expect(getNavLink("参加中の部屋")).toHaveClass("text-white");
+  });
+
+  it("/rooms/[roomId]/ratings では参加中の部屋がアクティブ", () => {
+    mockUsePathname.mockReturnValue("/rooms/abc123/ratings");
+    render(<Header />);
+    expect(getNavLink("参加中の部屋")).toHaveClass("text-white");
+  });
+
+  it("/rooms/current では参加中の部屋がアクティブ", () => {
+    mockUsePathname.mockReturnValue("/rooms/current");
+    render(<Header />);
+    expect(getNavLink("参加中の部屋")).toHaveClass("text-white");
+  });
+
+  it("/users/me ではプロフィールがアクティブ", () => {
+    mockUsePathname.mockReturnValue("/users/me");
+    render(<Header />);
+    expect(getNavLink("プロフィール")).toHaveClass("text-white");
+  });
+
+  it("/users/me/edit ではプロフィールがアクティブ (AC2)", () => {
+    mockUsePathname.mockReturnValue("/users/me/edit");
+    render(<Header />);
+    expect(getNavLink("プロフィール")).toHaveClass("text-white");
+  });
+
+  it("/users/me/history ではプロフィールがアクティブ (AC2)", () => {
+    mockUsePathname.mockReturnValue("/users/me/history");
+    render(<Header />);
+    expect(getNavLink("プロフィール")).toHaveClass("text-white");
+  });
+
+  it("/login では Header が非表示", () => {
+    mockUsePathname.mockReturnValue("/login");
+    const { container } = render(<Header />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -3,10 +3,10 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { House, PlusCircle, Chat, User, Users } from "@phosphor-icons/react";
 import clsx from "clsx";
 import { SignOutButton } from "@/components/ui/SignOutButton";
 import { Logo } from "@/components/ui/Logo";
+import { NAV_ITEMS } from "@/components/ui/nav-items";
 
 export function Header() {
   const pathname = usePathname();
@@ -15,45 +15,6 @@ export function Header() {
   if (pathname === "/login" || pathname === "/onboarding") return null;
 
   const isAuthenticated = status === "authenticated";
-
-  const staticNavItems = [
-    {
-      href: "/",
-      label: "トップ",
-      icon: House,
-      requiresAuth: false,
-      isActive: (p: string) => p === "/",
-    },
-    {
-      href: "/games",
-      label: "部屋を探す",
-      icon: Users,
-      requiresAuth: false,
-      isActive: (p: string) => p === "/games" || p.startsWith("/games/"),
-    },
-    {
-      href: "/rooms/new",
-      label: "部屋作成",
-      icon: PlusCircle,
-      requiresAuth: true,
-      isActive: (p: string) => p === "/rooms/new",
-    },
-    {
-      href: "/rooms/current/chat",
-      label: "参加中の部屋",
-      icon: Chat,
-      requiresAuth: true,
-      isActive: (p: string) =>
-        p.startsWith("/rooms/") && !p.startsWith("/rooms/new"),
-    },
-    {
-      href: "/users/me",
-      label: "プロフィール",
-      icon: User,
-      requiresAuth: true,
-      isActive: (p: string) => p.startsWith("/users/me"),
-    },
-  ];
 
   return (
     <header
@@ -71,7 +32,7 @@ export function Header() {
 
         {/* Desktop Nav */}
         <nav className="hidden md:flex items-center gap-1">
-          {staticNavItems.map(({ href, label, icon: Icon, requiresAuth, isActive: checkActive }) => {
+          {NAV_ITEMS.map(({ href, label, icon: Icon, requiresAuth, isActive: checkActive }) => {
             const isActive = checkActive(pathname);
             if (requiresAuth && !isAuthenticated) {
               return (

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -17,11 +17,42 @@ export function Header() {
   const isAuthenticated = status === "authenticated";
 
   const staticNavItems = [
-    { href: "/", label: "トップ", icon: House, requiresAuth: false },
-    { href: "/games", label: "部屋を探す", icon: Users, requiresAuth: false },
-    { href: "/rooms/new", label: "部屋作成", icon: PlusCircle, requiresAuth: true },
-    { href: "/rooms/current/chat", label: "参加中の部屋", icon: Chat, requiresAuth: true },
-    { href: "/users/me", label: "プロフィール", icon: User, requiresAuth: true },
+    {
+      href: "/",
+      label: "トップ",
+      icon: House,
+      requiresAuth: false,
+      isActive: (p: string) => p === "/",
+    },
+    {
+      href: "/games",
+      label: "部屋を探す",
+      icon: Users,
+      requiresAuth: false,
+      isActive: (p: string) => p === "/games" || p.startsWith("/games/"),
+    },
+    {
+      href: "/rooms/new",
+      label: "部屋作成",
+      icon: PlusCircle,
+      requiresAuth: true,
+      isActive: (p: string) => p === "/rooms/new",
+    },
+    {
+      href: "/rooms/current/chat",
+      label: "参加中の部屋",
+      icon: Chat,
+      requiresAuth: true,
+      isActive: (p: string) =>
+        p.startsWith("/rooms/") && !p.startsWith("/rooms/new"),
+    },
+    {
+      href: "/users/me",
+      label: "プロフィール",
+      icon: User,
+      requiresAuth: true,
+      isActive: (p: string) => p.startsWith("/users/me"),
+    },
   ];
 
   return (
@@ -40,8 +71,8 @@ export function Header() {
 
         {/* Desktop Nav */}
         <nav className="hidden md:flex items-center gap-1">
-          {staticNavItems.map(({ href, label, icon: Icon, requiresAuth }) => {
-            const isActive = href === "/" || href === "/games" ? pathname === href : pathname.startsWith(href);
+          {staticNavItems.map(({ href, label, icon: Icon, requiresAuth, isActive: checkActive }) => {
+            const isActive = checkActive(pathname);
             if (requiresAuth && !isAuthenticated) {
               return (
                 <Link

--- a/components/ui/nav-items.ts
+++ b/components/ui/nav-items.ts
@@ -1,0 +1,56 @@
+import { House, PlusCircle, Chat, User, Users } from "@phosphor-icons/react";
+import type { ComponentType } from "react";
+
+export type NavItem = {
+  href: string;
+  /** デスクトップ用ラベル */
+  label: string;
+  /** モバイル用短縮ラベル */
+  shortLabel: string;
+  icon: ComponentType<{ className?: string }>;
+  requiresAuth: boolean;
+  isActive: (pathname: string) => boolean;
+};
+
+export const NAV_ITEMS: NavItem[] = [
+  {
+    href: "/",
+    label: "トップ",
+    shortLabel: "トップ",
+    icon: House,
+    requiresAuth: false,
+    isActive: (p) => p === "/",
+  },
+  {
+    href: "/games",
+    label: "部屋を探す",
+    shortLabel: "探す",
+    icon: Users,
+    requiresAuth: false,
+    isActive: (p) => p === "/games" || p.startsWith("/games/"),
+  },
+  {
+    href: "/rooms/new",
+    label: "部屋作成",
+    shortLabel: "部屋作成",
+    icon: PlusCircle,
+    requiresAuth: true,
+    isActive: (p) => p === "/rooms/new",
+  },
+  {
+    href: "/rooms/current/chat",
+    label: "参加中の部屋",
+    shortLabel: "参加中",
+    icon: Chat,
+    requiresAuth: true,
+    isActive: (p) => p.startsWith("/rooms/") && !p.startsWith("/rooms/new"),
+  },
+  {
+    href: "/users/me",
+    label: "プロフィール",
+    shortLabel: "プロフィール",
+    icon: User,
+    requiresAuth: true,
+    isActive: (p) => p.startsWith("/users/me"),
+  },
+];


### PR DESCRIPTION
## 概要

2階層以上のルートに遷移したとき、ナビゲーションメニューのアクティブ状態が消える問題を修正。

### 根本原因

`pathname.startsWith(href)` の単一ロジックでは、`/rooms/new` や `/rooms/current/chat` というhrefを持つnavアイテムが `/rooms/[roomId]` にマッチしなかった。また `/games` はexact matchのため `/games/[gameId]/rooms` でもマッチしなかった。

### 対応内容

各navアイテムに `isActive: (pathname: string) => boolean` 関数を追加し、ルートごとに適切なマッチロジックを定義。

| navアイテム | アクティブ条件 |
|------------|-------------|
| トップ (`/`) | `p === "/"` |
| 部屋を探す (`/games`) | `p === "/games" \|\| p.startsWith("/games/")` |
| 部屋作成 (`/rooms/new`) | `p === "/rooms/new"` |
| 参加中の部屋 (`/rooms/current/chat`) | `p.startsWith("/rooms/") && !p.startsWith("/rooms/new")` |
| プロフィール (`/users/me`) | `p.startsWith("/users/me")` |

## 変更ファイル

- `components/ui/Header.tsx` — isActive関数を各navアイテムに追加
- `components/ui/BottomNav.tsx` — 同上
- `components/ui/Header.test.tsx` — 新規作成（12テスト）
- `components/ui/BottomNav.test.tsx` — 新規作成（12テスト）

## AC確認

- [x] `/rooms/[roomId]` → "参加中の部屋" がアクティブ
- [x] `/users/me/edit`, `/users/me/history` → "プロフィール" がアクティブ
- [x] `/games/[gameId]/rooms` → "部屋を探す" がアクティブ
- [x] トップレベルページも引き続き正常動作

Closes #130