### PR TITLE
feat: ヘッダー検索バーにサジェストと検索送信を実装

### DIFF
--- a/components/ui/GamePicker.tsx
+++ b/components/ui/GamePicker.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, memo } from "react";
 import Image from "next/image";
 import { MagnifyingGlass, X, GameController, Check, CaretDown } from "@phosphor-icons/react";
 import { type Game } from "@/lib/mock-data";
 import clsx from "clsx";
 import { GameCoverImage } from "@/components/ui/GameCoverImage";
+import { useGameSearch } from "@/lib/hooks/useGameSearch";
 
 // ─── ゲームカバー画像 ─────────────────────────────────────────────────────────
 
@@ -25,50 +26,6 @@ export const GameCover = memo(function GameCover({ game, size = "md", className 
     />
   );
 });
-
-// ─── ゲーム検索フック ─────────────────────────────────────────────────────────
-
-function useGameSearch(query: string) {
-  const [results, setResults] = useState<Game[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [isPopular, setIsPopular] = useState(false);
-  const abortRef = useRef<AbortController | null>(null);
-
-  const search = useCallback(async (q: string) => {
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    setLoading(true);
-    try {
-      const url =
-        q.trim().length === 0
-          ? `/api/v1/games/search?limit=10`
-          : `/api/v1/games/search?q=${encodeURIComponent(q)}&limit=10`;
-      const res = await fetch(url, { signal: controller.signal });
-      if (!res.ok) {
-        setResults([]);
-        return;
-      }
-      const json = (await res.json()) as { data: Game[] };
-      setIsPopular(q.trim().length === 0);
-      setResults(json.data);
-    } catch {
-      // AbortError は無視
-      setResults([]);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    const delay = query.trim().length === 0 ? 0 : 300;
-    const timer = setTimeout(() => search(query), delay);
-    return () => clearTimeout(timer);
-  }, [query, search]);
-
-  return { results, loading, isPopular };
-}
 
 // ─── ゲーム選択（単体） ────────────────────────────────────────────────────────
 

--- a/components/ui/Header.test.tsx
+++ b/components/ui/Header.test.tsx
@@ -5,6 +5,7 @@ const mockUsePathname = vi.fn();
 
 vi.mock("next/navigation", () => ({
   usePathname: () => mockUsePathname(),
+  useRouter: () => ({ push: vi.fn() }),
 }));
 
 const mockUseSession = vi.fn();
@@ -38,9 +39,12 @@ vi.mock("@phosphor-icons/react", () => ({
   Users: () => <span />,
   PlusCircle: () => <span />,
   MagnifyingGlass: () => <span />,
+  MagnifyingGlassIcon: () => <span />,
   House: () => <span />,
   User: () => <span />,
   SignOut: () => <span />,
+  Plus: () => <span />,
+  ChatText: () => <span />,
 }));
 
 vi.mock("@/components/ui/Logo", () => ({
@@ -110,7 +114,9 @@ describe("Header - 認証済みナビアクティブ状態", () => {
   it("検索バーのプレースホルダーが表示される", () => {
     mockUsePathname.mockReturnValue("/");
     render(<Header />);
-    expect(screen.getByPlaceholderText("ゲームを検索...")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("ゲーム or 部屋を検索..."),
+    ).toBeInTheDocument();
   });
 });
 

--- a/components/ui/HeaderSearchBar.test.tsx
+++ b/components/ui/HeaderSearchBar.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@phosphor-icons/react", () => ({
+  MagnifyingGlass: () => <span />,
+}));
+
+vi.mock("@/components/ui/GameCoverImage", () => ({
+  GameCoverImage: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+
+const mockUseGameSearch = vi.fn();
+vi.mock("@/lib/hooks/useGameSearch", () => ({
+  useGameSearch: (...args: unknown[]) => mockUseGameSearch(...args),
+}));
+
+import { HeaderSearchBar } from "./HeaderSearchBar";
+
+const noResults = { results: [], loading: false };
+const withResults = {
+  results: [
+    { id: "game1", name: "Apex Legends", coverImageUrl: null },
+    { id: "game2", name: "Valorant", coverImageUrl: null },
+  ],
+  loading: false,
+};
+
+beforeEach(() => {
+  mockPush.mockReset();
+  mockUseGameSearch.mockReturnValue(noResults);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("HeaderSearchBar", () => {
+  it('placeholder が "ゲーム or 部屋を検索..." である', () => {
+    render(<HeaderSearchBar />);
+    expect(
+      screen.getByPlaceholderText("ゲーム or 部屋を検索..."),
+    ).toBeInTheDocument();
+  });
+
+  it("空クエリではドロップダウンが開かない", () => {
+    render(<HeaderSearchBar />);
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("1 文字以上入力するとドロップダウンが開く", () => {
+    render(<HeaderSearchBar />);
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "apex" },
+    });
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+  });
+
+  it('「xxx」を検索クリックで /search?q=xxx に遷移する', () => {
+    render(<HeaderSearchBar />);
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "apex" },
+    });
+    fireEvent.click(screen.getByRole("option", { name: /apex.*を検索/ }));
+    expect(mockPush).toHaveBeenCalledWith("/search?q=apex");
+  });
+
+  it("ゲーム候補クリックで /games/${gameId}/rooms に遷移する", () => {
+    mockUseGameSearch.mockReturnValue(withResults);
+    render(<HeaderSearchBar />);
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "apex" },
+    });
+    fireEvent.click(screen.getByRole("option", { name: /Apex Legends/ }));
+    expect(mockPush).toHaveBeenCalledWith("/games/game1/rooms");
+  });
+
+  it("Enter で /search?q=... に遷移する", () => {
+    render(<HeaderSearchBar />);
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "apex" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mockPush).toHaveBeenCalledWith("/search?q=apex");
+  });
+
+  it("空クエリの Enter では遷移しない", () => {
+    render(<HeaderSearchBar />);
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "Enter" });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("isComposing=true の Enter では遷移しない", () => {
+    render(<HeaderSearchBar />);
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "apex" } });
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("Escape でドロップダウンが閉じる", () => {
+    render(<HeaderSearchBar />);
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "apex" } });
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("外クリックでドロップダウンが閉じる", () => {
+    render(<HeaderSearchBar />);
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "apex" } });
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("ArrowDown でハイライトが移動し aria-activedescendant が更新される", () => {
+    mockUseGameSearch.mockReturnValue(withResults);
+    render(<HeaderSearchBar />);
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "apex" } });
+    expect(input).not.toHaveAttribute("aria-activedescendant");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input).toHaveAttribute("aria-activedescendant");
+    const firstId = input.getAttribute("aria-activedescendant");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input.getAttribute("aria-activedescendant")).not.toBe(firstId);
+  });
+
+  it("ArrowUp でハイライトが逆順に移動する", () => {
+    mockUseGameSearch.mockReturnValue(withResults);
+    render(<HeaderSearchBar />);
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "apex" } });
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(input).toHaveAttribute("aria-activedescendant");
+  });
+
+  it("ArrowDown でハイライトした状態で Enter を押すとゲームに遷移する", () => {
+    mockUseGameSearch.mockReturnValue(withResults);
+    render(<HeaderSearchBar />);
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "apex" } });
+    // index 0: search item, index 1: Apex Legends
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mockPush).toHaveBeenCalledWith("/games/game1/rooms");
+  });
+
+  it("useGameSearch に limit=8 / fetchOnEmpty=false が渡される", () => {
+    render(<HeaderSearchBar />);
+    expect(mockUseGameSearch).toHaveBeenCalledWith("", {
+      limit: 8,
+      fetchOnEmpty: false,
+    });
+  });
+});

--- a/components/ui/HeaderSearchBar.tsx
+++ b/components/ui/HeaderSearchBar.tsx
@@ -1,16 +1,94 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect, useId } from "react";
+import { useRouter } from "next/navigation";
 import { MagnifyingGlass } from "@phosphor-icons/react";
+import { GameCoverImage } from "@/components/ui/GameCoverImage";
+import { useGameSearch } from "@/lib/hooks/useGameSearch";
 
 export function HeaderSearchBar() {
   const [query, setQuery] = useState("");
+  const [dismissed, setDismissed] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const router = useRouter();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const prefix = useId();
+  const listboxId = `${prefix}-listbox`;
+
+  const { results, loading } = useGameSearch(query, {
+    limit: 8,
+    fetchOnEmpty: false,
+  });
+
+  const hasQuery = query.trim().length > 0;
+  const isOpen = hasQuery && !dismissed;
+  // total options: 1 search item + N game items
+  const totalItems = 1 + results.length;
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setDismissed(true);
+        setActiveIndex(-1);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+    setDismissed(false);
+    setActiveIndex(-1);
+  };
+
+  const navigate = (index: number) => {
+    if (index === 0 || index === -1) {
+      if (!hasQuery) return;
+      router.push(`/search?q=${encodeURIComponent(query.trim())}`);
+    } else if (results[index - 1]) {
+      router.push(`/games/${results[index - 1].id}/rooms`);
+    }
+    setDismissed(true);
+    setActiveIndex(-1);
+    setQuery("");
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.nativeEvent.isComposing) return;
+
+    if (e.key === "Escape") {
+      setDismissed(true);
+      setActiveIndex(-1);
+      return;
+    }
+
+    if (!isOpen) {
+      if (e.key === "Enter") navigate(-1);
+      return;
+    }
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((prev) => (prev < totalItems - 1 ? prev + 1 : 0));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((prev) => (prev > 0 ? prev - 1 : totalItems - 1));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      navigate(activeIndex);
+    }
+  };
+
+  const getOptionId = (index: number) => `${prefix}-option-${index}`;
+  const activeDescendant =
+    activeIndex >= 0 ? getOptionId(activeIndex) : undefined;
 
   return (
-    <form
-      onSubmit={(e) => e.preventDefault()}
-      className="relative w-full max-w-lg"
-    >
+    <div ref={containerRef} className="relative w-full max-w-lg">
       <MagnifyingGlass
         className="absolute left-2 top-1/2 -translate-y-1/2"
         size={24}
@@ -18,10 +96,18 @@ export function HeaderSearchBar() {
       />
       <input
         type="text"
+        role="combobox"
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-autocomplete="list"
+        aria-controls={listboxId}
+        aria-activedescendant={activeDescendant}
         value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder="検索"
-        aria-label="検索"
+        onChange={handleQueryChange}
+        onKeyDown={handleKeyDown}
+        placeholder="ゲーム or 部屋を検索..."
+        aria-label="ゲーム or 部屋を検索"
+        maxLength={100}
         className="w-full rounded-xl border py-2 pl-9 pr-4 text-sm outline-none transition-colors focus:border-[var(--accent)]"
         style={{
           background: "var(--bg-card)",
@@ -29,6 +115,76 @@ export function HeaderSearchBar() {
           color: "var(--text-primary)",
         }}
       />
-    </form>
+
+      {isOpen && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          className="absolute z-50 mt-1.5 w-full overflow-hidden rounded-xl border shadow-2xl animate-fade-in-up"
+          style={{
+            backgroundColor: "var(--bg-card)",
+            borderColor: "var(--border)",
+            boxShadow: "0 16px 48px rgba(0,0,0,0.6)",
+            animationDuration: "150ms",
+          }}
+        >
+          {/* Search item */}
+          <li
+            id={getOptionId(0)}
+            role="option"
+            aria-selected={activeIndex === 0}
+            onClick={() => navigate(0)}
+            className="flex cursor-pointer items-center gap-3 px-3 py-2.5 text-sm transition-colors"
+            style={
+              activeIndex === 0
+                ? {
+                    backgroundColor: "rgba(124,58,237,0.15)",
+                    color: "var(--accent-light)",
+                  }
+                : { color: "var(--text-secondary)" }
+            }
+          >
+            <MagnifyingGlass size={16} />
+            <span>「{query.trim()}」を検索</span>
+          </li>
+
+          {/* Game results */}
+          {loading ? (
+            <li
+              className="px-4 py-3 text-center text-sm"
+              style={{ color: "var(--text-muted)" }}
+            >
+              検索中...
+            </li>
+          ) : (
+            results.map((game, i) => (
+              <li
+                key={game.id}
+                id={getOptionId(i + 1)}
+                role="option"
+                aria-selected={activeIndex === i + 1}
+                onClick={() => navigate(i + 1)}
+                className="flex cursor-pointer items-center gap-3 px-3 py-2.5 text-sm transition-colors hover:bg-white/[0.04]"
+                style={
+                  activeIndex === i + 1
+                    ? {
+                        backgroundColor: "rgba(124,58,237,0.15)",
+                        color: "var(--accent-light)",
+                      }
+                    : { color: "var(--text-primary)" }
+                }
+              >
+                <GameCoverImage
+                  coverImageUrl={game.coverImageUrl}
+                  name={game.name}
+                  size="sm"
+                />
+                <span className="flex-1 truncate">{game.name}</span>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
   );
 }

--- a/components/ui/MobileHomeHeader.test.tsx
+++ b/components/ui/MobileHomeHeader.test.tsx
@@ -31,7 +31,12 @@ vi.mock("@/components/ui/Logo", () => ({
 }));
 
 vi.mock("@/components/ui/HeaderSearchBar", () => ({
-  HeaderSearchBar: () => <input placeholder="検索" aria-label="検索" />,
+  HeaderSearchBar: () => (
+    <input
+      placeholder="ゲーム or 部屋を検索..."
+      aria-label="ゲーム or 部屋を検索"
+    />
+  ),
 }));
 
 import { MobileHomeHeader } from "./MobileHomeHeader";
@@ -69,6 +74,8 @@ describe("MobileHomeHeader", () => {
 
   it("検索バーは DOM に存在する", () => {
     render(<MobileHomeHeader />);
-    expect(screen.getByPlaceholderText("検索")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("ゲーム or 部屋を検索..."),
+    ).toBeInTheDocument();
   });
 });

--- a/lib/hooks/useGameSearch.ts
+++ b/lib/hooks/useGameSearch.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { type Game } from "@/lib/mock-data";
+
+type Options = {
+  limit?: number;
+  fetchOnEmpty?: boolean;
+};
+
+export function useGameSearch(
+  query: string,
+  { limit = 10, fetchOnEmpty = true }: Options = {},
+) {
+  const [results, setResults] = useState<Game[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [isPopular, setIsPopular] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const search = useCallback(
+    async (q: string) => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setLoading(true);
+      try {
+        const url =
+          q.trim().length === 0
+            ? `/api/v1/games/search?limit=${limit}`
+            : `/api/v1/games/search?q=${encodeURIComponent(q)}&limit=${limit}`;
+        const res = await fetch(url, { signal: controller.signal });
+        if (!res.ok) {
+          setResults([]);
+          return;
+        }
+        const json = (await res.json()) as { data: Game[] };
+        setIsPopular(q.trim().length === 0);
+        setResults(json.data);
+      } catch {
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [limit],
+  );
+
+  useEffect(() => {
+    if (!fetchOnEmpty && query.trim().length === 0) {
+      setResults([]);
+      setIsPopular(false);
+      setLoading(false);
+      return;
+    }
+    const delay = query.trim().length === 0 ? 0 : 300;
+    const timer = setTimeout(() => search(query), delay);
+    return () => clearTimeout(timer);
+  }, [query, search, fetchOnEmpty]);
+
+  return { results, loading, isPopular };
+}


### PR DESCRIPTION
## 概要

- `lib/hooks/useGameSearch.ts` を新規作成し `GamePicker.tsx` から共有フックを切り出し
- `HeaderSearchBar` を全面リライト：debounce 300ms のゲームサジェスト・キーボードナビ・ARIA combobox 対応
- `Header.test.tsx` / `MobileHomeHeader.test.tsx` の placeholder 期待値を新仕様に修正
- `HeaderSearchBar.test.tsx` を新規作成（14 テスト）

## 変更内容

### `lib/hooks/useGameSearch.ts`（新規）
`GamePicker.tsx` から `useGameSearch` フックを切り出し、`limit` / `fetchOnEmpty` オプションで `HeaderSearchBar` と `GamePicker` の両方に対応。

### `components/ui/HeaderSearchBar.tsx`（変更）
- placeholder: `ゲーム or 部屋を検索...`
- 1 文字以上入力で debounce 300ms 後にサジェストドロップダウン表示（最大 8 件）
- 「xxx」を検索 クリック/Enter → `/search?q=xxx` 遷移
- ゲーム候補クリック → `/games/${gameId}/rooms` 遷移
- ArrowDown / ArrowUp でハイライト移動、Escape / 外クリックで閉じる
- IME 合成中（`isComposing: true`）の Enter は無視
- ARIA: `role="combobox"` / `aria-expanded` / `role="listbox"` / `role="option"`

## テスト

`pnpm test components/ui/HeaderSearchBar.test.tsx components/ui/Header.test.tsx components/ui/MobileHomeHeader.test.tsx` → 29 tests passed

Closes #164