### PR TITLE
fix: avgRating の Decimal → number 変換を追加（ビルドエラー修正）

### DIFF
--- a/socket-server/index.ts
+++ b/socket-server/index.ts
@@ -145,7 +145,7 @@ io.use(async (socket, next) => {
             userId: user.id,
             username: user.username,
             iconUrl: user.iconUrl,
-            avgRating: user.avgRating,
+            avgRating: user.avgRating.toNumber(),
           } satisfies AuthenticatedSocketData;
           return next();
         }


### PR DESCRIPTION
## 概要

#202 で追加したトークン認証のユーザーDB lookup箇所で、Prismaの `avgRating` フィールドが `Decimal` 型で返るため `AuthenticatedSocketData` の `number` 型要件を満たさず、Railwayビルドが失敗していた。

## 修正内容

`socket-server/index.ts` の1行修正:

```diff
- avgRating: user.avgRating,
+ avgRating: user.avgRating.toNumber(),
```

## 関連

- #202 で導入したトークンベース認証のバグ修正