### PR TITLE
fix: pnpm build エラー修正と SessionProvider セッション表示修正

### DIFF
--- a/app/(onboarding)/onboarding/page.tsx
+++ b/app/(onboarding)/onboarding/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { type Game } from "@/lib/mock-data";
@@ -15,7 +15,7 @@ import { useOnboardingSubmit } from "./useOnboardingSubmit";
 
 const TOTAL_STEPS = 5;
 
-export default function OnboardingPage() {
+function OnboardingContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get("callbackUrl");
@@ -108,5 +108,13 @@ export default function OnboardingPage() {
         )}
       </div>
     </div>
+  );
+}
+
+export default function OnboardingPage() {
+  return (
+    <Suspense fallback={null}>
+      <OnboardingContent />
+    </Suspense>
   );
 }

--- a/app/api/v1/invite/[token]/join/route.ts
+++ b/app/api/v1/invite/[token]/join/route.ts
@@ -4,7 +4,6 @@ import { cookies } from "next/headers";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { emitToRoom } from "@/lib/socket-emitter";
-import { Prisma } from "@prisma/client";
 
 const bodySchema = z.object({
   displayName: z
@@ -99,7 +98,7 @@ export async function POST(request: Request, { params }: RouteParams) {
 
         return p;
       },
-      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+      { isolationLevel: "Serializable" }
     );
 
     const systemMsg = await prisma.chatMessage.create({

--- a/app/games/GamesGridServer.tsx
+++ b/app/games/GamesGridServer.tsx
@@ -1,8 +1,10 @@
+import { connection } from "next/server";
 import { getPopularGames } from "@/lib/games";
 import { prisma } from "@/lib/prisma";
 import { GamesGrid } from "./GamesGrid";
 
 export async function GamesGridServer() {
+  await connection();
   const [games, rawCounts] = await Promise.all([
     getPopularGames(100),
     prisma.room.groupBy({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Header } from "@/components/ui/Header";
 import { BottomNav } from "@/components/ui/BottomNav";
 import { WebVitalsReporter } from "@/components/ui/WebVitalsReporter";
 import { Providers } from "./providers";
+import { auth } from "@/auth";
 
 const notoSansJP = Noto_Sans_JP({
   subsets: ["latin"],
@@ -20,6 +21,18 @@ export const metadata: Metadata = {
   description: "オンラインゲームで一緒にプレイする相手をリアルタイムで見つけるマッチングプラットフォーム",
 };
 
+async function LayoutProviders({ children }: { children: React.ReactNode }) {
+  const session = await auth();
+  return (
+    <Providers session={session}>
+      <WebVitalsReporter />
+      <Header />
+      <main className="min-h-screen md:min-h-[calc(100vh_-_64px)] pb-[calc(60px_+_env(safe-area-inset-bottom))] md:pb-0">{children}</main>
+      <BottomNav />
+    </Providers>
+  );
+}
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -29,12 +42,7 @@ export default function RootLayout({
     <html lang="ja" className={notoSansJP.variable}>
       <body className="antialiased min-h-screen" style={{ backgroundColor: "var(--bg-base)", color: "var(--text-primary)" }}>
         <Suspense fallback={null}>
-          <Providers>
-            <WebVitalsReporter />
-            <Header />
-            <main className="min-h-screen md:min-h-[calc(100vh_-_64px)] pb-[calc(60px_+_env(safe-area-inset-bottom))] md:pb-0">{children}</main>
-            <BottomNav />
-          </Providers>
+          <LayoutProviders>{children}</LayoutProviders>
         </Suspense>
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Noto_Sans_JP } from "next/font/google";
+import { Suspense } from "react";
 import "./globals.css";
 import { Header } from "@/components/ui/Header";
 import { BottomNav } from "@/components/ui/BottomNav";
@@ -27,12 +28,14 @@ export default function RootLayout({
   return (
     <html lang="ja" className={notoSansJP.variable}>
       <body className="antialiased min-h-screen" style={{ backgroundColor: "var(--bg-base)", color: "var(--text-primary)" }}>
-        <Providers>
-          <WebVitalsReporter />
-          <Header />
-          <main className="min-h-screen md:min-h-[calc(100vh_-_64px)] pb-[calc(60px_+_env(safe-area-inset-bottom))] md:pb-0">{children}</main>
-          <BottomNav />
-        </Providers>
+        <Suspense fallback={null}>
+          <Providers>
+            <WebVitalsReporter />
+            <Header />
+            <main className="min-h-screen md:min-h-[calc(100vh_-_64px)] pb-[calc(60px_+_env(safe-area-inset-bottom))] md:pb-0">{children}</main>
+            <BottomNav />
+          </Providers>
+        </Suspense>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -15,7 +15,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <SessionProvider>
+    <SessionProvider session={null}>
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     </SessionProvider>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { SessionProvider } from "next-auth/react";
+import type { Session } from "next-auth";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
 
-export function Providers({ children }: { children: React.ReactNode }) {
+export function Providers({ children, session }: { children: React.ReactNode; session: Session | null }) {
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -15,7 +16,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <SessionProvider session={null}>
+    <SessionProvider session={session}>
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     </SessionProvider>
   );

--- a/components/users/ReceivedRatingsList.tsx
+++ b/components/users/ReceivedRatingsList.tsx
@@ -46,7 +46,7 @@ export function ReceivedRatingsList({ ratings }: ReceivedRatingsListProps) {
               >
                 <div className="flex items-start gap-3">
                   <UserAvatar
-                    username={rating.reviewer.username}
+                    username={rating.reviewer.username ?? "退会済みユーザー"}
                     iconUrl={rating.reviewer.iconUrl}
                     size="sm"
                   />


### PR DESCRIPTION
## Summary

- Prisma 名前空間インポートの削除（`Prisma.TransactionIsolationLevel` → 文字列リテラル）
- `username` の null フォールバック追加
- `SessionProvider` に実際のセッションを渡す構造に修正（`cacheComponents` との競合を解消）
- `<Providers>` を `<Suspense>` でラップしてプリレンダリングエラーを修正
- `OnboardingPage` で `useSearchParams()` を Suspense でラップ
- `GamesGridServer` に `await connection()` を追加してダイナミックと宣言

Closes #192

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `app/api/v1/invite/[token]/join/route.ts` | Prisma 名前空間インポートを除去 |
| `components/users/ReceivedRatingsList.tsx` | username の null フォールバック追加 |
| `app/layout.tsx` | `LayoutProviders` を Suspense 内に配置し `auth()` でセッション取得 |
| `app/providers.tsx` | `session` prop を受け取り `SessionProvider` に渡す |
| `app/(onboarding)/onboarding/page.tsx` | `useSearchParams()` を Suspense でラップ |
| `app/games/GamesGridServer.tsx` | `await connection()` でダイナミックとしてマーク |

## Test plan

- [ ] `pnpm build` が全 31 ページで完走する
- [ ] ログイン済みでトップページにアクセスすると Header にユーザー情報が即時表示される
- [ ] 未ログインでトップページにアクセスすると `/login` にリダイレクトされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)