### PR TITLE
fix: Railway ビルドエラーの修正（Node.js バージョン・TypeScript 型・Prisma generate）

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "concurrently --names \"next,socket\" --prefix-colors \"blue,green\" \"next dev --turbopack --port 3000\" \"tsx socket-server/index.ts\"",
     "dev:next": "next dev --turbopack --port 3000",
     "dev:socket": "tsx socket-server/index.ts",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "start:web": "next start",
     "start:socket": "tsx socket-server/index.ts",


### PR DESCRIPTION
## Summary

- Node.js バージョン要件を `package.json` に明示（`>=20.19`）— Prisma 7.x が要求するバージョン
- `HomeRecommendedGames.tsx`: `userGameRows` に明示的な型アノテーションを付与（Prisma 7.x の nested select 型推論エラー修正）
- `build` スクリプトに `prisma generate` を追加（Railway Nixpacks 環境で Prisma client が未生成のまま TypeScript コンパイルが走る問題を修正）

## Test plan

- [ ] PR をマージして Railway の staging デプロイが成功することを確認
- [ ] `GET /api/v1/health` が 200 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)