### PR TITLE
fix: Railway環境変数設定によるUntrustedHost・Socket CORSエラー修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ DATABASE_URL="postgresql://postgres:password@localhost:5432/questlink?schema=pub
 
 # NextAuth.js v5 シークレット（openssl rand -base64 32 で生成）
 AUTH_SECRET="your-secret-here"
+# リバースプロキシ背後（Railway, Vercel等）でのデプロイ時は true を設定。ローカル開発では不要
+AUTH_TRUST_HOST=
 
 # Google OAuth 認証情報（Google Cloud Console で取得）
 # 承認済みリダイレクトURI: http://localhost:3000/api/auth/callback/google

--- a/socket-server/index.ts
+++ b/socket-server/index.ts
@@ -38,6 +38,9 @@ const prisma = new PrismaClient({ adapter });
 
 const PORT = parseInt(process.env.SOCKET_PORT ?? "3001", 10);
 const NEXT_APP_URL = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+if (process.env.NODE_ENV === "production" && NEXT_APP_URL === "http://localhost:3000") {
+  console.warn("[socket-server] NEXTAUTH_URL is not set. CORS will reject production origins.");
+}
 const INTERNAL_SECRET = process.env.SOCKET_INTERNAL_SECRET;
 
 function parseCookies(cookieHeader: string): Record<string, string> {


### PR DESCRIPTION
develop → staging へのマージ。

## 概要

RailwayにWebとSocketを別サービスとしてデプロイした際に発生する以下のエラーへの対処を明示する。

- `[auth][error] UntrustedHost: Host must be trusted.`
- WebSocket CORS エラー（`NEXTAUTH_URL` 未設定によるオリジン不一致）

## 変更内容

- `.env.example` に `AUTH_TRUST_HOST` を追加
- `socket-server/index.ts` に `NEXTAUTH_URL` 未設定時の本番警告ログを追加

## Railway への設定手順

**Webサービス:**
| 変数名 | 値 |
|-------|-----|
| `AUTH_TRUST_HOST` | `true` |

**Socketサービス:**
| 変数名 | 値 |
|-------|-----|
| `NEXTAUTH_URL` | `https://web-staging-7ace.up.railway.app` |
| `AUTH_SECRET` | Webサービスと同じ値 |
| `DATABASE_URL` | Supabase接続文字列 |
| `REDIS_URL` | Railway Redis接続文字列 |
| `SOCKET_INTERNAL_SECRET` | Webサービスと同じ値 |
| `NODE_ENV` | `production` |

Related: #201