### PR TITLE
fix: Railway ビルドエラーの修正（prisma.config.ts の .env 読み込み）

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "prisma/config";
+import { existsSync } from "fs";
 
-process.loadEnvFile(".env");
+if (existsSync(".env")) {
+  process.loadEnvFile(".env");
+}
 
 export default defineConfig({
   schema: "./prisma/schema.prisma",


### PR DESCRIPTION
## Summary

- `prisma.config.ts` の `process.loadEnvFile(".env")` を条件分岐で囲み、`.env` が存在しない場合（Railway 等の CI 環境）でも `prisma generate` が成功するよう修正

## 原因

Railway では環境変数はプロセスに直接注入されるため `.env` ファイルが存在しない。`process.loadEnvFile(".env")` が `ENOENT` エラーを投げ `pnpm build` が失敗していた。

## Test plan

- [ ] PR をマージして Railway の staging デプロイが成功することを確認
- [ ] `GET /api/v1/health` が 200 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)