### PR TITLE
feat(lcp): トップ・ゲーム一覧の先頭カバー画像に priority を付与して LCP を改善

### DIFF
--- a/app/HomeGameGrid.tsx
+++ b/app/HomeGameGrid.tsx
@@ -13,7 +13,7 @@ export function HomeGameGrid({ games }: Props) {
 
   return (
     <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-6">
-      {games.map((game) => {
+      {games.map((game, index) => {
         return (
           <button
             key={game.id}
@@ -24,6 +24,7 @@ export function HomeGameGrid({ games }: Props) {
               <GameCoverImage
                 coverImageUrl={game.coverImageUrl}
                 name={game.name}
+                priority={index === 0}
                 className="transition-transform duration-300 group-hover:scale-105"
               />
               <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/70 via-transparent p-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">

--- a/app/games/GamesGrid.tsx
+++ b/app/games/GamesGrid.tsx
@@ -92,7 +92,7 @@ export function GamesGrid({ games: gamesProp, roomCounts = {}, onSelect }: Props
         </div>
       ) : filteredGames.length > 0 ? (
         <div className="grid grid-cols-3 gap-4 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-          {filteredGames.map((game) => {
+          {filteredGames.map((game, index) => {
             const roomCount = roomCounts[game.id] ?? 0;
 
             return (
@@ -106,6 +106,7 @@ export function GamesGrid({ games: gamesProp, roomCounts = {}, onSelect }: Props
                   <GameCoverImage
                     coverImageUrl={game.coverImageUrl}
                     name={game.name}
+                    priority={index === 0}
                     className="transition-transform duration-300 group-hover:scale-105"
                   />
 

--- a/components/ui/GameCoverImage.tsx
+++ b/components/ui/GameCoverImage.tsx
@@ -10,6 +10,7 @@ type GameCoverImageProps = {
   name: string;
   size?: "sm" | "md" | "lg";
   className?: string;
+  priority?: boolean;
 };
 
 const coverSizes = {
@@ -37,6 +38,7 @@ export const GameCoverImage = memo(function GameCoverImage({
   name,
   size,
   className,
+  priority = false,
 }: GameCoverImageProps) {
   const [error, setError] = useState(false);
 
@@ -70,6 +72,7 @@ export const GameCoverImage = memo(function GameCoverImage({
           fill
           className="object-cover"
           sizes="64px"
+          priority={priority}
           onError={() => setError(true)}
         />
       </div>
@@ -93,6 +96,7 @@ export const GameCoverImage = memo(function GameCoverImage({
           fill
           className="object-cover"
           sizes="(max-width: 640px) 33vw, (max-width: 768px) 25vw, 20vw"
+          priority={priority}
           onError={() => setError(true)}
         />
       )}


### PR DESCRIPTION
## 概要

`/` と `/games` のファーストビュー先頭のゲームカバー画像に `priority={true}` を付与し、LCP を改善する。

- `GameCoverImage` に `priority?: boolean` prop を追加（デフォルト `false`）
- `HomeGameGrid`（`/` のゲームストリップ）の先頭1枚に `priority={true}` を渡す
- `GamesGrid`（`/games` のゲームグリッド）の先頭1枚に `priority={true}` を渡す
- それ以外のカードは `priority={false}`（デフォルト）のまま

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `components/ui/GameCoverImage.tsx` | `priority?: boolean` prop を追加し `next/image` に伝播 |
| `app/HomeGameGrid.tsx` | 先頭 `index === 0` に `priority={true}` を渡す |
| `app/games/GamesGrid.tsx` | 先頭 `index === 0` に `priority={true}` を渡す |

## 確認項目

- [ ] `/` のファーストビューで最初のゲームカバー画像に `<link rel="preload">` が付与されている（DevTools Network タブで確認）
- [ ] `/games` のファーストビューで最初のゲームカバー画像に `<link rel="preload">` が付与されている
- [ ] TypeScript の型エラーがない
- [ ] Lighthouse で LCP が改善されること

Closes #178