### PR TITLE
feat: web-vitals の組み込み

### DIFF
--- a/app/api/v1/metrics/route.ts
+++ b/app/api/v1/metrics/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const metricSchema = z.object({
+  name: z.string(),
+  value: z.number(),
+  id: z.string(),
+  rating: z.enum(["good", "needs-improvement", "poor"]),
+});
+
+export async function POST(request: NextRequest) {
+  const body: unknown = await request.json();
+  const parsed = metricSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "BAD_REQUEST", message: "Invalid metric payload" } },
+      { status: 400 }
+    );
+  }
+  console.log("[Metrics]", parsed.data);
+  return NextResponse.json({ ok: true });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Noto_Sans_JP } from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/ui/Header";
 import { BottomNav } from "@/components/ui/BottomNav";
+import { WebVitalsReporter } from "@/components/ui/WebVitalsReporter";
 import { Providers } from "./providers";
 
 const notoSansJP = Noto_Sans_JP({
@@ -27,6 +28,7 @@ export default function RootLayout({
     <html lang="ja" className={notoSansJP.variable}>
       <body className="antialiased min-h-screen" style={{ backgroundColor: "var(--bg-base)", color: "var(--text-primary)" }}>
         <Providers>
+          <WebVitalsReporter />
           <Header />
           <main className="min-h-screen md:min-h-[calc(100vh_-_64px)] pb-[calc(60px_+_env(safe-area-inset-bottom))] md:pb-0">{children}</main>
           <BottomNav />

--- a/components/ui/WebVitalsReporter.tsx
+++ b/components/ui/WebVitalsReporter.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useReportWebVitals } from "next/web-vitals";
+
+export function WebVitalsReporter() {
+  useReportWebVitals((metric) => {
+    if (process.env.NODE_ENV === "development") {
+      console.log(`[Web Vitals] ${metric.name}:`, metric.value, metric.rating);
+    } else {
+      fetch("/api/v1/metrics", {
+        method: "POST",
+        body: JSON.stringify({
+          name: metric.name,
+          value: metric.value,
+          id: metric.id,
+          rating: metric.rating,
+        }),
+        headers: { "Content-Type": "application/json" },
+      }).catch(() => {});
+    }
+  });
+  return null;
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-dom": "19.2.3",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
+    "web-vitals": "^5.2.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       socket.io-client:
         specifier: ^4.8.3
         version: 4.8.3
+      web-vitals:
+        specifier: ^5.2.0
+        version: 5.2.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -3395,6 +3398,9 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  web-vitals@5.2.0:
+    resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -6903,6 +6909,8 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  web-vitals@5.2.0: {}
 
   webidl-conversions@8.0.1: {}
 


### PR DESCRIPTION
## 概要

`web-vitals` パッケージを導入し、LCP / INP / CLS / TTFB をブラウザから取得できるようにする。

- 開発環境: ブラウザコンソールに `[Web Vitals] {name}: {value} {rating}` 形式で出力
- 本番・staging: `/api/v1/metrics` へ POST 送信（DB保存なし、サーバー側 `console.log` のみ）

## 変更ファイル

- `package.json` — `web-vitals 5.2.0` を追加
- `components/ui/WebVitalsReporter.tsx` — 新規（`useReportWebVitals` 使用の Client Component）
- `app/layout.tsx` — `<WebVitalsReporter />` を追加
- `app/api/v1/metrics/route.ts` — 新規 POST エンドポイント（Zod バリデーション付き）

## 確認方法

1. `pnpm dev` で開発サーバー起動
2. `http://localhost:3000` をブラウザで開き DevTools Console を確認
3. ページ操作（クリック・別タブ移動）すると TTFB / LCP / CLS / INP が出力される

Closes #177