### PR TITLE
fix: Supabase クライアントをビルド時評価から遅延初期化に変更

### DIFF
--- a/app/api/v1/users/me/avatar/route.ts
+++ b/app/api/v1/users/me/avatar/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { supabase, AVATAR_BUCKET } from "@/lib/supabase";
+import { getSupabaseClient, AVATAR_BUCKET } from "@/lib/supabase";
 
 const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
@@ -33,6 +33,7 @@ export async function POST(request: Request) {
   const arrayBuffer = await file.arrayBuffer();
   const buffer = new Uint8Array(arrayBuffer);
 
+  const supabase = getSupabaseClient();
   const { error: uploadError } = await supabase.storage
     .from(AVATAR_BUCKET)
     .upload(path, buffer, {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,12 +1,10 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-if (!supabaseUrl || !supabaseServiceRoleKey) {
-  throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
-}
-
-export const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
-
 export const AVATAR_BUCKET = "avatar_images";
+
+export function getSupabaseClient() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  return createClient(url, key);
+}


### PR DESCRIPTION
## Summary

- `lib/supabase.ts`: モジュール評価時の `throw` を `getSupabaseClient()` 関数内に移動し、遅延初期化パターンに変更
- `app/api/v1/users/me/avatar/route.ts`: `supabase` 定数の参照を `getSupabaseClient()` 呼び出しに更新

## 原因

`SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` が未設定の socket サービスが web サービスと同一リポジトリからビルドされる際、`lib/supabase.ts` のモジュール評価時に `throw` が発生し `pnpm build` が失敗していた。Next.js のビルドはランタイムシークレット不要が原則であり、環境変数チェックは実際に使用される関数内で行うのが正しいパターン。

## Test plan

- [ ] PR をマージして Railway の web・socket 両サービスのデプロイが成功することを確認
- [ ] `GET /api/v1/health` が 200 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)