### PR TITLE
feat(auth): staging限定 Credentials provider を追加 (#175)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,9 @@ REDIS_URL="redis://localhost:6379"
 # Supabase Dashboard > Settings > API から取得
 SUPABASE_URL="https://xxxx.supabase.co"
 SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
+
+# Staging-only Credentials provider（k6 負荷テスト用）
+# STAGING_AUTH_BYPASS=1 のとき有効。本番では絶対に設定しないこと
+# CREDENTIALS_LOGIN_SECRET は openssl rand -base64 32 で生成
+STAGING_AUTH_BYPASS=
+CREDENTIALS_LOGIN_SECRET=

--- a/auth.config.test.ts
+++ b/auth.config.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { Session } from "next-auth";
 import type { NextRequest } from "next/server";
-import { authConfig } from "./auth.config";
+import { authConfig, stagingCredentialsAuthorize } from "./auth.config";
 
 const authorized = authConfig.callbacks!.authorized!;
 
@@ -221,5 +221,71 @@ describe("authorized コールバック", () => {
       });
       expect(result).toBe(true);
     });
+  });
+});
+
+describe("stagingCredentialsAuthorize", () => {
+  const SECRET = "test-secret";
+
+  beforeEach(() => vi.stubEnv("CREDENTIALS_LOGIN_SECRET", SECRET));
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("正しい email + password で User を返す", async () => {
+    const result = await stagingCredentialsAuthorize({
+      email: "loadtest+1@example.com",
+      password: SECRET,
+    });
+    expect(result).toMatchObject({ id: "loadtest+1@example.com", name: "loadtest+1" });
+  });
+
+  it("loadtest+99 も受け付ける", async () => {
+    const result = await stagingCredentialsAuthorize({
+      email: "loadtest+99@example.com",
+      password: SECRET,
+    });
+    expect(result).toMatchObject({ id: "loadtest+99@example.com", name: "loadtest+99" });
+  });
+
+  it("数字なしの loadtest メールは null を返す", async () => {
+    const result = await stagingCredentialsAuthorize({
+      email: "loadtest@example.com",
+      password: SECRET,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("パターン外の email は null を返す", async () => {
+    const result = await stagingCredentialsAuthorize({
+      email: "admin@example.com",
+      password: SECRET,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("パスワード不一致は null を返す", async () => {
+    const result = await stagingCredentialsAuthorize({
+      email: "loadtest+1@example.com",
+      password: "wrong",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("CREDENTIALS_LOGIN_SECRET 未設定は null を返す", async () => {
+    vi.stubEnv("CREDENTIALS_LOGIN_SECRET", "");
+    const result = await stagingCredentialsAuthorize({
+      email: "loadtest+1@example.com",
+      password: "",
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("STAGING_AUTH_BYPASS 未設定のとき", () => {
+  it("staging-credentials provider が providers 配列に存在しない", () => {
+    // テスト実行時は STAGING_AUTH_BYPASS が未設定のため、static import で providers = 3件
+    const found = authConfig.providers.some(
+      (p) => (p as { id?: string }).id === "staging-credentials"
+    );
+    expect(found).toBe(false);
   });
 });

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -2,6 +2,38 @@ import type { NextAuthConfig } from "next-auth";
 import Google from "next-auth/providers/google";
 import Twitter from "next-auth/providers/twitter";
 import Discord from "next-auth/providers/discord";
+import Credentials from "next-auth/providers/credentials";
+
+const LOADTEST_EMAIL_RE = /^loadtest\+\d+@example\.com$/;
+
+export async function stagingCredentialsAuthorize(
+  credentials: Partial<Record<string, unknown>>
+): Promise<{ id: string; email: string; name: string } | null> {
+  const email = typeof credentials.email === "string" ? credentials.email : "";
+  const password =
+    typeof credentials.password === "string" ? credentials.password : "";
+  const secret = process.env.CREDENTIALS_LOGIN_SECRET;
+  if (!secret) return null;
+  if (!LOADTEST_EMAIL_RE.test(email)) return null;
+  if (password !== secret) return null;
+  const username = email.split("@")[0];
+  return { id: email, email, name: username };
+}
+
+const stagingProviders: NextAuthConfig["providers"] =
+  process.env.STAGING_AUTH_BYPASS === "1"
+    ? [
+        Credentials({
+          id: "staging-credentials",
+          name: "Staging Test Account",
+          credentials: {
+            email: { label: "Email", type: "email" },
+            password: { label: "Password", type: "password" },
+          },
+          authorize: stagingCredentialsAuthorize,
+        }),
+      ]
+    : [];
 
 export const authConfig = {
   providers: [
@@ -10,6 +42,7 @@ export const authConfig = {
     Discord({
       authorization: { params: { scope: "identify email" } },
     }),
+    ...stagingProviders,
   ],
   pages: {
     signIn: "/login",

--- a/auth.ts
+++ b/auth.ts
@@ -24,6 +24,9 @@ export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
       return session;
     },
     async signIn({ account, profile }) {
+      // Credentials provider は authorize() で認証済み。DB upsert は jwt コールバックで行う
+      if (account?.type === "credentials") return true;
+
       if (!account?.provider || !profile) return false;
 
       const provider = toDbProvider(account.provider);
@@ -63,19 +66,36 @@ export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
 
       return true;
     },
-    async jwt({ token, account, profile, trigger }) {
+    async jwt({ token, account, profile, user, trigger }) {
       // セッション更新時（プロフィール設定完了後）: DBから最新usernameを取得
       if (trigger === "update" && token["userId"]) {
-        const user = await prisma.user.findUnique({
+        const dbUser = await prisma.user.findUnique({
           where: { id: token["userId"] as string },
           select: { username: true, iconUrl: true, avgRating: true },
         });
-        if (user) {
-          token["username"] = user.username;
-          token["iconUrl"] = user.iconUrl;
-          token["avgRating"] = Number(user.avgRating);
+        if (dbUser) {
+          token["username"] = dbUser.username;
+          token["iconUrl"] = dbUser.iconUrl;
+          token["avgRating"] = Number(dbUser.avgRating);
           token["needsProfileSetup"] = false;
         }
+        return token;
+      }
+
+      // Credentials (staging bypass) 初回ログイン: ユーザーを upsert してトークンに格納
+      if (account?.type === "credentials" && user?.email) {
+        const username = user.email.split("@")[0];
+        const dbUser = await prisma.user.upsert({
+          where: { username },
+          update: {},
+          create: { username, iconUrl: null },
+          select: { id: true, username: true, iconUrl: true, avgRating: true },
+        });
+        token["userId"] = dbUser.id;
+        token["username"] = dbUser.username;
+        token["iconUrl"] = dbUser.iconUrl;
+        token["avgRating"] = Number(dbUser.avgRating);
+        token["needsProfileSetup"] = false;
         return token;
       }
 


### PR DESCRIPTION
## 概要

k6 負荷テストで Google OAuth フローを自動実行できないため、`STAGING_AUTH_BYPASS=1` 環境変数が設定された場合のみ NextAuth v5 に Credentials provider を追加する。

- `STAGING_AUTH_BYPASS=1` のとき `loadtest+{n}@example.com` + `CREDENTIALS_LOGIN_SECRET` でログイン可能
- 本番環境（環境変数未設定）では provider が routes に一切現れない
- 初回ログイン時に DB ユーザーを自動作成（username = email ローカルパート）
- `auth.config.ts` は edge runtime 対応を維持（Prisma 不使用）、DB 処理は `auth.ts` の jwt コールバックで実行

## staging 環境セットアップ手順

staging 環境の環境変数に以下を追加してください：

```
STAGING_AUTH_BYPASS=1
CREDENTIALS_LOGIN_SECRET=<openssl rand -base64 32 で生成>
```

## k6 スクリプトでの使用方法

```javascript
// 1. CSRF token 取得
const csrfRes = http.get(`${BASE_URL}/api/auth/csrf`);
const csrfToken = JSON.parse(csrfRes.body).csrfToken;

// 2. Credentials ログイン
const loginRes = http.post(
  `${BASE_URL}/api/auth/callback/staging-credentials`,
  `email=loadtest%2B${__VU}%40example.com&password=${CREDENTIALS_LOGIN_SECRET}&csrfToken=${csrfToken}`,
  { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
);

// 3. cookie jar に authjs.session-token が保存され、以降のリクエストで自動送信される
```

## 変更ファイル

- `auth.config.ts` — `stagingCredentialsAuthorize` 関数を追加、`STAGING_AUTH_BYPASS=1` のとき Credentials provider をアクティブ化
- `auth.ts` — `signIn` コールバックに credentials 許可ガード追加、`jwt` コールバックに staging ユーザー upsert 処理追加
- `auth.config.test.ts` — `stagingCredentialsAuthorize` の単体テスト 7件追加
- `.env.example` — `STAGING_AUTH_BYPASS` / `CREDENTIALS_LOGIN_SECRET` を文書化

Closes #175