### PR TITLE
feat: ログアウトボタンをヘッダーからプロフィール画面に移動

### DIFF
--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -9,6 +9,7 @@ import { ProfileStats } from "@/components/users/ProfileStats";
 import { GameScrollList } from "@/components/users/GameScrollList";
 import { ReceivedRatingsList } from "@/components/users/ReceivedRatingsList";
 import { DeleteAccountButton } from "./DeleteAccountButton";
+import { SignOutButton } from "@/components/ui/SignOutButton";
 
 type ReceivedRating = {
   id: string;
@@ -115,8 +116,13 @@ export default function MyProfilePage() {
       <ProfileStats avgRating={user.avgRating} ratingCount={user.ratingCount} />
       <GameScrollList games={user.games} />
       <ReceivedRatingsList ratings={user.receivedRatings} />
-      <div className="mx-4 sm:mx-6 mt-8">
-        <DeleteAccountButton />
+      <div className="mx-4 sm:mx-6 mt-8 space-y-4">
+        <div>
+          <SignOutButton />
+        </div>
+        <div className="border-t pt-4" style={{ borderColor: "var(--border)" }}>
+          <DeleteAccountButton />
+        </div>
       </div>
     </div>
   );

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
 import clsx from "clsx";
-import { SignOutButton } from "@/components/ui/SignOutButton";
 import { Logo } from "@/components/ui/Logo";
 import { NAV_ITEMS } from "@/components/ui/nav-items";
 
@@ -67,12 +66,6 @@ export function Header() {
             );
           })}
 
-          {isAuthenticated && (
-            <>
-              <div className="mx-2 h-6 w-px" style={{ backgroundColor: "var(--border)" }} />
-              <SignOutButton />
-            </>
-          )}
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## 概要

ヘッダーナビゲーションのログアウトボタンを削除し、`/users/me` プロフィール画面に移動します。

- `components/ui/Header.tsx` — `SignOutButton` の import と認証済みブロック（ボタン + セパレータ）を削除
- `app/users/me/page.tsx` — `SignOutButton` を import し、`DeleteAccountButton` の上に配置。`border-t` でログアウト（可逆）とアカウント削除（不可逆）を視覚的に分離

Closes #133