### PR TITLE
feat: 部屋作成を2ステップウィザード化（ゲーム選択 → 部屋詳細入力）

### DIFF
--- a/app/games/GamesGrid.test.tsx
+++ b/app/games/GamesGrid.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { GamesGrid } from "./GamesGrid";
+
+const MOCK_GAMES = [
+  { id: "g1", name: "Apex Legends", coverImageUrl: null },
+  { id: "g2", name: "Valorant", coverImageUrl: null },
+  { id: "g3", name: "Minecraft", coverImageUrl: null },
+];
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("next/image", () => ({
+  // eslint-disable-next-line @next/next/no-img-element
+  default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
+}));
+
+vi.mock("@/components/ui/GameCoverImage", () => ({
+  GameCoverImage: () => null,
+}));
+
+vi.mock("@phosphor-icons/react", () => ({
+  MagnifyingGlass: () => null,
+}));
+
+function mockFetchSuccess(games = MOCK_GAMES) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: games }),
+    })
+  );
+}
+
+describe("GamesGrid", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("games prop 未指定時に /api/v1/games をフェッチしてゲーム一覧を表示する", async () => {
+    mockFetchSuccess();
+    render(<GamesGrid />);
+    await waitFor(() => {
+      expect(screen.getByText("Apex Legends")).toBeInTheDocument();
+    });
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith("/api/v1/games");
+  });
+
+  it("games prop を渡した場合はフェッチせずそのゲームを表示する", () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+    render(<GamesGrid games={MOCK_GAMES} />);
+    expect(screen.getByText("Apex Legends")).toBeInTheDocument();
+    expect(screen.getByText("Valorant")).toBeInTheDocument();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("検索クエリでゲームをフィルタリングできる", () => {
+    render(<GamesGrid games={MOCK_GAMES} />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Apex" } });
+    expect(screen.getByText("Apex Legends")).toBeInTheDocument();
+    expect(screen.queryByText("Valorant")).not.toBeInTheDocument();
+    expect(screen.queryByText("Minecraft")).not.toBeInTheDocument();
+  });
+
+  it("onSelect 未指定時、ゲームクリックで router.push が呼ばれる", () => {
+    render(<GamesGrid games={MOCK_GAMES} />);
+    fireEvent.click(screen.getAllByRole("button")[0]);
+    expect(mockPush).toHaveBeenCalledWith("/games/g1/rooms");
+  });
+
+  it("onSelect 指定時、ゲームクリックで onSelect が呼ばれ router.push は呼ばれない", () => {
+    const mockOnSelect = vi.fn();
+    render(<GamesGrid games={MOCK_GAMES} onSelect={mockOnSelect} />);
+    fireEvent.click(screen.getAllByRole("button")[0]);
+    expect(mockOnSelect).toHaveBeenCalledWith(MOCK_GAMES[0]);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("onSelect 指定時、オーバーレイテキストが「選択する →」になる", () => {
+    render(<GamesGrid games={MOCK_GAMES} onSelect={vi.fn()} />);
+    expect(screen.getAllByText("選択する →").length).toBeGreaterThan(0);
+    expect(screen.queryByText("部屋を探す →")).not.toBeInTheDocument();
+  });
+
+  it("onSelect 未指定時、オーバーレイテキストが「部屋を探す →」になる", () => {
+    render(<GamesGrid games={MOCK_GAMES} />);
+    expect(screen.getAllByText("部屋を探す →").length).toBeGreaterThan(0);
+    expect(screen.queryByText("選択する →")).not.toBeInTheDocument();
+  });
+
+  it("onSelect 指定時、roomCounts があっても募集数テキストが表示されない", () => {
+    const roomCounts = { g1: 3, g2: 0, g3: 1 };
+    render(<GamesGrid games={MOCK_GAMES} roomCounts={roomCounts} onSelect={vi.fn()} />);
+    expect(screen.queryByText("3 部屋募集中")).not.toBeInTheDocument();
+    expect(screen.queryByText("募集なし")).not.toBeInTheDocument();
+  });
+
+  it("検索結果が0件の場合「に一致するゲームが見つかりません」が表示される", () => {
+    render(<GamesGrid games={MOCK_GAMES} />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "xxxxxxxxxxx" } });
+    expect(screen.getByText(/に一致するゲームが見つかりません/)).toBeInTheDocument();
+  });
+});

--- a/app/games/GamesGrid.tsx
+++ b/app/games/GamesGrid.tsx
@@ -1,25 +1,47 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { MagnifyingGlass } from "@phosphor-icons/react";
 import type { GameResult } from "@/lib/games";
 import { GameCoverImage } from "@/components/ui/GameCoverImage";
 
 type Props = {
-  games: GameResult[];
-  roomCounts: Record<string, number>;
+  games?: GameResult[];
+  roomCounts?: Record<string, number>;
+  onSelect?: (game: GameResult) => void;
 };
 
-export function GamesGrid({ games, roomCounts }: Props) {
+export function GamesGrid({ games: gamesProp, roomCounts = {}, onSelect }: Props) {
   const router = useRouter();
   const [query, setQuery] = useState("");
+  const [fetchedGames, setFetchedGames] = useState<GameResult[]>([]);
+  const [loading, setLoading] = useState(!gamesProp);
+
+  useEffect(() => {
+    if (gamesProp) return;
+    fetch("/api/v1/games")
+      .then((r) => r.json())
+      .then((json: { data: GameResult[] }) => setFetchedGames(json.data))
+      .catch(() => setFetchedGames([]))
+      .finally(() => setLoading(false));
+  }, [gamesProp]);
+
+  const games = gamesProp ?? fetchedGames;
 
   const filteredGames = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return games;
     return games.filter((g) => g.name.toLowerCase().includes(q));
   }, [query, games]);
+
+  const handleClick = (game: GameResult) => {
+    if (onSelect) {
+      onSelect(game);
+    } else {
+      router.push(`/games/${game.id}/rooms`);
+    }
+  };
 
   return (
     <>
@@ -43,13 +65,24 @@ export function GamesGrid({ games, roomCounts }: Props) {
             }}
           />
         </div>
-        <span className="shrink-0 text-sm" style={{ color: "var(--text-secondary)" }}>
-          全{games.length}件
-        </span>
+        {!loading && (
+          <span className="shrink-0 text-sm" style={{ color: "var(--text-secondary)" }}>
+            全{games.length}件
+          </span>
+        )}
       </div>
 
       {/* Game grid */}
-      {filteredGames.length > 0 ? (
+      {loading ? (
+        <div className="grid grid-cols-3 gap-4 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <div key={i} className="animate-fade-in" style={{ animationDelay: `${i * 40}ms` }}>
+              <div className="aspect-[3/4] w-full rounded-xl animate-shimmer" />
+              <div className="mt-2 h-3 w-3/4 rounded-md animate-shimmer" />
+            </div>
+          ))}
+        </div>
+      ) : filteredGames.length > 0 ? (
         <div className="grid grid-cols-3 gap-4 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
           {filteredGames.map((game, index) => {
             const roomCount = roomCounts[game.id] ?? 0;
@@ -57,7 +90,7 @@ export function GamesGrid({ games, roomCounts }: Props) {
             return (
               <button
                 key={game.id}
-                onClick={() => router.push(`/games/${game.id}/rooms`)}
+                onClick={() => handleClick(game)}
                 className="group text-left animate-fade-in-up"
                 style={{ animationDelay: `${Math.min(index, 11) * 50}ms` }}
               >
@@ -71,7 +104,9 @@ export function GamesGrid({ games, roomCounts }: Props) {
 
                   {/* Hover overlay */}
                   <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/70 via-transparent p-3 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-                    <span className="text-xs font-semibold text-white">部屋を探す →</span>
+                    <span className="text-xs font-semibold text-white">
+                      {onSelect ? "選択する →" : "部屋を探す →"}
+                    </span>
                   </div>
                 </div>
 
@@ -80,9 +115,11 @@ export function GamesGrid({ games, roomCounts }: Props) {
                   <p className="truncate text-sm font-medium" style={{ color: "var(--text-primary)" }}>
                     {game.name}
                   </p>
-                  <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
-                    {roomCount > 0 ? `${roomCount} 部屋募集中` : "募集なし"}
-                  </p>
+                  {!onSelect && (
+                    <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
+                      {roomCount > 0 ? `${roomCount} 部屋募集中` : "募集なし"}
+                    </p>
+                  )}
                 </div>
               </button>
             );

--- a/app/rooms/new/page.test.tsx
+++ b/app/rooms/new/page.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import NewRoomPage from "./page";
+
+// ─── vi.mock ファクトリ内で参照できるようにホイスト ────────────────────────────
+const { mockPush, mockMutate, mutationCallbacks } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockMutate: vi.fn(),
+  mutationCallbacks: {} as {
+    onSuccess?: (data: { data: { id: string } }) => void;
+    onError?: (err: Error) => void;
+  },
+}));
+
+// ─── モック ───────────────────────────────────────────────────────────────────
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("next/image", () => ({
+  // eslint-disable-next-line @next/next/no-img-element
+  default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: [] }),
+  useMutation: (opts: {
+    mutationFn: unknown;
+    onSuccess: (data: { data: { id: string } }) => void;
+    onError: (err: Error) => void;
+  }) => {
+    mutationCallbacks.onSuccess = opts.onSuccess;
+    mutationCallbacks.onError = opts.onError;
+    return { mutate: mockMutate, isPending: false };
+  },
+}));
+
+vi.mock("@/app/games/GamesGrid", () => ({
+  GamesGrid: ({ onSelect }: { onSelect: (game: { id: string; name: string; coverImageUrl: null }) => void }) => (
+    <button
+      data-testid="game-picker"
+      onClick={() => onSelect({ id: "g1", name: "Apex Legends", coverImageUrl: null })}
+    >
+      ゲームを選ぶ
+    </button>
+  ),
+}));
+
+vi.mock("@/lib/api/rooms", () => ({ createRoom: vi.fn() }));
+
+vi.mock("@phosphor-icons/react", () => ({
+  Plus: () => null,
+  Minus: () => null,
+  CircleNotch: () => null,
+  ArrowLeft: () => null,
+  GameController: () => null,
+}));
+
+vi.mock("@/components/ui/TagFilterToggle", () => ({
+  TagFilterToggle: () => null,
+}));
+vi.mock("@/components/ui/TagFilterPanel", () => ({
+  TagFilterPanel: () => null,
+}));
+vi.mock("@/components/ui/ActiveFilterBar", () => ({
+  ActiveFilterBar: () => null,
+}));
+
+// ─── ヘルパー ─────────────────────────────────────────────────────────────────
+function selectGame() {
+  fireEvent.click(screen.getByTestId("game-picker"));
+}
+
+// ─── テスト ───────────────────────────────────────────────────────────────────
+describe("NewRoomPage", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockMutate.mockReset();
+  });
+
+  it("初期表示でステップ1（ゲーム選択）が表示される", () => {
+    render(<NewRoomPage />);
+    expect(screen.getByTestId("game-picker")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /作成する/ })).not.toBeInTheDocument();
+  });
+
+  it("ステップインジケーターに「ゲーム選択」「部屋詳細」ラベルが表示される", () => {
+    render(<NewRoomPage />);
+    expect(screen.getByText("ゲーム選択")).toBeInTheDocument();
+    expect(screen.getByText("部屋詳細")).toBeInTheDocument();
+  });
+
+  it("ゲームを選択するとステップ2に遷移し選択ゲーム名が表示される", () => {
+    render(<NewRoomPage />);
+    selectGame();
+    expect(screen.queryByTestId("game-picker")).not.toBeInTheDocument();
+    expect(screen.getByText("Apex Legends")).toBeInTheDocument();
+    expect(screen.getByText("選択中のゲーム")).toBeInTheDocument();
+  });
+
+  it("ステップ2でステップ1インジケーターが完了状態（✓）になる", () => {
+    render(<NewRoomPage />);
+    selectGame();
+    expect(screen.getByText("✓")).toBeInTheDocument();
+  });
+
+  it("「戻る」ボタンでステップ1に戻る", () => {
+    render(<NewRoomPage />);
+    selectGame();
+    fireEvent.click(screen.getByRole("button", { name: /戻る/ }));
+    expect(screen.getByTestId("game-picker")).toBeInTheDocument();
+  });
+
+  it("タイトル未入力では「作成する」ボタンが無効", () => {
+    render(<NewRoomPage />);
+    selectGame();
+    expect(screen.getByRole("button", { name: /作成する/ })).toBeDisabled();
+  });
+
+  it("タイトル入力後は「作成する」ボタンが有効になる", () => {
+    render(<NewRoomPage />);
+    selectGame();
+    fireEvent.change(screen.getAllByRole("textbox")[0], { target: { value: "テスト部屋" } });
+    expect(screen.getByRole("button", { name: /作成する/ })).not.toBeDisabled();
+  });
+
+  it("フォーム送信で createRoom が正しい引数（gameId, title, maxPlayers）で呼ばれる", () => {
+    render(<NewRoomPage />);
+    selectGame();
+    fireEvent.change(screen.getAllByRole("textbox")[0], { target: { value: "テスト部屋" } });
+    fireEvent.click(screen.getByRole("button", { name: /作成する/ }));
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gameId: "g1",
+        title: "テスト部屋",
+        maxPlayers: 4,
+      })
+    );
+  });
+
+  it("createRoom 成功時に router.push が呼ばれる", async () => {
+    render(<NewRoomPage />);
+    selectGame();
+    act(() => {
+      mutationCallbacks.onSuccess?.({ data: { id: "room-123" } });
+    });
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/rooms/room-123");
+    });
+  });
+
+  it("createRoom 失敗時にエラーメッセージが表示される", async () => {
+    render(<NewRoomPage />);
+    selectGame();
+    act(() => {
+      mutationCallbacks.onError?.(new Error("作成に失敗しました"));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("作成に失敗しました")).toBeInTheDocument();
+    });
+  });
+});

--- a/app/rooms/new/page.tsx
+++ b/app/rooms/new/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation } from "@tanstack/react-query";
-import { Plus, Minus, CircleNotch, ArrowLeft, MagnifyingGlass } from "@phosphor-icons/react";
-import type { Game } from "@/lib/mock-data";
+import { Plus, Minus, CircleNotch, ArrowLeft } from "@phosphor-icons/react";
+import type { GameResult } from "@/lib/games";
+import { GamesGrid } from "@/app/games/GamesGrid";
 import { GameCoverImage } from "@/components/ui/GameCoverImage";
 import { TagFilterToggle } from "@/components/ui/TagFilterToggle";
 import { TagFilterPanel } from "@/components/ui/TagFilterPanel";
@@ -27,43 +28,24 @@ async function fetchTags(): Promise<Tag[]> {
   return json.data;
 }
 
-async function fetchGames(): Promise<Game[]> {
-  const res = await fetch("/api/v1/games");
-  if (!res.ok) return [];
-  const json = (await res.json()) as { data: Game[] };
-  return json.data;
-}
-
 const STEPS = ["ゲーム選択", "部屋詳細"] as const;
 
 export default function NewRoomPage() {
   const router = useRouter();
   const [step, setStep] = useState<1 | 2>(1);
   const [title, setTitle] = useState("");
-  const [selectedGame, setSelectedGame] = useState<Game | null>(null);
+  const [selectedGame, setSelectedGame] = useState<GameResult | null>(null);
   const [maxPlayers, setMaxPlayers] = useState(4);
   const [description, setDescription] = useState("");
   const [selectedSlugs, setSelectedSlugs] = useState<string[]>([]);
   const [pendingSlugs, setPendingSlugs] = useState<string[]>([]);
   const [panelOpen, setPanelOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [gameQuery, setGameQuery] = useState("");
 
   const { data: tags = [] } = useQuery({
     queryKey: ["play-style-tags"],
     queryFn: fetchTags,
   });
-
-  const { data: allGames = [], isLoading: gamesLoading } = useQuery({
-    queryKey: ["games"],
-    queryFn: fetchGames,
-  });
-
-  const filteredGames = useMemo(() => {
-    const q = gameQuery.trim().toLowerCase();
-    if (!q) return allGames;
-    return allGames.filter((g) => g.name.toLowerCase().includes(q));
-  }, [allGames, gameQuery]);
 
   const mutation = useMutation({
     mutationFn: createRoom,
@@ -116,7 +98,7 @@ export default function NewRoomPage() {
   };
 
   return (
-    <div className="mx-auto max-w-2xl px-4 py-4 sm:py-8 sm:px-6">
+    <div className={step === 1 ? "mx-auto max-w-screen-xl px-4 py-4 sm:py-8 sm:px-6" : "mx-auto max-w-2xl px-4 py-4 sm:py-8 sm:px-6"}>
 
       <div className="mb-4 sm:mb-6 md:text-left text-center">
         <h1 className="text-lg sm:text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
@@ -188,74 +170,12 @@ export default function NewRoomPage() {
 
       {/* ステップ1: ゲーム選択 */}
       {step === 1 && (
-        <div className="flex flex-col gap-4">
-          {/* 検索バー */}
-          <div className="relative">
-            <MagnifyingGlass
-              className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2"
-              style={{ color: "var(--text-secondary)" }}
-            />
-            <input
-              type="text"
-              value={gameQuery}
-              onChange={(e) => setGameQuery(e.target.value)}
-              placeholder="ゲームを検索..."
-              className="w-full rounded-xl border py-2.5 pl-9 pr-4 text-sm outline-none transition-colors focus:border-[var(--accent)]"
-              style={{
-                backgroundColor: "var(--bg-card)",
-                borderColor: "var(--border)",
-                color: "var(--text-primary)",
-              }}
-            />
-          </div>
-
-          {/* ゲームグリッド */}
-          {gamesLoading ? (
-            <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5">
-              {Array.from({ length: 10 }).map((_, i) => (
-                <div key={i} className="animate-fade-in" style={{ animationDelay: `${i * 40}ms` }}>
-                  <div className="aspect-[3/4] w-full rounded-xl animate-shimmer" />
-                  <div className="mt-2 h-3 w-3/4 rounded-md animate-shimmer" />
-                </div>
-              ))}
-            </div>
-          ) : filteredGames.length === 0 ? (
-            <div className="py-16 text-center">
-              <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                &ldquo;{gameQuery}&rdquo; に一致するゲームが見つかりません
-              </p>
-            </div>
-          ) : (
-            <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5">
-              {filteredGames.map((game, index) => (
-                <button
-                  key={game.id}
-                  type="button"
-                  onClick={() => {
-                    setSelectedGame(game);
-                    setStep(2);
-                  }}
-                  className="group text-left animate-fade-in-up"
-                  style={{ animationDelay: `${Math.min(index, 11) * 40}ms` }}
-                >
-                  <div className="relative aspect-[3/4] w-full overflow-hidden rounded-xl">
-                    <GameCoverImage
-                      coverImageUrl={game.coverImageUrl}
-                      name={game.name}
-                      className="transition-transform duration-300 group-hover:scale-105"
-                    />
-                    <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/70 via-transparent p-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-                      <span className="text-xs font-semibold text-white">選択する →</span>
-                    </div>
-                  </div>
-                  <p className="mt-1.5 truncate text-xs font-medium" style={{ color: "var(--text-primary)" }}>
-                    {game.name}
-                  </p>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+        <GamesGrid
+          onSelect={(game) => {
+            setSelectedGame(game);
+            setStep(2);
+          }}
+        />
       )}
 
       {/* ステップ2: 部屋詳細入力 */}

--- a/app/rooms/new/page.tsx
+++ b/app/rooms/new/page.tsx
@@ -4,9 +4,10 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useQuery, useMutation } from "@tanstack/react-query";
-import { Plus, Minus, CircleNotch } from "@phosphor-icons/react";
+import { Plus, Minus, CircleNotch, ArrowLeft } from "@phosphor-icons/react";
 import type { Game } from "@/lib/mock-data";
-import { SingleGamePicker } from "@/components/ui/GamePicker";
+import { GridGamePicker } from "@/components/ui/GamePicker";
+import { GameCoverImage } from "@/components/ui/GameCoverImage";
 import { TagFilterToggle } from "@/components/ui/TagFilterToggle";
 import { TagFilterPanel } from "@/components/ui/TagFilterPanel";
 import { ActiveFilterBar } from "@/components/ui/ActiveFilterBar";
@@ -28,8 +29,11 @@ async function fetchTags(): Promise<Tag[]> {
   return json.data;
 }
 
+const STEPS = ["ゲーム選択", "部屋詳細"] as const;
+
 export default function NewRoomPage() {
   const router = useRouter();
+  const [step, setStep] = useState<1 | 2>(1);
   const [title, setTitle] = useState("");
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
   const [maxPlayers, setMaxPlayers] = useState(4);
@@ -103,6 +107,57 @@ export default function NewRoomPage() {
         </h1>
       </div>
 
+      {/* ステップインジケーター */}
+      <div className="flex items-center mb-6">
+        {STEPS.map((label, index) => {
+          const stepNum = (index + 1) as 1 | 2;
+          const isCompleted = stepNum < step;
+          const isCurrent = stepNum === step;
+          return (
+            <div key={stepNum} className="flex items-center flex-1">
+              <div className="flex items-center gap-2 shrink-0">
+                <div
+                  className="h-6 w-6 flex items-center justify-center rounded-full text-xs font-semibold transition-all duration-200 shrink-0"
+                  style={
+                    isCurrent
+                      ? {
+                          backgroundColor: "rgba(124,58,237,0.2)",
+                          color: "var(--accent-light)",
+                          border: "2px solid var(--accent)",
+                        }
+                      : isCompleted
+                        ? {
+                            backgroundColor: "var(--accent)",
+                            color: "#fff",
+                            border: "2px solid var(--accent)",
+                          }
+                        : {
+                            backgroundColor: "var(--bg-card)",
+                            color: "var(--text-muted)",
+                            border: "2px solid var(--border)",
+                          }
+                  }
+                >
+                  {isCompleted ? "✓" : stepNum}
+                </div>
+                <span
+                  className="text-xs sm:text-sm font-medium transition-colors duration-200"
+                  style={{ color: isCurrent ? "var(--accent-light)" : "var(--text-muted)" }}
+                >
+                  {label}
+                </span>
+              </div>
+              {index < STEPS.length - 1 && (
+                <div
+                  className="h-px flex-1 mx-3 transition-colors duration-300"
+                  style={{ backgroundColor: step > stepNum ? "var(--accent)" : "var(--border)" }}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
       {errorMessage && (
         <div
           className="mb-4 rounded-xl border px-4 py-3 text-sm"
@@ -112,160 +167,201 @@ export default function NewRoomPage() {
         </div>
       )}
 
-      <form onSubmit={handleSubmit} className="flex flex-col gap-5 sm:gap-6">
-        {/* Game Picker */}
-        <div>
-          <label className="mb-1.5 block text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-            ゲーム <span className="text-red-400">*</span>
-          </label>
-          <SingleGamePicker
-            value={selectedGame}
-            onChange={setSelectedGame}
-            placeholder="ゲームを選択"
+      {/* ステップ1: ゲーム選択 */}
+      {step === 1 && (
+        <div className="flex flex-col gap-5">
+          <GridGamePicker
+            value={selectedGame ? [selectedGame] : []}
+            onChange={(games) => {
+              const game = games[0] ?? null;
+              setSelectedGame(game);
+              if (game) setStep(2);
+            }}
+            max={1}
           />
-        </div>
-
-        {/* Title */}
-        <div>
-          <label className="mb-1.5 block text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-            部屋タイトル <span className="text-red-400">*</span>
-          </label>
-          <input
-            type="text"
-            required
-            maxLength={100}
-            placeholder=""
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            className="w-full rounded-xl border px-4 py-2.5 text-sm outline-none focus:border-[var(--accent)] transition-colors"
-            style={inputStyle}
-          />
-        </div>
-
-        {/* Max Players */}
-        <div>
-          <label className="mb-1.5 block text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-            最大人数 <span className="text-red-400">*</span>
-          </label>
-          <div className="inline-flex items-center rounded-xl border overflow-hidden" style={{ borderColor: "var(--border)" }}>
-            <button
-              type="button"
-              onClick={() => setMaxPlayers((v) => Math.max(2, v - 1))}
-              disabled={maxPlayers <= 2}
-              className="h-10 w-10 flex items-center justify-center transition-colors hover:opacity-80 disabled:opacity-30"
-              style={{ backgroundColor: "var(--bg-input)", color: "var(--text-primary)" }}
-              aria-label="人数を減らす"
+          <div className="flex gap-3">
+            <Link
+              href="/rooms"
+              className="flex-1 rounded-xl border px-6 py-3 text-center text-sm font-medium transition-all hover:opacity-80"
+              style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
             >
-              <Minus className="h-4 w-4" />
-            </button>
-            <div
-              className="h-10 w-14 flex items-center justify-center text-sm font-semibold border-x"
-              style={{ backgroundColor: "var(--bg-input)", borderColor: "var(--border)", color: "var(--text-primary)" }}
-            >
-              {maxPlayers}人
-            </div>
-            <button
-              type="button"
-              onClick={() => setMaxPlayers((v) => Math.min(16, v + 1))}
-              disabled={maxPlayers >= 16}
-              className="h-10 w-10 flex items-center justify-center transition-colors hover:opacity-80 disabled:opacity-30"
-              style={{ backgroundColor: "var(--bg-input)", color: "var(--text-primary)" }}
-              aria-label="人数を増やす"
-            >
-              <Plus className="h-4 w-4" />
-            </button>
+              キャンセル
+            </Link>
           </div>
         </div>
+      )}
 
-        {/* Play Style Tags */}
-        <div>
-          <label className="mb-1.5 block text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-            プレイスタイル{" "}
-            <span className="text-xs font-normal" style={{ color: "var(--text-muted)" }}>
-              （複数選択可）
-            </span>
-          </label>
-          <div className="flex items-center gap-2">
-            <TagFilterToggle
-              selectedCount={selectedSlugs.length}
-              panelOpen={panelOpen}
-              onPanelToggle={handlePanelToggle}
-              label="タグを選択"
+      {/* ステップ2: 部屋詳細入力 */}
+      {step === 2 && (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5 sm:gap-6">
+          {/* 選択済みゲーム（読み取り専用） */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+              ゲーム
+            </label>
+            <div
+              className="flex items-center gap-3 rounded-xl border px-3 py-2"
+              style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-input)" }}
+            >
+              {selectedGame && (
+                <>
+                  <GameCoverImage
+                    coverImageUrl={selectedGame.coverImageUrl}
+                    name={selectedGame.name}
+                    size="sm"
+                  />
+                  <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+                    {selectedGame.name}
+                  </span>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Title */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+              部屋タイトル <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              required
+              maxLength={100}
+              placeholder=""
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full rounded-xl border px-4 py-2.5 text-sm outline-none focus:border-[var(--accent)] transition-colors"
+              style={inputStyle}
             />
-            {selectedSlugs.length > 0 && (
+          </div>
+
+          {/* Max Players */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+              最大人数 <span className="text-red-400">*</span>
+            </label>
+            <div className="inline-flex items-center rounded-xl border overflow-hidden" style={{ borderColor: "var(--border)" }}>
               <button
                 type="button"
-                onClick={() => setSelectedSlugs([])}
-                className="shrink-0 text-xs transition-opacity hover:opacity-70"
-                style={{ color: "var(--text-muted)" }}
+                onClick={() => setMaxPlayers((v) => Math.max(2, v - 1))}
+                disabled={maxPlayers <= 2}
+                className="h-10 w-10 flex items-center justify-center transition-colors hover:opacity-80 disabled:opacity-30"
+                style={{ backgroundColor: "var(--bg-input)", color: "var(--text-primary)" }}
+                aria-label="人数を減らす"
               >
-                すべてクリア
+                <Minus className="h-4 w-4" />
               </button>
-            )}
+              <div
+                className="h-10 w-14 flex items-center justify-center text-sm font-semibold border-x"
+                style={{ backgroundColor: "var(--bg-input)", borderColor: "var(--border)", color: "var(--text-primary)" }}
+              >
+                {maxPlayers}人
+              </div>
+              <button
+                type="button"
+                onClick={() => setMaxPlayers((v) => Math.min(16, v + 1))}
+                disabled={maxPlayers >= 16}
+                className="h-10 w-10 flex items-center justify-center transition-colors hover:opacity-80 disabled:opacity-30"
+                style={{ backgroundColor: "var(--bg-input)", color: "var(--text-primary)" }}
+                aria-label="人数を増やす"
+              >
+                <Plus className="h-4 w-4" />
+              </button>
+            </div>
           </div>
-          <TagFilterPanel
-            tags={tags}
-            selectedTags={pendingSlugs}
-            onToggle={togglePendingSlug}
-            open={panelOpen}
-            onApply={handleApply}
-            applyLabel="決定"
-          />
-          <div className="mt-2 min-w-0">
-            <ActiveFilterBar
-              selectedTags={selectedSlugs}
-              allTags={tags}
-              onRemove={(slug) => setSelectedSlugs((prev) => prev.filter((s) => s !== slug))}
+
+          {/* Play Style Tags */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+              プレイスタイル{" "}
+              <span className="text-xs font-normal" style={{ color: "var(--text-muted)" }}>
+                （複数選択可）
+              </span>
+            </label>
+            <div className="flex items-center gap-2">
+              <TagFilterToggle
+                selectedCount={selectedSlugs.length}
+                panelOpen={panelOpen}
+                onPanelToggle={handlePanelToggle}
+                label="タグを選択"
+              />
+              {selectedSlugs.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setSelectedSlugs([])}
+                  className="shrink-0 text-xs transition-opacity hover:opacity-70"
+                  style={{ color: "var(--text-muted)" }}
+                >
+                  すべてクリア
+                </button>
+              )}
+            </div>
+            <TagFilterPanel
+              tags={tags}
+              selectedTags={pendingSlugs}
+              onToggle={togglePendingSlug}
+              open={panelOpen}
+              onApply={handleApply}
+              applyLabel="決定"
+            />
+            <div className="mt-2 min-w-0">
+              <ActiveFilterBar
+                selectedTags={selectedSlugs}
+                allTags={tags}
+                onRemove={(slug) => setSelectedSlugs((prev) => prev.filter((s) => s !== slug))}
+              />
+            </div>
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+              部屋の説明{" "}
+              <span className="text-xs font-normal" style={{ color: "var(--text-muted)" }}>
+                （任意）
+              </span>
+            </label>
+            <textarea
+              rows={2}
+              placeholder=""
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              maxLength={500}
+              className="w-full resize-none rounded-xl border px-4 py-2.5 text-sm outline-none focus:border-[var(--accent)] transition-colors"
+              style={inputStyle}
             />
           </div>
-        </div>
 
-        {/* Description */}
-        <div>
-          <label className="mb-1.5 block text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-            部屋の説明{" "}
-            <span className="text-xs font-normal" style={{ color: "var(--text-muted)" }}>
-              （任意）
-            </span>
-          </label>
-          <textarea
-            rows={2}
-            placeholder=""
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            maxLength={500}
-            className="w-full resize-none rounded-xl border px-4 py-2.5 text-sm outline-none focus:border-[var(--accent)] transition-colors"
-            style={inputStyle}
-          />
-        </div>
-
-        {/* Submit */}
-        <div className="flex gap-3">
-          <Link
-            href="/rooms"
-            className="flex-1 rounded-xl border px-6 py-3 text-center text-sm font-medium transition-all hover:opacity-80"
-            style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
-          >
-            キャンセル
-          </Link>
-          <button
-            type="submit"
-            disabled={!selectedGame || !title || mutation.isPending}
-            className="flex flex-1 items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90 hover:shadow-lg active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
-            style={{
-              background: "linear-gradient(135deg, var(--accent), #6d28d9)",
-              boxShadow: selectedGame && title ? "0 4px 14px rgba(124,58,237,0.4)" : "none",
-            }}
-          >
-            {mutation.isPending ? (
-              <CircleNotch className="h-4 w-4 animate-spin" />
-            ) : (
-              <Plus className="h-4 w-4" />
-            )}
-            作成する
-          </button>
-        </div>
-      </form>
+          {/* Buttons */}
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => setStep(1)}
+              className="flex items-center justify-center gap-2 rounded-xl border px-6 py-3 text-sm font-medium transition-all hover:opacity-80"
+              style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
+            >
+              <ArrowLeft className="h-4 w-4" />
+              戻る
+            </button>
+            <button
+              type="submit"
+              disabled={!title || mutation.isPending}
+              className="flex flex-1 items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-all hover:opacity-90 hover:shadow-lg active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
+              style={{
+                background: "linear-gradient(135deg, var(--accent), #6d28d9)",
+                boxShadow: title ? "0 4px 14px rgba(124,58,237,0.4)" : "none",
+              }}
+            >
+              {mutation.isPending ? (
+                <CircleNotch className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plus className="h-4 w-4" />
+              )}
+              作成する
+            </button>
+          </div>
+        </form>
+      )}
     </div>
   );
 }

--- a/app/rooms/new/page.tsx
+++ b/app/rooms/new/page.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import { useQuery, useMutation } from "@tanstack/react-query";
-import { Plus, Minus, CircleNotch, ArrowLeft } from "@phosphor-icons/react";
+import { Plus, Minus, CircleNotch, ArrowLeft, MagnifyingGlass } from "@phosphor-icons/react";
 import type { Game } from "@/lib/mock-data";
-import { GridGamePicker } from "@/components/ui/GamePicker";
 import { GameCoverImage } from "@/components/ui/GameCoverImage";
 import { TagFilterToggle } from "@/components/ui/TagFilterToggle";
 import { TagFilterPanel } from "@/components/ui/TagFilterPanel";
@@ -29,6 +27,13 @@ async function fetchTags(): Promise<Tag[]> {
   return json.data;
 }
 
+async function fetchGames(): Promise<Game[]> {
+  const res = await fetch("/api/v1/games");
+  if (!res.ok) return [];
+  const json = (await res.json()) as { data: Game[] };
+  return json.data;
+}
+
 const STEPS = ["ゲーム選択", "部屋詳細"] as const;
 
 export default function NewRoomPage() {
@@ -42,11 +47,23 @@ export default function NewRoomPage() {
   const [pendingSlugs, setPendingSlugs] = useState<string[]>([]);
   const [panelOpen, setPanelOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [gameQuery, setGameQuery] = useState("");
 
   const { data: tags = [] } = useQuery({
     queryKey: ["play-style-tags"],
     queryFn: fetchTags,
   });
+
+  const { data: allGames = [], isLoading: gamesLoading } = useQuery({
+    queryKey: ["games"],
+    queryFn: fetchGames,
+  });
+
+  const filteredGames = useMemo(() => {
+    const q = gameQuery.trim().toLowerCase();
+    if (!q) return allGames;
+    return allGames.filter((g) => g.name.toLowerCase().includes(q));
+  }, [allGames, gameQuery]);
 
   const mutation = useMutation({
     mutationFn: createRoom,
@@ -108,54 +125,56 @@ export default function NewRoomPage() {
       </div>
 
       {/* ステップインジケーター */}
-      <div className="flex items-center mb-6">
-        {STEPS.map((label, index) => {
-          const stepNum = (index + 1) as 1 | 2;
-          const isCompleted = stepNum < step;
-          const isCurrent = stepNum === step;
-          return (
-            <div key={stepNum} className="flex items-center flex-1">
-              <div className="flex items-center gap-2 shrink-0">
-                <div
-                  className="h-6 w-6 flex items-center justify-center rounded-full text-xs font-semibold transition-all duration-200 shrink-0"
-                  style={
-                    isCurrent
-                      ? {
-                          backgroundColor: "rgba(124,58,237,0.2)",
-                          color: "var(--accent-light)",
-                          border: "2px solid var(--accent)",
-                        }
-                      : isCompleted
+      <div className="flex items-center justify-center mb-6">
+        <div className="flex items-center">
+          {STEPS.map((label, index) => {
+            const stepNum = (index + 1) as 1 | 2;
+            const isCompleted = stepNum < step;
+            const isCurrent = stepNum === step;
+            return (
+              <div key={stepNum} className="flex items-center">
+                <div className="flex items-center gap-2 shrink-0">
+                  <div
+                    className="h-6 w-6 flex items-center justify-center rounded-full text-xs font-semibold transition-all duration-200 shrink-0"
+                    style={
+                      isCurrent
                         ? {
-                            backgroundColor: "var(--accent)",
-                            color: "#fff",
+                            backgroundColor: "rgba(124,58,237,0.2)",
+                            color: "var(--accent-light)",
                             border: "2px solid var(--accent)",
                           }
-                        : {
-                            backgroundColor: "var(--bg-card)",
-                            color: "var(--text-muted)",
-                            border: "2px solid var(--border)",
-                          }
-                  }
-                >
-                  {isCompleted ? "✓" : stepNum}
+                        : isCompleted
+                          ? {
+                              backgroundColor: "var(--accent)",
+                              color: "#fff",
+                              border: "2px solid var(--accent)",
+                            }
+                          : {
+                              backgroundColor: "var(--bg-card)",
+                              color: "var(--text-muted)",
+                              border: "2px solid var(--border)",
+                            }
+                    }
+                  >
+                    {isCompleted ? "✓" : stepNum}
+                  </div>
+                  <span
+                    className="text-xs sm:text-sm font-medium transition-colors duration-200"
+                    style={{ color: isCurrent ? "var(--accent-light)" : "var(--text-muted)" }}
+                  >
+                    {label}
+                  </span>
                 </div>
-                <span
-                  className="text-xs sm:text-sm font-medium transition-colors duration-200"
-                  style={{ color: isCurrent ? "var(--accent-light)" : "var(--text-muted)" }}
-                >
-                  {label}
-                </span>
+                {index < STEPS.length - 1 && (
+                  <div
+                    className="h-px w-12 mx-3 transition-colors duration-300"
+                    style={{ backgroundColor: step > stepNum ? "var(--accent)" : "var(--border)" }}
+                  />
+                )}
               </div>
-              {index < STEPS.length - 1 && (
-                <div
-                  className="h-px flex-1 mx-3 transition-colors duration-300"
-                  style={{ backgroundColor: step > stepNum ? "var(--accent)" : "var(--border)" }}
-                />
-              )}
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
 
       {errorMessage && (
@@ -169,25 +188,73 @@ export default function NewRoomPage() {
 
       {/* ステップ1: ゲーム選択 */}
       {step === 1 && (
-        <div className="flex flex-col gap-5">
-          <GridGamePicker
-            value={selectedGame ? [selectedGame] : []}
-            onChange={(games) => {
-              const game = games[0] ?? null;
-              setSelectedGame(game);
-              if (game) setStep(2);
-            }}
-            max={1}
-          />
-          <div className="flex gap-3">
-            <Link
-              href="/rooms"
-              className="flex-1 rounded-xl border px-6 py-3 text-center text-sm font-medium transition-all hover:opacity-80"
-              style={{ borderColor: "var(--border)", color: "var(--text-secondary)" }}
-            >
-              キャンセル
-            </Link>
+        <div className="flex flex-col gap-4">
+          {/* 検索バー */}
+          <div className="relative">
+            <MagnifyingGlass
+              className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2"
+              style={{ color: "var(--text-secondary)" }}
+            />
+            <input
+              type="text"
+              value={gameQuery}
+              onChange={(e) => setGameQuery(e.target.value)}
+              placeholder="ゲームを検索..."
+              className="w-full rounded-xl border py-2.5 pl-9 pr-4 text-sm outline-none transition-colors focus:border-[var(--accent)]"
+              style={{
+                backgroundColor: "var(--bg-card)",
+                borderColor: "var(--border)",
+                color: "var(--text-primary)",
+              }}
+            />
           </div>
+
+          {/* ゲームグリッド */}
+          {gamesLoading ? (
+            <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5">
+              {Array.from({ length: 10 }).map((_, i) => (
+                <div key={i} className="animate-fade-in" style={{ animationDelay: `${i * 40}ms` }}>
+                  <div className="aspect-[3/4] w-full rounded-xl animate-shimmer" />
+                  <div className="mt-2 h-3 w-3/4 rounded-md animate-shimmer" />
+                </div>
+              ))}
+            </div>
+          ) : filteredGames.length === 0 ? (
+            <div className="py-16 text-center">
+              <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+                &ldquo;{gameQuery}&rdquo; に一致するゲームが見つかりません
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5">
+              {filteredGames.map((game, index) => (
+                <button
+                  key={game.id}
+                  type="button"
+                  onClick={() => {
+                    setSelectedGame(game);
+                    setStep(2);
+                  }}
+                  className="group text-left animate-fade-in-up"
+                  style={{ animationDelay: `${Math.min(index, 11) * 40}ms` }}
+                >
+                  <div className="relative aspect-[3/4] w-full overflow-hidden rounded-xl">
+                    <GameCoverImage
+                      coverImageUrl={game.coverImageUrl}
+                      name={game.name}
+                      className="transition-transform duration-300 group-hover:scale-105"
+                    />
+                    <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/70 via-transparent p-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                      <span className="text-xs font-semibold text-white">選択する →</span>
+                    </div>
+                  </div>
+                  <p className="mt-1.5 truncate text-xs font-medium" style={{ color: "var(--text-primary)" }}>
+                    {game.name}
+                  </p>
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/app/rooms/new/page.tsx
+++ b/app/rooms/new/page.tsx
@@ -3,10 +3,10 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation } from "@tanstack/react-query";
-import { Plus, Minus, CircleNotch, ArrowLeft } from "@phosphor-icons/react";
+import Image from "next/image";
+import { Plus, Minus, CircleNotch, ArrowLeft, GameController } from "@phosphor-icons/react";
 import type { GameResult } from "@/lib/games";
 import { GamesGrid } from "@/app/games/GamesGrid";
-import { GameCoverImage } from "@/components/ui/GameCoverImage";
 import { TagFilterToggle } from "@/components/ui/TagFilterToggle";
 import { TagFilterPanel } from "@/components/ui/TagFilterPanel";
 import { ActiveFilterBar } from "@/components/ui/ActiveFilterBar";
@@ -182,28 +182,39 @@ export default function NewRoomPage() {
       {step === 2 && (
         <form onSubmit={handleSubmit} className="flex flex-col gap-5 sm:gap-6">
           {/* 選択済みゲーム（読み取り専用） */}
-          <div>
-            <label className="mb-1.5 block text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-              ゲーム
-            </label>
-            <div
-              className="flex items-center gap-3 rounded-xl border px-3 py-2"
-              style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-input)" }}
-            >
-              {selectedGame && (
-                <>
-                  <GameCoverImage
-                    coverImageUrl={selectedGame.coverImageUrl}
-                    name={selectedGame.name}
-                    size="sm"
+          {selectedGame && (
+            <div className="flex items-center gap-5">
+              <div className="h-24 w-16 shrink-0 overflow-hidden rounded-xl">
+                {selectedGame.coverImageUrl ? (
+                  <Image
+                    src={selectedGame.coverImageUrl}
+                    alt={selectedGame.name}
+                    width={64}
+                    height={96}
+                    className="h-full w-full object-cover"
                   />
-                  <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-                    {selectedGame.name}
-                  </span>
-                </>
-              )}
+                ) : (
+                  <div
+                    className="flex h-full items-center justify-center rounded-xl"
+                    style={{ backgroundColor: "var(--bg-card)" }}
+                  >
+                    <GameController className="h-8 w-8 opacity-40" style={{ color: "var(--accent)" }} />
+                  </div>
+                )}
+              </div>
+              <div>
+                <p
+                  className="mb-1 text-xs font-medium uppercase tracking-wider"
+                  style={{ color: "var(--text-muted)" }}
+                >
+                  選択中のゲーム
+                </p>
+                <p className="text-xl font-bold" style={{ color: "var(--text-primary)" }}>
+                  {selectedGame.name}
+                </p>
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Title */}
           <div>

--- a/docs/06_sitemap.md
+++ b/docs/06_sitemap.md
@@ -65,7 +65,7 @@
 | `/games/[gameId]/rooms` | ゲーム別部屋一覧 | 選択したゲームで絞り込んだ部屋を新着順で一覧表示。フィルター：プレイスタイルタグ（OR 検索）・空き枠あり/なし（`vacant`）・フリーワード（`q`、部屋名・募集文）。URL パラメータでフィルター条件を保持（ブックマーク・共有可）。ログイン済みかつ参加中の部屋がある場合はヘッダーに「参加中の部屋へ」ボタンを表示 | `GET /rooms`（`gameId` パラメータ付き）、`GET /rooms/current`（参加中チェック用） |
 | `/rooms/current` | 参加中の部屋リダイレクト | サーバーサイドで参加中の roomId を取得し `/rooms/{roomId}` へリダイレクト。参加中の部屋がない場合は「参加中の部屋がありません」メッセージと「部屋を探す」リンクを表示 | Prisma 直接アクセス |
 | `/rooms/current/chat` | 参加中の部屋チャット | サーバーサイドで参加中の roomId を取得し `/rooms/{roomId}/chat` へリダイレクト。参加中の部屋がない場合は「参加中の部屋がありません」メッセージと「部屋を探す」リンクを表示 | Prisma 直接アクセス（リダイレクト後は `GET /rooms/{roomId}/messages`、WebSocket `chat:send` / `chat:message`） |
-| `/rooms/new` | 部屋作成 | タイトル・ゲーム（IGDB連携検索で選択）・最大人数・説明・タグを入力して部屋を作成 | `GET /play-style-tags`、`GET /games/search`、`POST /rooms` |
+| `/rooms/new` | 部屋作成 | 2ステップウィザード形式。Step1: `GamesGrid` コンポーネントでゲームをグリッド選択（選択と同時に Step2 へ自動遷移）。Step2: タイトル・最大人数・プレイスタイルタグ・説明を入力して部屋を作成。ステップインジケーター表示あり | `GET /games`、`GET /play-style-tags`、`POST /rooms` |
 | `/rooms/[roomId]` | 部屋詳細 | 部屋情報・参加者一覧表示、参加 / 退室 / 解散、ホストによる部屋情報編集、SNS シェア、リアルタイム参加者更新（WebSocket）。ログイン済みで自分が参加中の場合は `/rooms/current` へリダイレクト。**未ログインでも `inviteToken` パラメータ付き招待リンク経由またはゲストセッション保持時はアクセス可**（Modal A 表示） | `GET /rooms/{roomId}`、`POST /rooms/{roomId}/join`、`POST /rooms/{roomId}/leave`、`POST /rooms/{roomId}/close`、`PATCH /rooms/{roomId}`、`POST /rooms/{roomId}/share`、`GET /play-style-tags`（ホスト編集用）、`GET /rooms/current`（自分の参加中部屋かの判定用） |
 | `/rooms/[roomId]?inviteToken=xxx` | 部屋詳細（招待URL経由） | 招待トークン付きURLで部屋詳細にアクセスした場合の追加モーダル表示。**Modal A（認証誘導）**：未ログイン＋guestFlowなし → 「ログインして参加」「ゲストで参加」ボタン。**Modal A（新規ユーザーエラー）**：OAuth後に新規ユーザーと判定 → 「招待リンクでの新規登録はできません」メッセージ＋「ゲストで参加」「プロフィール設定」ボタン。**Modal B（表示名入力）**：guestFlow=true＋未ログイン → 表示名入力でゲスト参加・チャットへ遷移 | `POST /invite/{inviteToken}/join` |
 | `/rooms/[roomId]/guest` | ゲスト参加フロー（旧） | 募集リンク経由でアクセスした未ログインユーザー向け。表示名（任意）を入力してゲストセッションを発行し、そのまま部屋に参加。ログインを促すボタンも併設 | `POST /auth/guest`、`POST /rooms/{roomId}/join` |
@@ -189,6 +189,7 @@
 | ver 6.2 | 2026年3月 | オンボーディング画面を5ステップウィザード形式に刷新。ゲーム選択を `GET /games`（全件取得）に変更し `GridGamePicker` コンポーネントで全タイトルをグリッド表示。ヘッダー・ボトムナビを非表示化しロゴのみ表示。`needsProfileSetup` JWT フラグによるリダイレクト制御を追加 |
 | ver 6.3 | 2026年4月 | 招待URL経由の参加フロー刷新。Modal A（認証誘導）・Modal B（表示名入力）の2段階モーダルを実装。招待URL経由の新規OAuthユーザーを招待ページに戻し `error=new_user` でエラー表示。ログインページに招待バナーとゲスト参加リンクを追加 |
 | ver 6.4 | 2026年4月 | 全画面ログイン必須化。`/login` 以外のすべての画面でログインを必須とし、未ログイン時は `/login` へリダイレクト。例外: ①`inviteToken` 付き `/rooms/[roomId]` は未ログインでもアクセス可（招待リンク Modal A 表示）、②ゲストセッション Cookie 保持時は `/rooms/[roomId]` 配下すべてアクセス可 |
+| ver 6.5 | 2026年4月 | 部屋作成ページ（`/rooms/new`）を2ステップウィザード化。Step1でゲームをグリッド選択（`GamesGrid` 共用）、Step2で部屋詳細入力。IGDB連携検索を廃止し `GET /games` に統一 |
 
 ---
 

--- a/e2e/new-room.spec.ts
+++ b/e2e/new-room.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("部屋作成ページ（/rooms/new）", () => {
+  test("未認証で /rooms/new にアクセスすると /login にリダイレクトされる", async ({
+    page,
+  }) => {
+    await page.goto("/rooms/new");
+    await expect(page).toHaveURL(/\/login/);
+  });
+});
+
+test.describe("ゲーム選択画面（/games）— GamesGrid 共通コンポーネント", () => {
+  test("「ゲームを選択」の見出しが表示される", async ({ page }) => {
+    await page.goto("/games");
+    await expect(
+      page.getByRole("heading", { name: "ゲームを選択" })
+    ).toBeVisible();
+  });
+
+  test("ゲーム検索バーが表示される", async ({ page }) => {
+    await page.goto("/games");
+    await expect(page.getByRole("textbox")).toBeVisible();
+  });
+
+  test("ゲームカードをクリックすると /games/{id}/rooms に遷移する", async ({
+    page,
+  }) => {
+    await page.goto("/games");
+
+    // ゲームカードが少なくとも1件表示されるのを待つ
+    const firstGameButton = page.getByRole("button").first();
+    await expect(firstGameButton).toBeVisible();
+
+    await firstGameButton.click();
+    await expect(page).toHaveURL(/\/games\/.+\/rooms/);
+  });
+});


### PR DESCRIPTION
## 概要

- `/rooms/new` の部屋作成フォームを、ゲーム選択 → 部屋詳細入力の2ステップウィザードに変更
- URL は `/rooms/new` のまま、クライアント側 state でステップを管理

## 変更内容

### `app/rooms/new/page.tsx`
- ステップ1（ゲーム選択）: `/games` ページと同じ `GamesGrid` UIを使用（`max-w-screen-xl` の広いレイアウト）
  - ゲームカードをクリックした瞬間にステップ2へ自動遷移
- ステップ2（部屋詳細入力）: 選択済みゲームを `/games/[gameId]/rooms` ヘッダー風の読み取り専用UIで表示（縦長カバー画像＋ゲーム名）
  - 「戻る」ボタンでゲーム選択に戻れる（選択状態は保持）
- ステップインジケーター: 番号付き円＋ラベル＋コネクター線を中央揃えで表示

### `app/games/GamesGrid.tsx`
- `games`・`roomCounts` をオプション化し、`onSelect` コールバックを追加
- `games` 未指定時は `/api/v1/games` から内部フェッチ（スケルトン表示あり）
- `onSelect` 指定時はゲーム名のみ表示・hover テキストを「選択する →」に変更

Closes #136