### PR TITLE
feat: モバイル版トップページにヘッダー(ロゴ+検索バー)を追加

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { CaretRight } from "@phosphor-icons/react/dist/ssr";
 import { connection } from "next/server";
 import { GameStripSkeleton } from "@/components/ui/skeletons/GameStripSkeleton";
 import { RoomGrid } from "@/components/ui/skeletons/RoomGrid";
+import { MobileHomeHeader } from "@/components/ui/MobileHomeHeader";
 import { HomeRecommendedGames } from "./HomeRecommendedGames";
 import { HomeRecruitingRooms } from "./HomeRecruitingRooms";
 
@@ -11,7 +12,9 @@ export default async function HomePage() {
   await connection();
 
   return (
-    <main className="mx-auto max-w-screen-xl px-4 py-10 pb-24 md:pb-10 space-y-12">
+    <>
+      <MobileHomeHeader />
+      <main className="mx-auto max-w-screen-xl px-4 py-10 pb-24 md:pb-10 space-y-12">
       {/* ── おすすめゲーム ── */}
       <section>
         <div className="mb-4 flex items-center justify-between">
@@ -54,5 +57,6 @@ export default async function HomePage() {
         </Suspense>
       </section>
     </main>
+    </>
   );
 }

--- a/components/ui/HeaderSearchBar.tsx
+++ b/components/ui/HeaderSearchBar.tsx
@@ -12,8 +12,9 @@ export function HeaderSearchBar() {
       className="relative w-full max-w-lg"
     >
       <MagnifyingGlass
-        className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2"
-        style={{ color: "var(--text-secondary)" }}
+        className="absolute left-2 top-1/2 -translate-y-1/2"
+        size={24}
+        color="var(--text-secondary)"
       />
       <input
         type="text"

--- a/components/ui/MobileHomeHeader.test.tsx
+++ b/components/ui/MobileHomeHeader.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@phosphor-icons/react", () => ({
+  MagnifyingGlass: () => <span />,
+  X: () => <span />,
+}));
+
+vi.mock("@/components/ui/Logo", () => ({
+  Logo: () => <div data-testid="logo" />,
+}));
+
+vi.mock("@/components/ui/HeaderSearchBar", () => ({
+  HeaderSearchBar: () => <input placeholder="検索" aria-label="検索" />,
+}));
+
+import { MobileHomeHeader } from "./MobileHomeHeader";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MobileHomeHeader", () => {
+  it("ロゴが表示される", () => {
+    render(<MobileHomeHeader />);
+    expect(screen.getByTestId("logo")).toBeInTheDocument();
+  });
+
+  it("初期状態では検索を開くボタンのみがアクセシブル", () => {
+    render(<MobileHomeHeader />);
+    expect(screen.getByRole("button", { name: "検索を開く" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "検索を閉じる" })).toBeNull();
+  });
+
+  it("ボタンをタップすると検索を閉じるボタンがアクセシブルになり開くボタンは隠れる", () => {
+    render(<MobileHomeHeader />);
+    fireEvent.click(screen.getByRole("button", { name: "検索を開く" }));
+    expect(screen.getByRole("button", { name: "検索を閉じる" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "検索を開く" })).toBeNull();
+  });
+
+  it("再度タップすると元に戻る", () => {
+    render(<MobileHomeHeader />);
+    fireEvent.click(screen.getByRole("button", { name: "検索を開く" }));
+    fireEvent.click(screen.getByRole("button", { name: "検索を閉じる" }));
+    expect(screen.getByRole("button", { name: "検索を開く" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "検索を閉じる" })).toBeNull();
+  });
+
+  it("検索バーは DOM に存在する", () => {
+    render(<MobileHomeHeader />);
+    expect(screen.getByPlaceholderText("検索")).toBeInTheDocument();
+  });
+});

--- a/components/ui/MobileHomeHeader.tsx
+++ b/components/ui/MobileHomeHeader.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { MagnifyingGlass, X } from "@phosphor-icons/react";
+import { Logo } from "@/components/ui/Logo";
+import { HeaderSearchBar } from "@/components/ui/HeaderSearchBar";
+
+export function MobileHomeHeader() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const [withTransition, setWithTransition] = useState(false);
+  const [prevPathname, setPrevPathname] = useState(pathname);
+
+  if (pathname !== prevPathname) {
+    setPrevPathname(pathname);
+    setOpen(false);
+    setWithTransition(false);
+  }
+
+  // withTransition が false のとき次フレームで再有効化 (setState はコールバック内のみ)
+  useEffect(() => {
+    if (withTransition) return;
+    const id = requestAnimationFrame(() => setWithTransition(true));
+    return () => cancelAnimationFrame(id);
+  }, [withTransition]);
+
+  const t = withTransition;
+
+  return (
+    <header
+      className="sticky top-0 z-40 border-b md:hidden"
+      style={{ backgroundColor: "var(--bg-base)", borderColor: "var(--border)" }}
+    >
+      <div className="flex h-14 items-center px-4">
+        {/* Logo: collapses + fades when search is open */}
+        <Link
+          href="/"
+          aria-hidden={open}
+          tabIndex={open ? -1 : 0}
+          className={`block shrink-0 overflow-hidden ${
+            open ? "max-w-0 opacity-0" : "mr-3 max-w-xs opacity-100"
+          } ${t ? "transition-all duration-200 ease-out" : ""}`}
+        >
+          <Logo height={32} />
+        </Link>
+
+        {/* Morph target: icon → search bar in place (grows leftward) */}
+        <div className="flex flex-1 justify-end">
+          <div
+            className={`relative h-10 ${t ? "transition-[width] duration-200 ease-out" : ""}`}
+            style={{ width: open ? "100%" : "40px" }}
+          >
+            {/* Icon view (visible when closed) */}
+            <button
+              type="button"
+              onClick={() => setOpen(true)}
+              aria-label="検索を開く"
+              aria-hidden={open}
+              tabIndex={open ? -1 : 0}
+              className={`absolute inset-0 flex items-center justify-center rounded-lg ${
+                open ? "pointer-events-none opacity-0" : "opacity-100"
+              } ${t ? "transition-opacity duration-150" : ""}`}
+              style={{ color: "var(--text-secondary)" }}
+            >
+              <MagnifyingGlass size={24} weight="bold" />
+            </button>
+
+            {/* Search bar view (visible when open) */}
+            <div
+              aria-hidden={!open}
+              className={`absolute inset-0 flex items-center gap-2 ${
+                open ? "opacity-100" : "pointer-events-none opacity-0"
+              } ${t ? "transition-opacity duration-150" : ""}`}
+            >
+              <div className="min-w-0 flex-1">
+                <HeaderSearchBar />
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="検索を閉じる"
+                tabIndex={open ? 0 : -1}
+                className="shrink-0 rounded-lg p-2"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                <X size={20} weight="bold" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- モバイル (`< 768px`) のトップページ (`/`) に専用ヘッダーを新設: 左上ロゴ / 右上 MagnifyingGlass アイコン
- 検索アイコンをタップすると、ロゴが左側に折りたたまれつつ、アイコンが `HeaderSearchBar` (PR #161 の検索バー) に morph 展開 (width 40px → 100%)。X タップで元に戻る
- 他ページ遷移時は transition を無効化して即閉じる → 戻ったときに閉じるアニメーションが見えない挙動

## Scope
- 新規: `components/ui/MobileHomeHeader.tsx`, `components/ui/MobileHomeHeader.test.tsx`
- 変更: `app/page.tsx` (MobileHomeHeader 描画)、`components/ui/HeaderSearchBar.tsx` (アイコンサイズを 24 に統一)
- デスクトップヘッダー (`Header.tsx`) / `BottomNav.tsx` / 他ページは触っていない

## Test plan
- [x] `pnpm test components/ui/MobileHomeHeader.test.tsx` — 5 件通過
- [x] `pnpm lint` クリーン
- [ ] モバイル (< md) でトップページ: ロゴ + サーチアイコン表示、タップで morph 展開、X で閉じる
- [ ] モバイルで `/games`, `/rooms`, `/login` に遷移 → モバイルヘッダー非表示
- [ ] トップページで検索バーを開いたまま別画面に遷移 → 戻ってきたときに閉じアニメーションが見えないこと
- [ ] デスクトップ (≥ md) は既存ヘッダーのまま変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)