### PR TITLE
feat: タグフィルターパネルの欄外クリックで選択確定 (#153)

### DIFF
--- a/app/rooms/RoomsFilter.tsx
+++ b/app/rooms/RoomsFilter.tsx
@@ -117,6 +117,7 @@ export function RoomsFilter({ gameId }: { gameId?: string }) {
           onToggle={togglePendingTag}
           open={panelOpen}
           onApply={handleApply}
+          onClickOutside={handleApply}
         />
         <div className="mt-2 min-w-0">
           <ActiveFilterBar

--- a/app/rooms/new/page.tsx
+++ b/app/rooms/new/page.tsx
@@ -314,6 +314,7 @@ export default function NewRoomPage() {
               open={panelOpen}
               onApply={handleApply}
               applyLabel="決定"
+              onClickOutside={handleApply}
             />
             <div className="mt-2 min-w-0">
               <ActiveFilterBar

--- a/components/ui/TagFilterPanel.test.tsx
+++ b/components/ui/TagFilterPanel.test.tsx
@@ -76,4 +76,31 @@ describe("TagFilterPanel", () => {
       expect(btn).toHaveAttribute("type", "button");
     });
   });
+
+  it("パネル外をクリックすると onClickOutside が呼ばれる", () => {
+    const onClickOutside = vi.fn();
+    render(
+      <TagFilterPanel tags={tags} selectedTags={[]} onToggle={vi.fn()} open={true} onClickOutside={onClickOutside} />
+    );
+    fireEvent.mouseDown(document.body);
+    expect(onClickOutside).toHaveBeenCalledOnce();
+  });
+
+  it("パネル内をクリックしても onClickOutside は呼ばれない", () => {
+    const onClickOutside = vi.fn();
+    render(
+      <TagFilterPanel tags={tags} selectedTags={[]} onToggle={vi.fn()} open={true} onClickOutside={onClickOutside} />
+    );
+    fireEvent.mouseDown(screen.getByText("ガチ勢"));
+    expect(onClickOutside).not.toHaveBeenCalled();
+  });
+
+  it("パネルが閉じているときは onClickOutside が登録されない", () => {
+    const onClickOutside = vi.fn();
+    render(
+      <TagFilterPanel tags={tags} selectedTags={[]} onToggle={vi.fn()} open={false} onClickOutside={onClickOutside} />
+    );
+    fireEvent.mouseDown(document.body);
+    expect(onClickOutside).not.toHaveBeenCalled();
+  });
 });

--- a/components/ui/TagFilterPanel.tsx
+++ b/components/ui/TagFilterPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef, useEffect } from "react";
 import clsx from "clsx";
 
 type Tag = {
@@ -17,9 +18,23 @@ type TagFilterPanelProps = {
   open: boolean;
   onApply?: () => void;
   applyLabel?: string;
+  onClickOutside?: () => void;
 };
 
-export function TagFilterPanel({ tags, selectedTags, onToggle, open, onApply, applyLabel }: TagFilterPanelProps) {
+export function TagFilterPanel({ tags, selectedTags, onToggle, open, onApply, applyLabel, onClickOutside }: TagFilterPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClickOutside?.();
+      }
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [open, onClickOutside]);
+
   if (!open) return null;
 
   const categoryMap = new Map<string, { name: string; tags: Tag[] }>();
@@ -43,6 +58,7 @@ export function TagFilterPanel({ tags, selectedTags, onToggle, open, onApply, ap
 
   return (
     <div
+      ref={panelRef}
       className="animate-slide-down mt-2 rounded-xl border p-4"
       style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
     >


### PR DESCRIPTION
## 概要

- パネル外（欄外）をクリックした際に、「決定」ボタンと同じ動作（pendingタグを確定してパネルを閉じる）を実行するように改善
- `TagFilterPanel` に `onClickOutside` prop を追加し、`useRef` + `useEffect` の `mousedown` イベントで欄外クリックを検出
- `RoomsFilter`・部屋作成ページの両方に適用

## 変更内容

- `components/ui/TagFilterPanel.tsx` — `onClickOutside?: () => void` prop 追加、click-outside 検出実装
- `components/ui/TagFilterPanel.test.tsx` — 欄外クリック・内部クリック・パネル閉時の 3 件テスト追加
- `app/rooms/RoomsFilter.tsx` — `onClickOutside={handleApply}` を渡すよう変更
- `app/rooms/new/page.tsx` — 同上

## テスト

- [x] ユニットテスト 11 件すべてパス
- [x] ESLint エラーなし

Closes #153