### PR TITLE
fix: スケルトンがある画面のフェードインを削除し、ゲーム一覧のスケルトン枚数を増やす

### DIFF
--- a/app/HomeGameGrid.tsx
+++ b/app/HomeGameGrid.tsx
@@ -13,13 +13,12 @@ export function HomeGameGrid({ games }: Props) {
 
   return (
     <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-6">
-      {games.map((game, index) => {
+      {games.map((game) => {
         return (
           <button
             key={game.id}
             onClick={() => router.push(`/games/${game.id}/rooms`)}
-            className="group text-left animate-fade-in-up"
-            style={{ animationDelay: `${Math.min(index, 11) * 50}ms` }}
+            className="group text-left"
           >
             <div className="relative aspect-[3/4] w-full overflow-hidden rounded-xl">
               <GameCoverImage

--- a/app/games/GamesGrid.tsx
+++ b/app/games/GamesGrid.tsx
@@ -75,8 +75,8 @@ export function GamesGrid({ games: gamesProp, roomCounts = {}, onSelect }: Props
       {/* Game grid */}
       {loading ? (
         <div className="grid grid-cols-3 gap-4 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-          {Array.from({ length: 12 }).map((_, i) => (
-            <div key={i} className="animate-fade-in" style={{ animationDelay: `${i * 40}ms` }}>
+          {Array.from({ length: 24 }).map((_, i) => (
+            <div key={i}>
               <div className="aspect-[3/4] w-full rounded-xl animate-shimmer" />
               <div className="mt-2 h-3 w-3/4 rounded-md animate-shimmer" />
             </div>
@@ -84,15 +84,14 @@ export function GamesGrid({ games: gamesProp, roomCounts = {}, onSelect }: Props
         </div>
       ) : filteredGames.length > 0 ? (
         <div className="grid grid-cols-3 gap-4 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-          {filteredGames.map((game, index) => {
+          {filteredGames.map((game) => {
             const roomCount = roomCounts[game.id] ?? 0;
 
             return (
               <button
                 key={game.id}
                 onClick={() => handleClick(game)}
-                className="group text-left animate-fade-in-up"
-                style={{ animationDelay: `${Math.min(index, 11) * 50}ms` }}
+                className="group text-left"
               >
                 {/* Cover image */}
                 <div className="relative aspect-[3/4] w-full overflow-hidden rounded-xl">

--- a/app/games/loading.tsx
+++ b/app/games/loading.tsx
@@ -9,7 +9,7 @@ export default function GamesLoading() {
         <div className="h-4 w-12 rounded animate-shimmer" />
       </div>
       <div className="grid grid-cols-3 gap-4 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-        {Array.from({ length: 12 }).map((_, i) => (
+        {Array.from({ length: 24 }).map((_, i) => (
           <div key={i} className="space-y-2">
             <div className="aspect-[3/4] w-full rounded-xl animate-shimmer" />
             <div className="h-3.5 w-full rounded animate-shimmer" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -121,7 +121,7 @@ export default async function HomePage() {
   return (
     <main className="mx-auto max-w-screen-xl px-4 py-10 pb-24 md:pb-10 space-y-12">
       {/* ── おすすめゲーム ── */}
-      <section className="animate-fade-in-up">
+      <section>
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-xl font-bold" style={{ color: "var(--text-primary)" }}>
             おすすめゲーム
@@ -140,7 +140,7 @@ export default async function HomePage() {
       </section>
 
       {/* ── 募集中の部屋 ── */}
-      <section className="animate-fade-in-up" style={{ animationDelay: "100ms" }}>
+      <section>
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-xl font-bold" style={{ color: "var(--text-primary)" }}>
             募集中の部屋

--- a/app/rooms/RoomsFilter.tsx
+++ b/app/rooms/RoomsFilter.tsx
@@ -134,8 +134,8 @@ export function RoomsFilter({ gameId }: { gameId?: string }) {
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className="rounded-2xl border overflow-hidden animate-fade-in"
-              style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)", animationDelay: `${i * 60}ms` }}
+              className="rounded-2xl border overflow-hidden"
+              style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
             >
               <div className="h-32 animate-shimmer" />
               <div className="p-4 space-y-3">
@@ -169,10 +169,8 @@ export function RoomsFilter({ gameId }: { gameId?: string }) {
         </div>
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-          {filtered.map((room, index) => (
-            <div key={room.id} className="animate-fade-in-up" style={{ animationDelay: `${index * 60}ms` }}>
-              <RoomCard room={room} />
-            </div>
+          {filtered.map((room) => (
+            <RoomCard key={room.id} room={room} />
           ))}
         </div>
       )}

--- a/app/rooms/[roomId]/ParticipantSidebar.tsx
+++ b/app/rooms/[roomId]/ParticipantSidebar.tsx
@@ -20,7 +20,7 @@ export function ParticipantSidebar({
   currentGuestSessionId,
 }: ParticipantSidebarProps) {
   return (
-    <div className="space-y-4 animate-fade-in-up" style={{ animationDelay: "160ms" }}>
+    <div className="space-y-4">
       <div
         className="rounded-2xl border p-4 sm:p-5"
         style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}

--- a/app/rooms/[roomId]/RoomDetailView.tsx
+++ b/app/rooms/[roomId]/RoomDetailView.tsx
@@ -137,8 +137,8 @@ export function RoomDetailView({ roomId }: Props) {
           {isParticipant && (
             <Link
               href={`/rooms/${room.id}/chat`}
-              className="flex items-center justify-between rounded-xl border px-5 py-4 transition-all hover:border-[var(--accent)] animate-fade-in-up"
-              style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)", animationDelay: "80ms" }}
+              className="flex items-center justify-between rounded-xl border px-5 py-4 transition-all hover:border-[var(--accent)]"
+              style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
             >
               <div className="flex items-center gap-3">
                 <div
@@ -158,23 +158,17 @@ export function RoomDetailView({ roomId }: Props) {
           )}
 
           {/* Invite link */}
-          {isHost && room.status !== "closed" && (
-            <div className="animate-fade-in-up" style={{ animationDelay: "80ms" }}>
-              <InvitePanel roomId={room.id} />
-            </div>
-          )}
+          {isHost && room.status !== "closed" && <InvitePanel roomId={room.id} />}
 
           {/* Actions */}
-          <div className="animate-fade-in-up" style={{ animationDelay: "80ms" }}>
-            <RoomActions
-              roomId={room.id}
-              isParticipant={isParticipant}
-              isHost={isHost}
-              isGuest={isGuest}
-              status={room.status}
-              onInviteJoinClick={onInviteJoinClick}
-            />
-          </div>
+          <RoomActions
+            roomId={room.id}
+            isParticipant={isParticipant}
+            isHost={isHost}
+            isGuest={isGuest}
+            status={room.status}
+            onInviteJoinClick={onInviteJoinClick}
+          />
         </div>
 
         {/* Sidebar: Participants */}

--- a/app/rooms/[roomId]/RoomHeaderCard.tsx
+++ b/app/rooms/[roomId]/RoomHeaderCard.tsx
@@ -18,7 +18,7 @@ export function RoomHeaderCard({ room }: RoomHeaderCardProps) {
 
   return (
     <div
-      className="rounded-2xl border overflow-hidden animate-fade-in-up"
+      className="rounded-2xl border overflow-hidden"
       style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border)" }}
     >
       {/* Game cover header */}


### PR DESCRIPTION
## 概要

- スケルトン (`animate-shimmer`) を持つ画面について、スケルトン → 本体 UI の切替時に走っていた `animate-fade-in` / `animate-fade-in-up` およびスタガー用 `animationDelay` を削除した。スケルトン自体に当たっていたフェードインも合わせて除去。
- ゲーム一覧 (`/games`) のスケルトン枚数を 12 → 24 に増やし、どの画面サイズでも画面全体がスケルトンで埋まるようにした。

## 変更理由

- スケルトンは「そのまま本体 UI に変身する」ことで読み込みを自然に見せる役割。ここでフェードインが走ると、スケルトンが一瞬消えて UI がふわっと湧き上がる挙動になり、メタファが壊れて違和感があった。
- ゲーム一覧は xl (6 列) で 2 行しか表示されず画面下部が空白になっていたため、スケルトン中に「ページが短い」誤印象を与えていた。

## 変更ファイル

- `app/page.tsx` — ホーム 2 section の fade-in-up 削除
- `app/HomeGameGrid.tsx` — ゲームカードの fade-in-up + stagger 削除
- `app/games/GamesGrid.tsx` — スケルトン / 本体カード両方の fade-in(-up) 削除、スケルトン枚数 12 → 24
- `app/games/loading.tsx` — スケルトン枚数 12 → 24
- `app/rooms/RoomsFilter.tsx` — スケルトン / 本体両方の fade-in(-up) 削除、冗長なラッパー div 除去
- `app/rooms/[roomId]/RoomHeaderCard.tsx` — カード本体の fade-in-up 削除
- `app/rooms/[roomId]/RoomDetailView.tsx` — チャット導線 / 招待 / アクションの 3 箇所削除 (ラッパーごと)
- `app/rooms/[roomId]/ParticipantSidebar.tsx` — サイドバーの fade-in-up 削除

スコープ外: オンボーディング・ログイン・モーダル・チャット新着など、スケルトンを介さないアニメーションは従来どおり残している。

## Test plan

- [ ] `/` (ホーム) でスケルトン → UI の切替時にフェードインが走らないこと
- [ ] `/games` でスケルトンが画面全体を埋め、切替時にフェードインが走らないこと
- [ ] `/rooms` / `/games/[gameId]/rooms` でスケルトン → UI の切替時にフェードインが走らないこと
- [ ] `/rooms/[roomId]` でヘッダー / サイドバー / アクションがフェードインなしで表示されること
- [ ] オンボーディング、ログイン、モーダル、チャット新着、タグフィルタパネルのアニメーションが従来どおり動くこと
- [ ] `pnpm lint` がエラーなく通ること
- [ ] `pnpm test` が通ること