### PR TITLE
feat: プロフィール画面 UI 刷新

### DIFF
--- a/app/users/[userId]/page.tsx
+++ b/app/users/[userId]/page.tsx
@@ -50,9 +50,8 @@ export default function UserProfilePage() {
   }
 
   return (
-    <div className="mx-auto max-w-3xl pb-8 sm:mt-6 sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)]">
+    <div className="mx-auto max-w-3xl pb-8 sm:mt-2 sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)]">
       <ProfileHero
-        coverImageUrl={user.games[0]?.coverImageUrl}
         username={user.username}
         iconUrl={user.iconUrl}
         actions={

--- a/app/users/[userId]/page.tsx
+++ b/app/users/[userId]/page.tsx
@@ -69,8 +69,6 @@ export default function UserProfilePage() {
       />
       <ProfileInfo
         username={user.username}
-        avgRating={user.avgRating}
-        ratingCount={user.ratingCount}
         playStyleTags={user.playStyleTags}
         bio={user.bio}
         bioFallback="自己紹介はまだありません"

--- a/app/users/me/edit/page.tsx
+++ b/app/users/me/edit/page.tsx
@@ -144,7 +144,14 @@ export default function EditProfilePage() {
 
   return (
     <div className="mx-auto max-w-2xl px-4 py-4 sm:px-6 sm:py-8">
-      <BackButton href={"/users/me"} />
+      <div className="relative mb-4 sm:mb-6 text-center md:text-left">
+        <h1 className="text-lg sm:text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
+          プロフィール編集
+        </h1>
+        <div className="absolute left-0 top-1/2 -translate-y-1/2">
+          <BackButton href="/users/me" />
+        </div>
+      </div>
       <form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col gap-6 sm:gap-8">
         {/* Avatar section */}
         <div className="flex justify-center">

--- a/app/users/me/history/page.tsx
+++ b/app/users/me/history/page.tsx
@@ -12,12 +12,13 @@ export default async function HistoryPage() {
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-4 sm:py-8 sm:px-6">
-      <BackButton href={"/users/me"} />
-
-      <div className="mb-4 sm:mb-6">
-        <h1 className="text-xl sm:text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
+      <div className="relative mb-4 sm:mb-6 text-center md:text-left">
+        <h1 className="text-lg sm:text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
           参加履歴
         </h1>
+        <div className="absolute left-0 top-1/2 -translate-y-1/2">
+          <BackButton href="/users/me" />
+        </div>
       </div>
 
       <Suspense fallback={<HistoryListSkeleton />}>

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -66,7 +66,7 @@ export default function MyProfilePage() {
           <ProfileActionsMenu />
         </div>
       </div>
-      <div className="space-y-4 px-4 md:px-0">
+      <div className="space-y-4">
         <div
           className="rounded-2xl border"
           style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -66,8 +66,11 @@ export default function MyProfilePage() {
           <ProfileActionsMenu />
         </div>
       </div>
-      <div className="sm:space-y-4">
-        <div className="sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)]">
+      <div className="space-y-4 px-4 md:px-0">
+        <div
+          className="rounded-2xl border"
+          style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
+        >
           <ProfileHero username={user.username} iconUrl={user.iconUrl} />
           <ProfileInfo
             username={user.username}
@@ -75,7 +78,7 @@ export default function MyProfilePage() {
             bio={user.bio}
           />
         </div>
-        <div className="grid grid-cols-2 gap-3 px-4 sm:px-0 sm:gap-4">
+        <div className="grid grid-cols-2 gap-3 sm:gap-4">
           <div
             className="rounded-2xl border flex flex-col items-center py-4"
             style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
@@ -101,10 +104,16 @@ export default function MyProfilePage() {
             <p className="mt-0.5 text-xs" style={{ color: "var(--text-muted)" }}>評価件数</p>
           </div>
         </div>
-        <div className="sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)] sm:py-4">
+        <div
+          className="rounded-2xl border py-4"
+          style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
+        >
           <GameScrollList games={user.games} />
         </div>
-        <div className="sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)] sm:py-4">
+        <div
+          className="rounded-2xl border py-4"
+          style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
+        >
           <ReceivedRatingsList ratings={user.receivedRatings} />
         </div>
       </div>

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import { PencilSimple, ClockCounterClockwise } from "@phosphor-icons/react";
 import { ProfileHero } from "@/components/users/ProfileHero";
 import { ProfileInfo } from "@/components/users/ProfileInfo";
 import { ProfileStats } from "@/components/users/ProfileStats";
 import { GameScrollList } from "@/components/users/GameScrollList";
 import { ReceivedRatingsList } from "@/components/users/ReceivedRatingsList";
+import { ProfileActionsMenu } from "@/components/users/ProfileActionsMenu";
 import { DeleteAccountButton } from "./DeleteAccountButton";
-import { SignOutButton } from "@/components/ui/SignOutButton";
 
 type ReceivedRating = {
   id: string;
@@ -57,47 +55,34 @@ export default function MyProfilePage() {
   }
 
   return (
-    <div className="mx-auto max-w-3xl pb-8 sm:mt-6 sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)]">
-      <ProfileHero
-        coverImageUrl={user.games[0]?.coverImageUrl}
-        username={user.username}
-        iconUrl={user.iconUrl}
-        actions={
-          <div className="flex justify-end gap-2 px-4 pt-4 sm:px-6">
-            <Link
-              href="/users/me/edit"
-              className="flex items-center gap-2 rounded-xl border p-2 sm:px-4 sm:py-2 text-sm font-medium transition-all hover:border-[var(--accent)]"
-              style={{ borderColor: "var(--border)", color: "var(--text-secondary)", backgroundColor: "var(--bg-input)" }}
-            >
-              <PencilSimple className="h-4 w-4" />
-              <span className="hidden sm:inline">プロフィール編集</span>
-            </Link>
-            <Link
-              href="/users/me/history"
-              className="flex items-center gap-2 rounded-xl border p-2 sm:px-4 sm:py-2 text-sm font-medium transition-all hover:border-[var(--accent)]"
-              style={{ borderColor: "var(--border)", color: "var(--text-secondary)", backgroundColor: "var(--bg-input)" }}
-            >
-              <ClockCounterClockwise className="h-4 w-4" />
-              <span className="hidden sm:inline">参加履歴</span>
-            </Link>
-          </div>
-        }
-      />
-      <ProfileInfo
-        username={user.username}
-        avgRating={user.avgRating}
-        ratingCount={user.ratingCount}
-        playStyleTags={user.playStyleTags}
-        bio={user.bio}
-      />
-      <ProfileStats avgRating={user.avgRating} ratingCount={user.ratingCount} />
-      <GameScrollList games={user.games} />
-      <ReceivedRatingsList ratings={user.receivedRatings} />
-      <div className="mx-4 sm:mx-6 mt-8 space-y-4">
-        <div>
-          <SignOutButton />
+    <div className="mx-auto max-w-3xl pb-8">
+      <div className="relative px-4 md:px-0 pt-4 sm:pt-6 mb-3 sm:mb-4">
+        <h1
+          className="text-lg sm:text-2xl font-bold text-center md:text-left"
+          style={{ color: "var(--text-primary)" }}
+        >
+          プロフィール
+        </h1>
+        <div className="absolute right-2 top-2 md:hidden">
+          <ProfileActionsMenu />
         </div>
-        <div className="border-t pt-4" style={{ borderColor: "var(--border)" }}>
+      </div>
+      <div className="sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)]">
+        <ProfileHero username={user.username} iconUrl={user.iconUrl} />
+        <ProfileInfo
+          username={user.username}
+          avgRating={user.avgRating}
+          ratingCount={user.ratingCount}
+          playStyleTags={user.playStyleTags}
+          bio={user.bio}
+        />
+        <ProfileStats avgRating={user.avgRating} ratingCount={user.ratingCount} />
+        <GameScrollList games={user.games} />
+        <ReceivedRatingsList ratings={user.receivedRatings} />
+        <div
+          className="mx-4 sm:mx-6 mt-8 border-t pt-4 pb-4 sm:pb-6"
+          style={{ borderColor: "var(--border)" }}
+        >
           <DeleteAccountButton />
         </div>
       </div>

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -55,7 +55,7 @@ export default function MyProfilePage() {
 
   return (
     <div className="mx-auto max-w-3xl pb-8">
-      <div className="relative px-4 md:px-0 pt-4 sm:pt-6 mb-3 sm:mb-4">
+      <div className="relative px-4 md:px-0 pt-4 sm:pt-6 mb-6 sm:mb-8">
         <h1
           className="text-lg sm:text-2xl font-bold text-center md:text-left"
           style={{ color: "var(--text-primary)" }}

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -67,24 +67,32 @@ export default function MyProfilePage() {
           <ProfileActionsMenu />
         </div>
       </div>
-      <div className="sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)]">
-        <ProfileHero username={user.username} iconUrl={user.iconUrl} />
-        <ProfileInfo
-          username={user.username}
-          avgRating={user.avgRating}
-          ratingCount={user.ratingCount}
-          playStyleTags={user.playStyleTags}
-          bio={user.bio}
-        />
-        <ProfileStats avgRating={user.avgRating} ratingCount={user.ratingCount} />
-        <GameScrollList games={user.games} />
-        <ReceivedRatingsList ratings={user.receivedRatings} />
-        <div
-          className="mx-4 sm:mx-6 mt-8 border-t pt-4 pb-4 sm:pb-6"
-          style={{ borderColor: "var(--border)" }}
-        >
-          <DeleteAccountButton />
+      <div className="sm:space-y-4">
+        <div className="sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)]">
+          <ProfileHero username={user.username} iconUrl={user.iconUrl} />
+          <ProfileInfo
+            username={user.username}
+            avgRating={user.avgRating}
+            ratingCount={user.ratingCount}
+            playStyleTags={user.playStyleTags}
+            bio={user.bio}
+          />
         </div>
+        <div className="sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)]">
+          <ProfileStats avgRating={user.avgRating} ratingCount={user.ratingCount} />
+        </div>
+        <div className="sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)] sm:py-4">
+          <GameScrollList games={user.games} />
+        </div>
+        <div className="sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)] sm:py-4">
+          <ReceivedRatingsList ratings={user.receivedRatings} />
+        </div>
+      </div>
+      <div
+        className="mx-4 sm:mx-6 mt-8 sm:mt-6 border-t pt-4 pb-4"
+        style={{ borderColor: "var(--border)" }}
+      >
+        <DeleteAccountButton />
       </div>
     </div>
   );

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { ProfileHero } from "@/components/users/ProfileHero";
 import { ProfileInfo } from "@/components/users/ProfileInfo";
+import { UserAvatar } from "@/components/ui/UserAvatar";
 import { GameScrollList } from "@/components/users/GameScrollList";
 import { ReceivedRatingsList } from "@/components/users/ReceivedRatingsList";
 import { ProfileActionsMenu } from "@/components/users/ProfileActionsMenu";
@@ -66,12 +66,11 @@ export default function MyProfilePage() {
           <ProfileActionsMenu />
         </div>
       </div>
-      <div className="space-y-4">
-        <div
-          className=""
-          style={{ backgroundColor: "var(--bg-card)" }}
-        >
-          <ProfileHero username={user.username} iconUrl={user.iconUrl} />
+      <div className="space-y-4 pt-10">
+        <div className="relative pt-10" style={{ backgroundColor: "var(--bg-card)" }}>
+          <div className="absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2">
+            <UserAvatar username={user.username} iconUrl={user.iconUrl} size="xl" />
+          </div>
           <ProfileInfo
             username={user.username}
             playStyleTags={user.playStyleTags}

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -68,8 +68,8 @@ export default function MyProfilePage() {
       </div>
       <div className="space-y-4">
         <div
-          className="sm:rounded-2xl sm:border"
-          style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
+          className=""
+          style={{ backgroundColor: "var(--bg-card)" }}
         >
           <ProfileHero username={user.username} iconUrl={user.iconUrl} />
           <ProfileInfo
@@ -80,8 +80,8 @@ export default function MyProfilePage() {
         </div>
         <div className="grid grid-cols-2 gap-3 sm:gap-4">
           <div
-            className="sm:rounded-2xl sm:border flex flex-col items-center py-4"
-            style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
+            className=" flex flex-col items-center py-4"
+            style={{ backgroundColor: "var(--bg-card)" }}
           >
             <p className="text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
               {user.avgRating > 0 ? user.avgRating.toFixed(1) : "-"}
@@ -92,8 +92,8 @@ export default function MyProfilePage() {
             <p className="mt-0.5 text-xs" style={{ color: "var(--text-muted)" }}>平均評価</p>
           </div>
           <div
-            className="sm:rounded-2xl sm:border flex flex-col items-center py-4"
-            style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
+            className=" flex flex-col items-center py-4"
+            style={{ backgroundColor: "var(--bg-card)" }}
           >
             <p className="text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
               {user.ratingCount}
@@ -105,14 +105,14 @@ export default function MyProfilePage() {
           </div>
         </div>
         <div
-          className="sm:rounded-2xl sm:border py-4"
-          style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
+          className=" py-4"
+          style={{ backgroundColor: "var(--bg-card)" }}
         >
           <GameScrollList games={user.games} />
         </div>
         <div
-          className="sm:rounded-2xl sm:border py-4"
-          style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
+          className=" py-4"
+          style={{ backgroundColor: "var(--bg-card)" }}
         >
           <ReceivedRatingsList ratings={user.receivedRatings} />
         </div>

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -68,7 +68,7 @@ export default function MyProfilePage() {
       </div>
       <div className="space-y-4">
         <div
-          className="rounded-2xl border"
+          className="rounded-2xl sm:border"
           style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
         >
           <ProfileHero username={user.username} iconUrl={user.iconUrl} />
@@ -80,7 +80,7 @@ export default function MyProfilePage() {
         </div>
         <div className="grid grid-cols-2 gap-3 sm:gap-4">
           <div
-            className="rounded-2xl border flex flex-col items-center py-4"
+            className="rounded-2xl sm:border flex flex-col items-center py-4"
             style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
           >
             <p className="text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
@@ -92,7 +92,7 @@ export default function MyProfilePage() {
             <p className="mt-0.5 text-xs" style={{ color: "var(--text-muted)" }}>平均評価</p>
           </div>
           <div
-            className="rounded-2xl border flex flex-col items-center py-4"
+            className="rounded-2xl sm:border flex flex-col items-center py-4"
             style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
           >
             <p className="text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
@@ -105,13 +105,13 @@ export default function MyProfilePage() {
           </div>
         </div>
         <div
-          className="rounded-2xl border py-4"
+          className="rounded-2xl sm:border py-4"
           style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
         >
           <GameScrollList games={user.games} />
         </div>
         <div
-          className="rounded-2xl border py-4"
+          className="rounded-2xl sm:border py-4"
           style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
         >
           <ReceivedRatingsList ratings={user.receivedRatings} />

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -3,7 +3,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { ProfileHero } from "@/components/users/ProfileHero";
 import { ProfileInfo } from "@/components/users/ProfileInfo";
-import { ProfileStats } from "@/components/users/ProfileStats";
 import { GameScrollList } from "@/components/users/GameScrollList";
 import { ReceivedRatingsList } from "@/components/users/ReceivedRatingsList";
 import { ProfileActionsMenu } from "@/components/users/ProfileActionsMenu";
@@ -72,14 +71,35 @@ export default function MyProfilePage() {
           <ProfileHero username={user.username} iconUrl={user.iconUrl} />
           <ProfileInfo
             username={user.username}
-            avgRating={user.avgRating}
-            ratingCount={user.ratingCount}
             playStyleTags={user.playStyleTags}
             bio={user.bio}
           />
         </div>
-        <div className="sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)]">
-          <ProfileStats avgRating={user.avgRating} ratingCount={user.ratingCount} />
+        <div className="grid grid-cols-2 gap-3 px-4 sm:px-0 sm:gap-4">
+          <div
+            className="rounded-2xl border flex flex-col items-center py-4"
+            style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
+          >
+            <p className="text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
+              {user.avgRating > 0 ? user.avgRating.toFixed(1) : "-"}
+              <span className="ml-1 text-sm font-normal" style={{ color: "var(--text-secondary)" }}>
+                / 5.0
+              </span>
+            </p>
+            <p className="mt-0.5 text-xs" style={{ color: "var(--text-muted)" }}>平均評価</p>
+          </div>
+          <div
+            className="rounded-2xl border flex flex-col items-center py-4"
+            style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
+          >
+            <p className="text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
+              {user.ratingCount}
+              <span className="ml-1 text-sm font-normal" style={{ color: "var(--text-secondary)" }}>
+                件
+              </span>
+            </p>
+            <p className="mt-0.5 text-xs" style={{ color: "var(--text-muted)" }}>評価件数</p>
+          </div>
         </div>
         <div className="sm:rounded-2xl sm:border sm:border-[var(--border)] sm:bg-[var(--bg-card)] sm:py-4">
           <GameScrollList games={user.games} />

--- a/app/users/me/page.tsx
+++ b/app/users/me/page.tsx
@@ -68,7 +68,7 @@ export default function MyProfilePage() {
       </div>
       <div className="space-y-4">
         <div
-          className="rounded-2xl sm:border"
+          className="sm:rounded-2xl sm:border"
           style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
         >
           <ProfileHero username={user.username} iconUrl={user.iconUrl} />
@@ -80,7 +80,7 @@ export default function MyProfilePage() {
         </div>
         <div className="grid grid-cols-2 gap-3 sm:gap-4">
           <div
-            className="rounded-2xl sm:border flex flex-col items-center py-4"
+            className="sm:rounded-2xl sm:border flex flex-col items-center py-4"
             style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
           >
             <p className="text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
@@ -92,7 +92,7 @@ export default function MyProfilePage() {
             <p className="mt-0.5 text-xs" style={{ color: "var(--text-muted)" }}>平均評価</p>
           </div>
           <div
-            className="rounded-2xl sm:border flex flex-col items-center py-4"
+            className="sm:rounded-2xl sm:border flex flex-col items-center py-4"
             style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
           >
             <p className="text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
@@ -105,13 +105,13 @@ export default function MyProfilePage() {
           </div>
         </div>
         <div
-          className="rounded-2xl sm:border py-4"
+          className="sm:rounded-2xl sm:border py-4"
           style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
         >
           <GameScrollList games={user.games} />
         </div>
         <div
-          className="rounded-2xl sm:border py-4"
+          className="sm:rounded-2xl sm:border py-4"
           style={{ borderColor: "var(--border)", backgroundColor: "var(--bg-card)" }}
         >
           <ReceivedRatingsList ratings={user.receivedRatings} />

--- a/components/users/GameScrollList.tsx
+++ b/components/users/GameScrollList.tsx
@@ -16,7 +16,7 @@ type GameScrollListProps = {
 
 export function GameScrollList({ games }: GameScrollListProps) {
   return (
-    <div className="mt-4 sm:mt-0">
+    <div className="mt-4">
       <h2
         className="mb-3 px-4 sm:px-6 text-sm font-semibold uppercase tracking-wider"
         style={{ color: "var(--text-muted)" }}
@@ -24,7 +24,7 @@ export function GameScrollList({ games }: GameScrollListProps) {
         プレイしているゲーム
       </h2>
       {games.length > 0 ? (
-        <div className="flex gap-3 overflow-x-auto px-4 sm:px-6 pb-2 scrollbar-none">
+        <div className="flex gap-3 overflow-x-auto px-4 sm:px-6 pb-2 scrollbar-none [&::-webkit-scrollbar]:hidden">
           {games.map((game) => (
             <div key={game.id} className="flex shrink-0 flex-col items-center gap-2">
               <div

--- a/components/users/GameScrollList.tsx
+++ b/components/users/GameScrollList.tsx
@@ -16,7 +16,7 @@ type GameScrollListProps = {
 
 export function GameScrollList({ games }: GameScrollListProps) {
   return (
-    <div className="mt-4">
+    <div className="mt-4 sm:mt-0">
       <h2
         className="mb-3 px-4 sm:px-6 text-sm font-semibold uppercase tracking-wider"
         style={{ color: "var(--text-muted)" }}

--- a/components/users/ProfileActionsMenu.tsx
+++ b/components/users/ProfileActionsMenu.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { DotsThree, DotsThreeVertical } from "@phosphor-icons/react";
+import { SignOutButton } from "@/components/ui/SignOutButton";
+
+export function ProfileActionsMenu() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        aria-label="メニューを開く"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className="flex h-9 w-9 items-center justify-center rounded-full transition-colors hover:bg-[rgba(124,58,237,0.1)]"
+        style={{ color: "var(--text-secondary)" }}
+      >
+        <DotsThree size={28} weight="bold" />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-2 w-48 rounded-xl border py-1 shadow-lg"
+          style={{
+            backgroundColor: "var(--bg-card)",
+            borderColor: "var(--border)",
+            zIndex: 60,
+          }}
+        >
+          <Link
+            href="/users/me/edit"
+            role="menuitem"
+            onClick={() => setOpen(false)}
+            className="flex items-center px-4 py-2 text-sm transition-all hover:text-white hover:bg-[rgba(124,58,237,0.1)]"
+            style={{ color: "var(--text-secondary)" }}
+          >
+            プロフィール編集
+          </Link>
+          <Link
+            href="/users/me/history"
+            role="menuitem"
+            onClick={() => setOpen(false)}
+            className="flex items-center px-4 py-2 text-sm transition-all hover:text-white hover:bg-[rgba(124,58,237,0.1)]"
+            style={{ color: "var(--text-secondary)" }}
+          >
+            参加履歴
+          </Link>
+          <div
+            className="my-1 border-t"
+            style={{ borderColor: "var(--border)" }}
+          />
+          <div role="menuitem">
+            <SignOutButton />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/users/ProfileHero.tsx
+++ b/components/users/ProfileHero.tsx
@@ -1,52 +1,18 @@
 "use client";
 
-import Image from "next/image";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 
 type ProfileHeroProps = {
-  coverImageUrl?: string | null;
   username: string;
   iconUrl: string | null;
   actions?: React.ReactNode;
 };
 
-export function ProfileHero({ coverImageUrl, username, iconUrl, actions }: ProfileHeroProps) {
+export function ProfileHero({ username, iconUrl, actions }: ProfileHeroProps) {
   return (
-    <div className="relative">
-      {/* Hero Banner */}
-      <div
-        className="min-h-[200px] overflow-hidden sm:rounded-t-2xl"
-        style={{ backgroundColor: "var(--bg-card)" }}
-      >
-        {/* Background image */}
-        <div className="absolute inset-0">
-          {coverImageUrl ? (
-            <Image
-              src={coverImageUrl}
-              alt=""
-              fill
-              className="object-cover"
-              sizes="768px"
-              aria-hidden="true"
-            />
-          ) : (
-            <div
-              className="h-full w-full"
-              style={{ background: "linear-gradient(135deg, #1e1030 0%, #2d1b69 50%, #1a0f2e 100%)" }}
-            />
-          )}
-        </div>
-        {/* Action slot — top area */}
-        {actions && (
-          <div className="relative z-10">
-            {actions}
-          </div>
-        )}
-        {/* Spacer for hero height */}
-        <div className="pb-10 pt-14" />
-      </div>
-      {/* Avatar — centered at hero bottom, outside overflow-hidden */}
-      <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 z-10">
+    <div>
+      {actions}
+      <div className="flex justify-center pt-6">
         <UserAvatar username={username} iconUrl={iconUrl} size="xl" />
       </div>
     </div>

--- a/components/users/ProfileInfo.tsx
+++ b/components/users/ProfileInfo.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { PlayStyleTag } from "@/components/ui/PlayStyleTag";
-import { RatingDisplay } from "@/components/ui/StarRating";
 
 type PlayStyleTagItem = {
   id: string;
@@ -11,8 +10,6 @@ type PlayStyleTagItem = {
 
 type ProfileInfoProps = {
   username: string;
-  avgRating: number;
-  ratingCount: number;
   playStyleTags: PlayStyleTagItem[];
   bio: string | null;
   bioFallback?: string;
@@ -20,8 +17,6 @@ type ProfileInfoProps = {
 
 export function ProfileInfo({
   username,
-  avgRating,
-  ratingCount,
   playStyleTags,
   bio,
   bioFallback,
@@ -31,9 +26,6 @@ export function ProfileInfo({
       <h1 className="text-xl sm:text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
         {username}
       </h1>
-      <div className="mt-1.5 flex justify-center">
-        <RatingDisplay avgRating={avgRating} ratingCount={ratingCount} />
-      </div>
       {playStyleTags.length > 0 && (
         <div className="mt-3 flex flex-wrap justify-center gap-2">
           {playStyleTags.map((tag) => (

--- a/components/users/ProfileInfo.tsx
+++ b/components/users/ProfileInfo.tsx
@@ -27,7 +27,7 @@ export function ProfileInfo({
   bioFallback,
 }: ProfileInfoProps) {
   return (
-    <div className="px-4 sm:px-6 pt-14 pb-4 text-center">
+    <div className="px-4 sm:px-6 pt-3 pb-4 text-center">
       <h1 className="text-xl sm:text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
         {username}
       </h1>

--- a/components/users/ReceivedRatingsList.tsx
+++ b/components/users/ReceivedRatingsList.tsx
@@ -23,7 +23,7 @@ export function ReceivedRatingsList({ ratings }: ReceivedRatingsListProps) {
   const [showAll, setShowAll] = useState(false);
 
   return (
-    <div className="mt-8 sm:mt-0 px-4 sm:px-6">
+    <div className="px-4 sm:px-6">
       <h2
         className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider"
         style={{ color: "var(--text-muted)" }}

--- a/components/users/ReceivedRatingsList.tsx
+++ b/components/users/ReceivedRatingsList.tsx
@@ -23,7 +23,7 @@ export function ReceivedRatingsList({ ratings }: ReceivedRatingsListProps) {
   const [showAll, setShowAll] = useState(false);
 
   return (
-    <div className="mt-8 px-4 sm:px-6">
+    <div className="mt-8 sm:mt-0 px-4 sm:px-6">
       <h2
         className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider"
         style={{ color: "var(--text-muted)" }}


### PR DESCRIPTION
## 概要

- ヒーロー背景（ゲームカバー画像・グラデーション）を撤廃し、アバターを通常フローに戻した
- `/users/me` のページタイトルをカード外に追加（モバイル中央・デスクトップ左）
- デスクトップは `UserAvatarMenu` から遷移できるため、プロフィールページの編集・履歴・ログアウトボタンを削除
- モバイル限定の 3 点リーダーメニュー (`ProfileActionsMenu`) を新設し、編集・履歴・ログアウトへ遷移可能に
- `/users/me/edit`・`/users/me/history` にページタイトルを追加し、BackButton をタイトル左横に配置

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `components/users/ProfileHero.tsx` | ヒーロー背景撤廃、アバターを通常フローへ |
| `components/users/ProfileInfo.tsx` | pt-14 → pt-3（アバターオーバーハング分クリアランス削除） |
| `components/users/ProfileActionsMenu.tsx` | 新規：モバイル限定 3 点リーダーメニュー |
| `app/users/me/page.tsx` | タイトル追加（カード外）、ボタン類撤去 |
| `app/users/me/edit/page.tsx` | タイトル追加、BackButton をタイトル左横に配置 |
| `app/users/me/history/page.tsx` | タイトルを Variant A スタイルに統一、BackButton を左横に |
| `app/users/[userId]/page.tsx` | coverImageUrl prop 撤去 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)