### PR TITLE
fix: pnpm db:seed:load の PrismaClientInitializationError と ECONNREFUSED を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:seed": "prisma db seed",
-    "db:seed:load": "tsx prisma/seed-load.ts",
+    "db:seed:load": "tsx --env-file=.env prisma/seed-load.ts",
     "batch:games": "tsx batch/syncGames.ts",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",

--- a/prisma/seed-load.ts
+++ b/prisma/seed-load.ts
@@ -1,6 +1,10 @@
 import { PrismaClient, RoomStatus } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
 
-const prisma = new PrismaClient();
+const pool = new Pool({ connectionString: process.env["DATABASE_URL"] });
+const adapter = new PrismaPg(pool);
+const prisma = new PrismaClient({ adapter });
 
 const LOAD_TEST_USER_COUNT = 500;
 const LOAD_TEST_ROOM_COUNT = 200;
@@ -98,4 +102,6 @@ main()
     console.error(e);
     process.exit(1);
   })
-  .finally(() => prisma.$disconnect());
+  .finally(() => {
+    void prisma.$disconnect();
+  });


### PR DESCRIPTION
## 概要

`pnpm db:seed:load` 実行時に発生していた2つのエラーを修正。

### 修正1: PrismaClientInitializationError（`prisma/seed-load.ts`）

`new PrismaClient()` をアダプターなしで呼び出していたため、driver adapter モード必須の本プロジェクトで初期化エラーが発生していた。`seed.ts` と同じパターン（`Pool` + `PrismaPg` + `PrismaClient({ adapter })`）に統一。

### 修正2: ECONNREFUSED（`package.json`）

`tsx prisma/seed-load.ts` を直接実行する場合、Prisma CLI が行う `.env` の自動ロードが行われないため `DATABASE_URL` が `undefined` になり `localhost:5432` への接続が拒否されていた。`tsx` の `--env-file=.env` フラグを追加して解消。

## 変更ファイル

- `prisma/seed-load.ts` — PrismaPg アダプター初期化を追加
- `package.json` — `db:seed:load` スクリプトに `--env-file=.env` を追加

## 動作確認

`pnpm db:seed:load` を実行し、以下の出力を確認済み：

```
✅ 負荷テスト用シードデータの投入が完了しました
  ユーザー: 500 件
  部屋: 200 件
  ゲーム分散: ... (5 種類)
  ステータス分散: waiting×100, full×50, closed×50 (概算)
```

Closes #215