### PR TITLE
feat: Lighthouse CI の設定 (#176)

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -44,12 +44,12 @@ jobs:
         run: npx wait-on http://localhost:3000 --timeout 60000
 
       - name: Run Lighthouse CI (collect)
-        run: pnpm dlx lhci collect
+        run: pnpm exec lhci collect
         env:
           LHCI_COLLECT_URL: ${{ inputs.base_url || 'http://localhost:3000' }}
 
       - name: Run Lighthouse CI (assert)
-        run: pnpm dlx lhci assert
+        run: pnpm exec lhci assert
 
       - name: Upload Lighthouse reports
         uses: actions/upload-artifact@v4

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,69 @@
+name: Lighthouse CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: '計測対象のベースURL (例: https://staging.example.com)。空欄の場合はローカルビルドを起動して計測'
+        required: false
+        default: ''
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Next.js app
+        if: ${{ inputs.base_url == '' }}
+        run: pnpm build
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          NEXTAUTH_URL: http://localhost:3000
+
+      - name: Start server
+        if: ${{ inputs.base_url == '' }}
+        run: pnpm start &
+
+      - name: Wait for server
+        if: ${{ inputs.base_url == '' }}
+        run: npx wait-on http://localhost:3000 --timeout 60000
+
+      - name: Run Lighthouse CI (collect)
+        run: pnpm dlx lhci collect
+        env:
+          LHCI_COLLECT_URL: ${{ inputs.base_url || 'http://localhost:3000' }}
+
+      - name: Run Lighthouse CI (assert)
+        run: pnpm dlx lhci assert
+
+      - name: Upload Lighthouse reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: lighthouse-reports
+          path: .lighthouseci/
+          retention-days: 30
+
+      - name: Post summary
+        if: always()
+        run: |
+          echo "## Lighthouse CI Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "計測対象URL: ${{ inputs.base_url || 'http://localhost:3000' }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "レポートは Artifacts タブからダウンロードできます。" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ next-env.d.ts
 # claude code
 .claude/
 .worktrees/
+
+# lighthouse ci
+.lighthouseci/

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -1,0 +1,50 @@
+// @ts-check
+'use strict';
+
+const BASE_URL = process.env.LHCI_COLLECT_URL ?? 'http://localhost:3000';
+
+/** @type {import('@lhci/cli').LighthouseRcConfig} */
+module.exports = {
+  ci: {
+    collect: {
+      url: [
+        `${BASE_URL}/`,
+        `${BASE_URL}/games`,
+        `${BASE_URL}/games/1/rooms`,
+        `${BASE_URL}/rooms/1`,
+        // WebSocket を使うチャット画面は pre-join（入室前）の静的状態で計測する
+        `${BASE_URL}/rooms/1/chat`,
+      ],
+      numberOfRuns: 3,
+      settings: {
+        formFactor: 'mobile',
+        throttling: {
+          rttMs: 40,
+          throughputKbps: 10240,
+          cpuSlowdownMultiplier: 4,
+        },
+        screenEmulation: {
+          mobile: true,
+          width: 390,
+          height: 844,
+          deviceScaleFactor: 3,
+          disabled: false,
+        },
+      },
+    },
+    assert: {
+      preset: 'lighthouse:no-pwa',
+      assertions: {
+        'categories:performance': ['warn', { minScore: 0.8 }],
+        'largest-contentful-paint': ['error', { maxNumericValue: 2500 }],
+        'interaction-to-next-paint': ['warn', { maxNumericValue: 200 }],
+        'cumulative-layout-shift': ['error', { maxNumericValue: 0.1 }],
+      },
+    },
+    upload: {
+      target: 'filesystem',
+      outputDir: '.lighthouseci',
+      reportFilenamePattern: '%%PATHNAME%%-%%DATETIME%%-report.%%EXTENSION%%',
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
+    "@lhci/cli": "^0.14.0",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## 概要

フロントエンドのパフォーマンス計測基盤として Lighthouse CI を導入しました。ゴールデンパス5ページに対して自動計測を行えます。

## 変更内容

- **`lighthouserc.cjs`**（新規）: 計測対象URL・モバイル閾値を定義
- **`.github/workflows/lighthouse.yml`**（新規）: `workflow_dispatch` による手動トリガー、staging URLを環境変数で上書き可能
- **`package.json`**: `@lhci/cli: ^0.14.0` を devDependencies に追加
- **`.gitignore`**: `.lighthouseci/` を追加

## 計測対象URL（5ページ）

| URL | 備考 |
|-----|------|
| `/` | トップページ |
| `/games` | ゲーム一覧 |
| `/games/1/rooms` | ルーム一覧（任意のgameId） |
| `/rooms/1` | ルーム詳細（任意のroomId） |
| `/rooms/1/chat` | チャット画面（WebSocket使用のためpre-join状態で計測） |

## 合格閾値

| 指標 | 閾値 | レベル |
|------|------|--------|
| Performance | ≥ 80（モバイル） | warn |
| LCP | < 2500ms | error |
| INP | < 200ms | warn |
| CLS | < 0.1 | error |

## AC チェック

- [x] ゴールデンパス5URLの計測設定済み
- [x] `pnpm dlx lhci collect` / `lhci assert` で計測・閾値チェックが実行可能
- [x] `workflow_dispatch` で手動実行できる
- [x] staging URL を `LHCI_COLLECT_URL` 環境変数で上書き可能
- [x] `/rooms/[roomId]/chat` のpre-join計測コメント記載済み
- [x] レポートはローカルファイル（JSON/HTML）出力のみ（Artifacts にアップロード）

Closes #176