### PR TITLE
feat(api): GET /api/v1/health エンドポイントを追加

### DIFF
--- a/app/api/v1/health/route.ts
+++ b/app/api/v1/health/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(request: NextRequest) {
+  const deep = request.nextUrl.searchParams.get("deep") === "1";
+
+  if (!deep) {
+    return NextResponse.json({ status: "ok" });
+  }
+
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return NextResponse.json({ status: "ok", db: "ok" });
+  } catch {
+    return NextResponse.json({ status: "error", db: "error" }, { status: 503 });
+  }
+}


### PR DESCRIPTION
## 概要

k6 負荷テストのヘルスチェックおよびステージング環境の死活監視用として、Next.js アプリ（port 3000）側に `/api/v1/health` エンドポイントを追加する。

## 変更内容

- `GET /api/v1/health` — 即時 200 + `{ status: "ok" }` を返す軽量ヘルスチェック
- `GET /api/v1/health?deep=1` — Prisma で DB ping（`SELECT 1`）を実行し、成功時 200 + `{ status: "ok", db: "ok" }`、失敗時 503 + `{ status: "error", db: "error" }` を返す

## 変更ファイル

- `app/api/v1/health/route.ts`（新規作成）

Closes #174