### PR TITLE
feat: Socket.io クロスドメイン認証をトークンベースに変更

### DIFF
--- a/app/api/v1/auth/socket-token/route.ts
+++ b/app/api/v1/auth/socket-token/route.ts
@@ -1,10 +1,41 @@
 import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
 import { encode } from "next-auth/jwt";
+import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
+
+const GUEST_ID_RE = /^guest_[0-9a-f]{32}$/;
 
 export async function GET() {
   const session = await auth();
-  if (!session?.user?.id) {
+
+  if (session?.user?.id) {
+    const token = await encode({
+      token: { userId: session.user.id },
+      secret: process.env.AUTH_SECRET ?? "",
+      salt: "socket-auth",
+      maxAge: 60,
+    });
+    return NextResponse.json({ token });
+  }
+
+  // ゲストセッション確認
+  const cookieStore = await cookies();
+  const guestSessionId = cookieStore.get("quest_link_guest_session")?.value ?? "";
+
+  if (!GUEST_ID_RE.test(guestSessionId)) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "認証が必要です" } },
+      { status: 401 }
+    );
+  }
+
+  const participant = await prisma.roomParticipant.findFirst({
+    where: { guestSessionId, leftAt: null },
+    select: { id: true },
+  });
+
+  if (!participant) {
     return NextResponse.json(
       { error: { code: "UNAUTHORIZED", message: "認証が必要です" } },
       { status: 401 }
@@ -12,7 +43,7 @@ export async function GET() {
   }
 
   const token = await encode({
-    token: { userId: session.user.id },
+    token: { guestSessionId },
     secret: process.env.AUTH_SECRET ?? "",
     salt: "socket-auth",
     maxAge: 60,

--- a/app/api/v1/auth/socket-token/route.ts
+++ b/app/api/v1/auth/socket-token/route.ts
@@ -1,0 +1,22 @@
+import { auth } from "@/auth";
+import { encode } from "next-auth/jwt";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "認証が必要です" } },
+      { status: 401 }
+    );
+  }
+
+  const token = await encode({
+    token: { userId: session.user.id },
+    secret: process.env.AUTH_SECRET ?? "",
+    salt: "socket-auth",
+    maxAge: 60,
+  });
+
+  return NextResponse.json({ token });
+}

--- a/app/rooms/[roomId]/chat/useSocketRoom.test.ts
+++ b/app/rooms/[roomId]/chat/useSocketRoom.test.ts
@@ -10,9 +10,11 @@ const mockSocket = vi.hoisted(() => ({
 }));
 
 const mockDisconnectSocket = vi.hoisted(() => vi.fn());
+const mockConnectSocket = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 vi.mock("@/lib/socket", () => ({
   getSocket: () => mockSocket,
+  connectSocket: mockConnectSocket,
   disconnectSocket: mockDisconnectSocket,
 }));
 
@@ -70,9 +72,9 @@ describe("useSocketRoom", () => {
       expect(state.participants).toEqual(initialParticipants);
     });
 
-    it("マウント時に socket.connect() が呼ばれ connectionStatus が connecting になる", () => {
+    it("マウント時に connectSocket() が呼ばれ connectionStatus が connecting になる", () => {
       renderHook(() => useSocketRoom(defaultOptions));
-      expect(mockSocket.connect).toHaveBeenCalledOnce();
+      expect(mockConnectSocket).toHaveBeenCalledOnce();
       expect(useChatStore.getState().connectionStatus).toBe("connecting");
     });
   });

--- a/app/rooms/[roomId]/chat/useSocketRoom.ts
+++ b/app/rooms/[roomId]/chat/useSocketRoom.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { getSocket, disconnectSocket } from "@/lib/socket";
+import { getSocket, connectSocket, disconnectSocket } from "@/lib/socket";
 import { useChatStore, type ChatMessage, type Participant } from "@/lib/stores/chatStore";
 
 type UseSocketRoomOptions = {
@@ -24,7 +24,7 @@ export function useSocketRoom({ roomId, initialMessages, initialParticipants }: 
     const socket = getSocket();
 
     setConnectionStatus("connecting");
-    socket.connect();
+    void connectSocket();
 
     socket.on("connect", () => {
       setConnectionStatus("connected");

--- a/docs/05_01_api_auth.md
+++ b/docs/05_01_api_auth.md
@@ -19,6 +19,7 @@ Google / X / Discord の3プロバイダに対応。複数プロバイダを同�
 | POST | `/auth/guest` | 不要 | ゲストセッション発行 |
 | POST | `/auth/{provider}/link` | 必要 | 追加プロバイダを現アカウントに連携 |
 | DELETE | `/auth/{provider}/unlink` | 必要 | プロバイダ連携の解除 |
+| GET | `/auth/socket-token` | 必要（ユーザーまたはゲスト） | Socket.io 接続用短命トークン発行 |
 
 **`{provider}` の値**: `google` / `x` / `discord`
 
@@ -206,6 +207,39 @@ DELETE /auth/{provider}/unlink
 |------|------------|------|
 | 400 | `LAST_PROVIDER` | 唯一のプロバイダは解除できない |
 | 404 | `PROVIDER_NOT_LINKED` | そのプロバイダは連携されていない |
+
+---
+
+---
+
+## 8. Socket.io 接続用トークン発行
+
+Socket.io のクロスドメイン接続（本番環境）向けに、60秒有効の短命 JWT を発行する。
+クライアントはこのトークンを `io.connect({ auth: { token } })` に渡す。
+
+```
+GET /auth/socket-token
+```
+
+**認証**: ユーザーセッション Cookie または `quest_link_guest_session` Cookie のいずれか
+
+### レスポンス `200 OK`
+
+```json
+{ "token": "<JWT文字列>" }
+```
+
+### エラー
+
+| HTTP | エラーコード | 説明 |
+|------|------------|------|
+| 401 | `UNAUTHORIZED` | 有効なセッションもゲストセッションも存在しない |
+
+### 備考
+
+- トークンの有効期限は **60秒**。接続直前に取得して即座に使用すること
+- ゲストの場合は現在アクティブな部屋参加（`leftAt IS NULL`）が必要
+- salt: `"socket-auth"`（セッション Cookie の salt とは分離）
 
 ---
 

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -15,6 +15,20 @@ export function getSocket(): Socket {
   return socket;
 }
 
+export async function connectSocket(): Promise<void> {
+  const s = getSocket();
+  try {
+    const res = await fetch("/api/v1/auth/socket-token");
+    if (res.ok) {
+      const data = (await res.json()) as { token: string };
+      s.auth = { token: data.token };
+    }
+  } catch {
+    // フォールバック: Cookieベース認証で接続
+  }
+  s.connect();
+}
+
 export function disconnectSocket(): void {
   socket?.disconnect();
   socket = null;

--- a/socket-server/index.ts
+++ b/socket-server/index.ts
@@ -147,6 +147,24 @@ io.use(async (socket, next) => {
           return next();
         }
       }
+
+      if (decoded?.guestSessionId) {
+        const tokenGuestId = decoded.guestSessionId as string;
+        if (GUEST_ID_RE.test(tokenGuestId)) {
+          const guest = await prisma.guest.findUnique({
+            where: { guestSessionId: tokenGuestId },
+            select: { displayName: true },
+          });
+          if (guest) {
+            socket.data = {
+              kind: "guest",
+              guestSessionId: tokenGuestId,
+              displayName: guest.displayName,
+            } satisfies AuthenticatedSocketData;
+            return next();
+          }
+        }
+      }
     }
 
     // 2. Cookieベース認証（ローカル開発フォールバック）

--- a/socket-server/index.ts
+++ b/socket-server/index.ts
@@ -116,10 +116,40 @@ httpServer.on("request", async (req: IncomingMessage, res: ServerResponse) => {
   res.end("Not Found");
 });
 
-// 認証ミドルウェア: セッションCookieを検証し未認証接続を拒否する
-// 通常ユーザー: authjs.session-token / ゲスト: quest_link_guest_session
+// 認証ミドルウェア: トークン認証（クロスドメイン対応）→ Cookieフォールバックの順で検証
+// トークン認証: socket.handshake.auth.token（socket-auth salt の短命JWT）
+// Cookie認証: authjs.session-token / ゲスト: quest_link_guest_session
 io.use(async (socket, next) => {
   try {
+    // 1. トークンベース認証（本番クロスドメイン環境向け）
+    const authToken = socket.handshake.auth?.token as string | undefined;
+    if (authToken) {
+      const decoded = await decode({
+        token: authToken,
+        secret: process.env.AUTH_SECRET ?? "",
+        salt: "socket-auth",
+      });
+
+      if (decoded?.userId) {
+        const user = await prisma.user.findUnique({
+          where: { id: decoded.userId as string },
+          select: { id: true, username: true, iconUrl: true, avgRating: true },
+        });
+
+        if (user) {
+          socket.data = {
+            kind: "user",
+            userId: user.id,
+            username: user.username,
+            iconUrl: user.iconUrl,
+            avgRating: user.avgRating,
+          } satisfies AuthenticatedSocketData;
+          return next();
+        }
+      }
+    }
+
+    // 2. Cookieベース認証（ローカル開発フォールバック）
     const cookieHeader = socket.request.headers.cookie ?? "";
     const cookies = parseCookies(cookieHeader);
     const cookieName =


### PR DESCRIPTION
## 概要

本番環境（Railway）で WebサービスとSocketサービスが別ドメインにデプロイされているため、ブラウザのSameSite制約によりCookieがSocketサーバーに届かず認証失敗が発生する問題を修正。

短命なSocket専用JWT（60秒有効）をNext.js側APIで発行し、Socket.io の `auth` パラメータ経由で渡すトークンベース認証を実装した。Cookieベース認証はローカル開発用フォールバックとして維持。

## 接続フロー（修正後）

```
[本番]
Client → GET /api/v1/auth/socket-token   (同一ドメイン、Cookieで認証)
       ← { token: "<60秒有効JWT>" }
Client → io.connect({ auth: { token } }) (Cookieなし、トークン渡し)
Socket Server → decode(token, salt:"socket-auth") → 認証OK

[ローカル / トークン取得失敗時]
Client → io.connect()  (withCredentials: true でCookie自動送信)
Socket Server → Cookie decode → 認証OK（既存動作を維持）
```

## 変更内容

- `app/api/v1/auth/socket-token/route.ts`（新規）: Socket専用JWT発行エンドポイント。未認証時は401を返す
- `lib/socket.ts`: `connectSocket()` 関数を追加。トークン取得→`socket.auth`設定→接続の順で実行し、取得失敗時はCookieフォールバック
- `socket-server/index.ts`: 認証ミドルウェアを更新。`handshake.auth.token` を最優先でチェックし、DBからユーザー情報を取得。トークンなし・検証失敗時は既存のCookie認証にフォールバック
- `app/rooms/[roomId]/chat/useSocketRoom.ts`: `socket.connect()` → `void connectSocket()` に変更
- `app/rooms/[roomId]/chat/useSocketRoom.test.ts`: `connectSocket` モック追加、テストアサーション更新

Closes #202