### PR TITLE
fix: テストの @phosphor-icons/react モックに CaretLeft を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# pnpm
+.pnpm-store/
+
 # claude code
 .claude/
 .worktrees/

--- a/app/rooms/[roomId]/chat/ChatParticipantList.test.tsx
+++ b/app/rooms/[roomId]/chat/ChatParticipantList.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 
 vi.mock("@phosphor-icons/react", () => ({
   ArrowLeft: () => <span data-testid="icon-arrow-left" />,
+  CaretLeft: () => <span data-testid="icon-caret-left" />,
   Crown: () => <span data-testid="icon-crown" />,
 }));
 
@@ -57,9 +58,9 @@ describe("ChatParticipantList", () => {
       expect(screen.getByText("Valorant")).toBeInTheDocument();
     });
 
-    it("「部屋の詳細へ」リンクが正しい href を持つ", () => {
+    it("戻るリンクが正しい href を持つ", () => {
       render(<ChatParticipantList {...defaultProps} />);
-      expect(screen.getByRole("link", { name: /部屋の詳細へ/ })).toHaveAttribute(
+      expect(screen.getByRole("link", { name: /戻る/ })).toHaveAttribute(
         "href",
         "/rooms/room-1"
       );

--- a/app/users/me/edit/page.test.tsx
+++ b/app/users/me/edit/page.test.tsx
@@ -43,6 +43,7 @@ vi.mock("next/link", () => ({
 
 vi.mock("@phosphor-icons/react", () => ({
   ArrowLeft: () => <span />,
+  CaretLeft: () => <span />,
   FloppyDisk: () => <span />,
   Camera: () => <span />,
 }));

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -105,6 +105,11 @@
       "source": "pbakaus/impeccable",
       "sourceType": "github",
       "computedHash": "3ed1b5db2db9594a15fca4d01a0f4b07581ccd635844a8c667782c19b83c95e2"
+    },
+    "vercel-react-best-practices": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "computedHash": "43ca6c197f8ec13055079da7053232d477068b03ca443f9ac1bc819b95cdd432"
     }
   }
 }


### PR DESCRIPTION
## Summary

- `BackButton` コンポーネントが `CaretLeft` アイコンを使用しているが、テストのモック定義に含まれていなかったためテストが失敗していた
- `ChatParticipantList.test.tsx` と `app/users/me/edit/page.test.tsx` のモックに `CaretLeft` を追加
- `ChatParticipantList.test.tsx` のリンクテストを `BackButton` の実際の `aria-label="戻る"` に合わせて修正

## Test plan

- [ ] `pnpm test` で全テストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)