### PR TITLE
fix: Node.js バージョン要件を追加（Railway Prisma ビルドエラー修正）

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "questlink",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=20.19"
+  },
   "scripts": {
     "dev": "concurrently --names \"next,socket\" --prefix-colors \"blue,green\" \"next dev --turbopack --port 3000\" \"tsx socket-server/index.ts\"",
     "dev:next": "next dev --turbopack --port 3000",


### PR DESCRIPTION
## Summary
- \`package.json\` に \`engines: { "node": ">=20.19" }\` を追加
- Railway Nixpacks が古い Node.js を選択し Prisma 7.x のインストールに失敗していた問題を修正

## Test plan
- [ ] Railway の次回デプロイで \`pnpm install\` が成功することを確認
- [ ] ビルドが完走し \`/api/v1/health\` が 200 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)