### PR TITLE
feat: Railway ステージング環境の構築（Web + Socket 2サービス構成）

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev:socket": "tsx socket-server/index.ts",
     "build": "next build",
     "start": "next start",
+    "start:web": "next start",
+    "start:socket": "tsx socket-server/index.ts",
     "lint": "eslint",
     "generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
@@ -42,6 +44,7 @@
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
     "web-vitals": "^5.2.0",
+    "tsx": "^4.21.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },
@@ -64,7 +67,6 @@
     "jsdom": "^28.1.0",
     "prisma": "^7.4.1",
     "tailwindcss": "^4",
-    "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.0.18"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       socket.io-client:
         specifier: ^4.8.3
         version: 4.8.3
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       web-vitals:
         specifier: ^5.2.0
         version: 5.2.0
@@ -123,9 +126,6 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.2.0
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       typescript:
         specifier: ^5
         version: 5.9.3

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "pnpm install && pnpm build"
+  },
+  "deploy": {
+    "startCommand": "pnpm start:web",
+    "healthcheckPath": "/api/v1/health",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
## 概要

k6 負荷テストおよび Lighthouse CI 計測用の Railway ステージング環境を構築するためのコード変更。

- `package.json` に本番起動スクリプト `start:web` / `start:socket` を追加
- `tsx` を devDependencies → dependencies へ移動（Railway Nixpacks が本番ビルド後に devDeps を prune しても `start:socket` が動作するよう）
- `railway.json` を新規作成（Web サービスのビルド・デプロイ設定）

## 変更ファイル

- `package.json` — スクリプト追加 + tsx を dependencies へ移動
- `pnpm-lock.yaml` — lockfile 更新
- `railway.json` — 新規（Railway Web サービス用設定）

## Railway UI での手動セットアップ（コード変更外）

- 2 サービス作成（web / socket）
- Socket サービスの Start Command を `pnpm start:socket` に上書き
- 各サービスに環境変数を設定（issue 記載の変数）
- インスタンス数を 2 に設定

Closes #183