### PR TITLE
fix: 解散確認モーダルが参加者リストに被る問題を修正

### DIFF
--- a/components/ui/ConfirmModal.tsx
+++ b/components/ui/ConfirmModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { createPortal } from "react-dom";
 import { CircleNotch } from "@phosphor-icons/react";
 
 type Props = {
@@ -12,7 +13,7 @@ type Props = {
 };
 
 export function ConfirmModal({ title, description, confirmLabel, onConfirm, onCancel, isPending }: Props) {
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4 animate-fade-in"
       onClick={onCancel}
@@ -50,6 +51,7 @@ export function ConfirmModal({ title, description, confirmLabel, onConfirm, onCa
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
## 概要

`ConfirmModal` を `createPortal` で `document.body` 直下にレンダリングするよう変更し、親要素のスタッキングコンテキストから脱出させた。

## 原因

`RoomDetailView` の `animate-fade-in-up`（`opacity` + `translateY`）が新しいスタッキングコンテキストを生成しており、その内部にある `ConfirmModal` の `z-50` が `ParticipantSidebar` を超えられなかった。

## 変更ファイル

- `components/ui/ConfirmModal.tsx` — `createPortal(…, document.body)` を使用

Closes #151