### PR TITLE
fix: 部屋作成後に /rooms/new を再訪問するとフォームがリセットされない問題を修正

### DIFF
--- a/app/rooms/new/page.test.tsx
+++ b/app/rooms/new/page.test.tsx
@@ -149,6 +149,19 @@ describe("NewRoomPage", () => {
     });
   });
 
+  it("createRoom 成功後にフォームがリセットされステップ1に戻る", async () => {
+    render(<NewRoomPage />);
+    selectGame();
+    fireEvent.change(screen.getAllByRole("textbox")[0], { target: { value: "テスト部屋" } });
+    act(() => {
+      mutationCallbacks.onSuccess?.({ data: { id: "room-123" } });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("game-picker")).toBeInTheDocument();
+    });
+    expect(mockPush).toHaveBeenCalledWith("/rooms/room-123");
+  });
+
   it("createRoom 失敗時にエラーメッセージが表示される", async () => {
     render(<NewRoomPage />);
     selectGame();

--- a/app/rooms/new/page.tsx
+++ b/app/rooms/new/page.tsx
@@ -47,9 +47,22 @@ export default function NewRoomPage() {
     queryFn: fetchTags,
   });
 
+  const resetForm = () => {
+    setStep(1);
+    setTitle("");
+    setSelectedGame(null);
+    setMaxPlayers(4);
+    setDescription("");
+    setSelectedSlugs([]);
+    setPendingSlugs([]);
+    setPanelOpen(false);
+    setErrorMessage(null);
+  };
+
   const mutation = useMutation({
     mutationFn: createRoom,
     onSuccess: (res) => {
+      resetForm();
       router.push(`/rooms/${res.data.id}`);
     },
     onError: (err: Error) => {


### PR DESCRIPTION
## 概要

- 部屋作成成功後、`onSuccess` コールバック内で全フォーム state を初期値にリセットする
- Next.js Router Cache によりページコンポーネントがアンマウントされないため、明示的なリセットが必要

## 変更内容

- `app/rooms/new/page.tsx`: `resetForm` 関数を追加し `onSuccess` で呼び出す
- `app/rooms/new/page.test.tsx`: 成功後にステップ1へ戻ることを確認するテストを追加

Closes #150