### PR TITLE
feat: 部屋一覧 API に q パラメータを追加

### DIFF
--- a/app/api/v1/rooms/route.test.ts
+++ b/app/api/v1/rooms/route.test.ts
@@ -60,6 +60,13 @@ const SAMPLE_RAW_ROOM = {
   ],
 };
 
+const SAMPLE_RAW_ROOM_WITH_DESC = {
+  ...SAMPLE_RAW_ROOM,
+  id: "room-2",
+  title: "週末ゲーム会",
+  description: "初心者大歓迎！スモーク使える方歓迎！",
+};
+
 // ─── ヘルパー ──────────────────────────────────────────────────────────────────
 
 function makeGetRequest(params: Record<string, string> = {}): Request {
@@ -118,6 +125,34 @@ describe("GET /api/v1/rooms", () => {
         where: expect.objectContaining({ gameId: VALID_GAME_ID }),
       })
     );
+  });
+
+  it("正常系: q が title に一致する部屋を 200 で返す", async () => {
+    mockAuth.mockResolvedValueOnce(AUTHENTICATED_SESSION);
+    mockRoomFindMany.mockResolvedValueOnce([SAMPLE_RAW_ROOM] as never);
+    mockRoomCount.mockResolvedValueOnce(1);
+
+    const res = await GET(makeGetRequest({ q: "テスト" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data).toHaveLength(1);
+    expect(json.data[0].title).toBe("テストルーム");
+    expect(json.meta).toEqual({ total: 1, page: 1, limit: 20 });
+  });
+
+  it("正常系: q が description に一致する部屋を 200 で返す", async () => {
+    mockAuth.mockResolvedValueOnce(AUTHENTICATED_SESSION);
+    mockRoomFindMany.mockResolvedValueOnce([SAMPLE_RAW_ROOM_WITH_DESC] as never);
+    mockRoomCount.mockResolvedValueOnce(1);
+
+    const res = await GET(makeGetRequest({ q: "スモーク" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data).toHaveLength(1);
+    expect(json.data[0].title).toBe("週末ゲーム会");
+    expect(json.meta).toEqual({ total: 1, page: 1, limit: 20 });
   });
 
   it("q クエリパラメータが where 句の OR 条件に含まれる", async () => {

--- a/app/api/v1/rooms/route.test.ts
+++ b/app/api/v1/rooms/route.test.ts
@@ -119,6 +119,49 @@ describe("GET /api/v1/rooms", () => {
       })
     );
   });
+
+  it("q クエリパラメータが where 句の OR 条件に含まれる", async () => {
+    mockAuth.mockResolvedValueOnce(AUTHENTICATED_SESSION);
+    mockRoomFindMany.mockResolvedValueOnce([]);
+    mockRoomCount.mockResolvedValueOnce(0);
+
+    await GET(makeGetRequest({ q: "FPS" }));
+
+    expect(mockRoomFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { title: { contains: "FPS", mode: "insensitive" } },
+            { description: { contains: "FPS", mode: "insensitive" } },
+          ],
+        }),
+      })
+    );
+  });
+
+  it("q が 101 文字以上のとき 400 BAD_REQUEST を返す", async () => {
+    mockAuth.mockResolvedValueOnce(AUTHENTICATED_SESSION);
+
+    const res = await GET(makeGetRequest({ q: "a".repeat(101) }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("q 未指定時は where 句に OR 条件が含まれない", async () => {
+    mockAuth.mockResolvedValueOnce(AUTHENTICATED_SESSION);
+    mockRoomFindMany.mockResolvedValueOnce([]);
+    mockRoomCount.mockResolvedValueOnce(0);
+
+    await GET(makeGetRequest());
+
+    expect(mockRoomFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.not.objectContaining({ OR: expect.anything() }),
+      })
+    );
+  });
 });
 
 describe("POST /api/v1/rooms", () => {

--- a/app/api/v1/rooms/route.ts
+++ b/app/api/v1/rooms/route.ts
@@ -69,6 +69,7 @@ const listQuerySchema = z.object({
   status: z.enum(["waiting", "full", "closed"]).default("waiting"),
   gameId: z.string().uuid().optional(),
   tagSlugs: z.string().optional(),
+  q: z.string().trim().max(100).optional(),
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(20),
 });
@@ -88,7 +89,7 @@ export async function GET(request: Request) {
     );
   }
 
-  const { status, gameId, tagSlugs, page, limit } = parsed.data;
+  const { status, gameId, tagSlugs, q, page, limit } = parsed.data;
   const skip = (page - 1) * limit;
 
   const tagSlugList = tagSlugs ? tagSlugs.split(",").filter(Boolean) : [];
@@ -100,6 +101,12 @@ export async function GET(request: Request) {
       playStyleTags: {
         some: { tag: { slug: { in: tagSlugList } } },
       },
+    }),
+    ...(q && {
+      OR: [
+        { title: { contains: q, mode: "insensitive" } },
+        { description: { contains: q, mode: "insensitive" } },
+      ],
     }),
   };
 

--- a/lib/api/rooms.ts
+++ b/lib/api/rooms.ts
@@ -74,6 +74,7 @@ export async function fetchRooms(params?: {
   status?: string;
   gameId?: string;
   tagSlugs?: string;
+  q?: string;
   page?: number;
   limit?: number;
 }): Promise<RoomsListResponse> {
@@ -81,6 +82,7 @@ export async function fetchRooms(params?: {
   if (params?.status) searchParams.set("status", params.status);
   if (params?.gameId) searchParams.set("gameId", params.gameId);
   if (params?.tagSlugs) searchParams.set("tagSlugs", params.tagSlugs);
+  if (params?.q) searchParams.set("q", params.q);
   if (params?.page) searchParams.set("page", String(params.page));
   if (params?.limit) searchParams.set("limit", String(params.limit));
 


### PR DESCRIPTION
## 概要

`GET /api/v1/rooms` に `q`（フリーワード）クエリパラメータを追加。
`title` / `description` の大小文字不問部分一致（OR 条件）で絞り込みを行う。

## 変更内容

- `listQuerySchema` に `q: z.string().trim().max(100).optional()` を追加
- `where` 句に OR 条件（title / description の contains）を追加
- `fetchRooms` の params 型と URLSearchParams 組み立てに `q` を追加
- テストに 3 ケース追加（OR 条件反映・101 文字超で 400・未指定時は OR なし）

## テスト

```
pnpm test app/api/v1/rooms/route.test.ts
# 11/11 passed
```

Closes #163