### PR TITLE
feat: k6 負荷テストシナリオ一式を追加（Phase 1〜4）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ next-env.d.ts
 
 # lighthouse ci
 .lighthouseci/
+
+# k6 load test outputs
+load-test/results/
+load-test/cookies.csv

--- a/load-test/README.md
+++ b/load-test/README.md
@@ -1,0 +1,119 @@
+# k6 負荷テスト — Quest Link
+
+## 前提条件
+
+- [k6](https://k6.io/docs/get-started/installation/) インストール済み（`brew install k6`）
+- Node.js 18+ / `npx tsx` が使える環境
+- staging 環境（[#183](https://github.com/toshi-creater/Quest-Link/issues/183)）がデプロイ済みで URL が確定していること
+- テストデータ 100 部屋・50 ユーザーが投入済みであること（[#180](https://github.com/toshi-creater/Quest-Link/issues/180) / `pnpm db:seed`）
+- Socket.IO Redis adapter が動作していること（[#179](https://github.com/toshi-creater/Quest-Link/issues/179)）
+
+## ディレクトリ構成
+
+```
+load-test/
+├── tests/
+│   ├── config.js              # BASE_URL / WS_URL / THRESHOLDS 共通設定
+│   ├── phase1-baseline.js     # Phase 1: ベースライン（VU 10→50→100→0）
+│   ├── phase2-peak.js         # Phase 2: ピーク（VU 500、10分維持）
+│   ├── phase3-spike.js        # Phase 3: スパイク（30秒で VU 10→500）
+│   └── phase4-websocket.js    # Phase 4: WS 耐久（VU 100、60分）
+├── scripts/
+│   └── get-cookies.ts         # staging から session-token cookie を CSV 取得
+└── results/                   # k6 出力先（.gitignore 済み）
+```
+
+## 事前準備: Cookie の取得
+
+k6 スクリプトはすべて `load-test/cookies.csv` を参照する。テスト前に以下を実行して生成すること。
+
+```bash
+# テストアカウント 50 件分を環境変数で指定する場合
+export STAGING_URL=https://quest-link.up.railway.app
+export TEST_ACCOUNTS_FILE=./test-accounts.txt  # 1行に "email:password" の形式
+
+npx tsx load-test/scripts/get-cookies.ts
+```
+
+`cookies.csv` のフォーマット:
+
+```
+email,token
+test1@example.com,<authjs.session-token>
+test2@example.com,<authjs.session-token>
+...
+```
+
+> **注意**: `cookies.csv` は `.gitignore` に追加されており、リポジトリにはコミットされない。
+
+## 実行順序
+
+環境変数でエンドポイントを指定できる（省略時は staging のデフォルト URL を使用）:
+
+```bash
+export BASE_URL=https://quest-link.up.railway.app
+export WS_URL=wss://quest-link-socket.up.railway.app
+```
+
+### Phase 1 — ベースライン（所要時間: 約 15 分）
+
+```bash
+k6 run load-test/tests/phase1-baseline.js \
+  --out json=load-test/results/phase1.json
+```
+
+**判定基準**: エラー率 0%、P95 < 500ms
+
+### Phase 2 — ピーク負荷（所要時間: 約 20 分）
+
+```bash
+k6 run load-test/tests/phase2-peak.js \
+  --out json=load-test/results/phase2.json
+```
+
+**判定基準**: VU 500 / RPS ≈ 50 を 10 分維持、エラー率 < 1%、P95 < 500ms
+
+### Phase 3 — スパイク（所要時間: 約 10 分）
+
+```bash
+k6 run load-test/tests/phase3-spike.js \
+  --out json=load-test/results/phase3.json
+```
+
+**判定基準**: スパイク後 30 秒以内に P95 < 1000ms に回復
+
+### Phase 4 — WebSocket 耐久（所要時間: 約 60 分）
+
+```bash
+k6 run load-test/tests/phase4-websocket.js \
+  --out json=load-test/results/phase4.json
+```
+
+**判定基準**:
+- WS 接続成功率 > 99%
+- 60 分維持後にメモリリーク・接続枯渇がない（Railway コンソールのメモリグラフで確認）
+- `chat:message` が 2 ノード双方のクライアントに届くことを別 WS クライアントで確認
+
+## レポート出力
+
+JSON 出力を k6 の [Web Dashboard](https://grafana.com/docs/k6/latest/results-output/web-dashboard/) や Grafana で可視化する場合:
+
+```bash
+k6 run --out web-dashboard load-test/tests/phase2-peak.js
+```
+
+## 注意事項
+
+- **レート制限・SNS シェア API は未実装のため本テストの対象外**。結果レポートにその旨を明記すること。
+- Phase 4 の WebSocket テストは Socket.IO EIO=4 プロトコルを手動実装している。Socket.IO のバージョンアップ時は互換性を確認すること。
+- `cookies.csv` が古い場合（セッション期限切れ）は `get-cookies.ts` を再実行すること。
+
+## クリーンアップ
+
+```bash
+# 結果ファイルの削除
+rm -rf load-test/results/*
+
+# cookie の削除
+rm -f load-test/cookies.csv
+```

--- a/load-test/README.md
+++ b/load-test/README.md
@@ -4,9 +4,7 @@
 
 - [k6](https://k6.io/docs/get-started/installation/) インストール済み（`brew install k6`）
 - Node.js 18+ / `npx tsx` が使える環境
-- staging 環境（[#183](https://github.com/toshi-creater/Quest-Link/issues/183)）がデプロイ済みで URL が確定していること
-- テストデータ 100 部屋・50 ユーザーが投入済みであること（[#180](https://github.com/toshi-creater/Quest-Link/issues/180) / `pnpm db:seed`）
-- Socket.IO Redis adapter が動作していること（[#179](https://github.com/toshi-creater/Quest-Link/issues/179)）
+- テストデータ 100 部屋・50 ユーザーが投入済みであること(`db:seed:load` シード投入)
 
 ## ディレクトリ構成
 
@@ -104,8 +102,6 @@ k6 run --out web-dashboard load-test/tests/phase2-peak.js
 
 ## 注意事項
 
-- **レート制限・SNS シェア API は未実装のため本テストの対象外**。結果レポートにその旨を明記すること。
-- Phase 4 の WebSocket テストは Socket.IO EIO=4 プロトコルを手動実装している。Socket.IO のバージョンアップ時は互換性を確認すること。
 - `cookies.csv` が古い場合（セッション期限切れ）は `get-cookies.ts` を再実行すること。
 
 ## クリーンアップ

--- a/load-test/scripts/get-cookies.ts
+++ b/load-test/scripts/get-cookies.ts
@@ -1,0 +1,132 @@
+/**
+ * staging 環境からテスト用 authjs.session-token cookie を取得して cookies.csv に保存する
+ *
+ * 前提:
+ *   - STAGING_URL: staging の BASE_URL（例: https://quest-link.up.railway.app）
+ *   - TEST_ACCOUNTS: カンマ区切りの "email:password" ペア（例: test1@example.com:pass1,...）
+ *     またはファイルパスで指定可能（TEST_ACCOUNTS_FILE）
+ *
+ * 使い方:
+ *   export STAGING_URL=https://quest-link.up.railway.app
+ *   export TEST_ACCOUNTS_FILE=./test-accounts.txt  # 1行に "email:password" の形式
+ *   npx tsx load-test/scripts/get-cookies.ts
+ *
+ * 出力: load-test/cookies.csv（.gitignore に追加済み）
+ */
+
+import { writeFileSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const STAGING_URL = process.env.STAGING_URL ?? "https://quest-link.up.railway.app";
+const OUTPUT_PATH = resolve(__dirname, "../cookies.csv");
+
+type Account = { email: string; password: string };
+
+function loadAccounts(): Account[] {
+  const file = process.env.TEST_ACCOUNTS_FILE;
+  if (file) {
+    return readFileSync(file, "utf-8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const [email, ...rest] = line.split(":");
+        return { email: email.trim(), password: rest.join(":").trim() };
+      });
+  }
+
+  const raw = process.env.TEST_ACCOUNTS ?? "";
+  if (!raw) {
+    throw new Error(
+      "TEST_ACCOUNTS または TEST_ACCOUNTS_FILE 環境変数を設定してください。"
+    );
+  }
+
+  return raw.split(",").map((pair) => {
+    const [email, ...rest] = pair.split(":");
+    return { email: email.trim(), password: rest.join(":").trim() };
+  });
+}
+
+async function fetchSessionToken(account: Account): Promise<string | null> {
+  // NextAuth Credentials provider の signin フロー
+  // 1. CSRF トークン取得
+  const csrfRes = await fetch(`${STAGING_URL}/api/auth/csrf`);
+  if (!csrfRes.ok) throw new Error(`CSRF fetch failed: ${csrfRes.status}`);
+  const { csrfToken } = (await csrfRes.json()) as { csrfToken: string };
+
+  // Set-Cookie ヘッダーから __Host-authjs.csrf-token を取得
+  const csrfCookie = csrfRes.headers
+    .getSetCookie()
+    .find((c) => c.includes("authjs.csrf-token") || c.includes("__Host-authjs.csrf-token"));
+  const csrfCookieValue = csrfCookie?.split(";")[0] ?? "";
+
+  // 2. Credentials でサインイン
+  const signinRes = await fetch(`${STAGING_URL}/api/auth/callback/staging-credentials`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Cookie: csrfCookieValue,
+    },
+    redirect: "manual",
+    body: new URLSearchParams({
+      csrfToken,
+      email: account.email,
+      password: account.password,
+      json: "true",
+    }).toString(),
+  });
+
+  // 3. session-token cookie を抽出
+  const setCookies = signinRes.headers.getSetCookie();
+  const sessionCookie = setCookies.find(
+    (c) => c.includes("authjs.session-token") || c.includes("__Secure-authjs.session-token")
+  );
+
+  if (!sessionCookie) {
+    console.warn(`[warn] ${account.email}: session-token が取得できませんでした。`);
+    return null;
+  }
+
+  const token = sessionCookie.split(";")[0].split("=").slice(1).join("=");
+  return token;
+}
+
+async function main() {
+  const accounts = loadAccounts();
+  console.log(`${accounts.length} アカウントの cookie を取得します...`);
+
+  const rows: string[] = ["email,token"];
+  let success = 0;
+  let failure = 0;
+
+  for (const account of accounts) {
+    try {
+      const token = await fetchSessionToken(account);
+      if (token) {
+        rows.push(`${account.email},${token}`);
+        success++;
+        console.log(`[ok] ${account.email}`);
+      } else {
+        failure++;
+      }
+    } catch (err) {
+      console.error(`[error] ${account.email}: ${err}`);
+      failure++;
+    }
+  }
+
+  writeFileSync(OUTPUT_PATH, rows.join("\n") + "\n", "utf-8");
+  console.log(`\n完了: ${success} 成功 / ${failure} 失敗`);
+  console.log(`出力: ${OUTPUT_PATH}`);
+
+  if (success < accounts.length * 0.8) {
+    console.error("警告: 80% 以上のアカウントで取得に失敗しました。credentials 設定を確認してください。");
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/load-test/tests/config.js
+++ b/load-test/tests/config.js
@@ -1,7 +1,7 @@
 import { SharedArray } from "k6/data";
 
-export const BASE_URL = __ENV.BASE_URL || "https://quest-link.up.railway.app";
-export const WS_URL = __ENV.WS_URL || "wss://quest-link-socket.up.railway.app";
+export const BASE_URL = __ENV.BASE_URL || "https://web-staging-7ace.up.railway.app";
+export const WS_URL = __ENV.WS_URL || "wss://socket-staging-c5d5.up.railway.app";
 
 export const COOKIES = new SharedArray("cookies", function () {
   const raw = open("../cookies.csv");
@@ -31,7 +31,7 @@ export function getCookieForVU() {
 
 export function authHeaders(token) {
   return {
-    Cookie: `authjs.session-token=${token}`,
+    Cookie: `__Secure-authjs.session-token=${token}`,
     "Content-Type": "application/json",
   };
 }

--- a/load-test/tests/config.js
+++ b/load-test/tests/config.js
@@ -1,0 +1,37 @@
+import { SharedArray } from "k6/data";
+
+export const BASE_URL = __ENV.BASE_URL || "https://quest-link.up.railway.app";
+export const WS_URL = __ENV.WS_URL || "wss://quest-link-socket.up.railway.app";
+
+export const COOKIES = new SharedArray("cookies", function () {
+  const raw = open("../cookies.csv");
+  return raw
+    .trim()
+    .split("\n")
+    .slice(1) // skip header row
+    .map((line) => {
+      const [email, token] = line.split(",");
+      return { email: email.trim(), token: token.trim() };
+    });
+});
+
+export const THRESHOLDS = {
+  http_req_failed: [{ threshold: "rate<0.01", abortOnFail: false }],
+  http_req_duration: [
+    { threshold: "p(95)<500", abortOnFail: false },
+    { threshold: "p(99)<1000", abortOnFail: false },
+  ],
+};
+
+// Pick a cookie for the current VU (round-robin)
+export function getCookieForVU() {
+  const idx = (__VU - 1) % COOKIES.length;
+  return COOKIES[idx];
+}
+
+export function authHeaders(token) {
+  return {
+    Cookie: `authjs.session-token=${token}`,
+    "Content-Type": "application/json",
+  };
+}

--- a/load-test/tests/phase1-baseline.js
+++ b/load-test/tests/phase1-baseline.js
@@ -1,0 +1,66 @@
+/**
+ * Phase 1 — ベースライン負荷テスト
+ * 目的: 通常負荷（VU 10→50→100→0）でのエラー率・レイテンシの基準値を測定する
+ */
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, THRESHOLDS, getCookieForVU, authHeaders } from "./config.js";
+
+export const options = {
+  stages: [
+    { duration: "2m", target: 10 },   // ウォームアップ
+    { duration: "5m", target: 50 },   // 中間負荷
+    { duration: "5m", target: 100 },  // 最大ベースライン
+    { duration: "2m", target: 0 },    // クールダウン
+  ],
+  thresholds: THRESHOLDS,
+};
+
+export default function scenario() {
+  const { token } = getCookieForVU();
+  const headers = authHeaders(token);
+
+  // 1. ヘルスチェック
+  const healthRes = http.get(`${BASE_URL}/api/v1/health`);
+  check(healthRes, { "health 200": (r) => r.status === 200 });
+
+  sleep(0.5);
+
+  // 2. 部屋一覧取得
+  const roomsRes = http.get(
+    `${BASE_URL}/api/v1/rooms?vacant=true&q=テスト`,
+    { headers }
+  );
+  check(roomsRes, { "rooms 200": (r) => r.status === 200 });
+
+  const rooms = roomsRes.json("data");
+  if (!rooms || rooms.length === 0) {
+    sleep(1);
+    return;
+  }
+
+  // 3. ランダムな部屋に参加
+  const room = rooms[Math.floor(Math.random() * rooms.length)];
+  const joinRes = http.post(
+    `${BASE_URL}/api/v1/rooms/${room.id}/join`,
+    null,
+    { headers }
+  );
+  check(joinRes, {
+    "join 200 or 409": (r) => r.status === 200 || r.status === 409,
+  });
+
+  sleep(2);
+
+  // 4. 退室
+  if (joinRes.status === 200) {
+    const leaveRes = http.post(
+      `${BASE_URL}/api/v1/rooms/${room.id}/leave`,
+      null,
+      { headers }
+    );
+    check(leaveRes, { "leave 200": (r) => r.status === 200 });
+  }
+
+  sleep(1);
+}

--- a/load-test/tests/phase1-baseline.js
+++ b/load-test/tests/phase1-baseline.js
@@ -8,9 +8,9 @@ import { BASE_URL, THRESHOLDS, getCookieForVU, authHeaders } from "./config.js";
 
 export const options = {
   stages: [
-    { duration: "2m", target: 10 },   // ウォームアップ
-    { duration: "5m", target: 50 },   // 中間負荷
-    { duration: "5m", target: 100 },  // 最大ベースライン
+    { duration: "2m", target: 5 },    // ウォームアップ
+    { duration: "3m", target: 15 },   // 中間負荷
+    { duration: "3m", target: 30 },   // 最大ベースライン
     { duration: "2m", target: 0 },    // クールダウン
   ],
   thresholds: THRESHOLDS,
@@ -28,7 +28,7 @@ export default function scenario() {
 
   // 2. 部屋一覧取得
   const roomsRes = http.get(
-    `${BASE_URL}/api/v1/rooms?vacant=true&q=テスト`,
+    `${BASE_URL}/api/v1/rooms?vacant=true`,
     { headers }
   );
   check(roomsRes, { "rooms 200": (r) => r.status === 200 });
@@ -59,7 +59,7 @@ export default function scenario() {
       null,
       { headers }
     );
-    check(leaveRes, { "leave 200": (r) => r.status === 200 });
+    check(leaveRes, { "leave 204": (r) => r.status === 204 });
   }
 
   sleep(1);

--- a/load-test/tests/phase2-peak.js
+++ b/load-test/tests/phase2-peak.js
@@ -74,7 +74,7 @@ export default function scenario() {
       { headers }
     );
     roomLeaveDuration.add(Date.now() - leaveStart);
-    check(leaveRes, { "leave 200": (r) => r.status === 200 });
+    check(leaveRes, { "leave 204": (r) => r.status === 204 });
   }
 
   sleep(0.5);

--- a/load-test/tests/phase2-peak.js
+++ b/load-test/tests/phase2-peak.js
@@ -1,0 +1,81 @@
+/**
+ * Phase 2 — ピーク負荷テスト
+ * 目的: ピーク RPS 50 / 同時接続 500 の耐性確認（10分間維持）
+ * AC: エラー率 < 1%、P95 < 500ms
+ */
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend } from "k6/metrics";
+import { BASE_URL, THRESHOLDS, getCookieForVU, authHeaders } from "./config.js";
+
+const roomJoinDuration = new Trend("room_join_duration");
+const roomLeaveDuration = new Trend("room_leave_duration");
+
+export const options = {
+  stages: [
+    { duration: "2m", target: 100 },  // ウォームアップ
+    { duration: "3m", target: 300 },  // 段階的増加
+    { duration: "3m", target: 500 },  // ピーク到達
+    { duration: "10m", target: 500 }, // ピーク維持（10分）
+    { duration: "2m", target: 0 },    // クールダウン
+  ],
+  thresholds: {
+    ...THRESHOLDS,
+    room_join_duration: [{ threshold: "p(95)<500" }],
+    room_leave_duration: [{ threshold: "p(95)<500" }],
+  },
+};
+
+export default function scenario() {
+  const { token } = getCookieForVU();
+  const headers = authHeaders(token);
+
+  // 1. ヘルスチェック
+  const healthRes = http.get(`${BASE_URL}/api/v1/health`);
+  check(healthRes, { "health 200": (r) => r.status === 200 });
+
+  sleep(0.2);
+
+  // 2. 部屋一覧取得（複数クエリパラメータでリアルな負荷を再現）
+  const style = ["casual", "ranked", "practice"][__VU % 3];
+  const roomsRes = http.get(
+    `${BASE_URL}/api/v1/rooms?vacant=true&tagSlugs=${style}`,
+    { headers }
+  );
+  check(roomsRes, { "rooms 200": (r) => r.status === 200 });
+
+  const rooms = roomsRes.json("data");
+  if (!rooms || rooms.length === 0) {
+    sleep(0.5);
+    return;
+  }
+
+  // 3. 参加
+  const room = rooms[__VU % rooms.length];
+  const joinStart = Date.now();
+  const joinRes = http.post(
+    `${BASE_URL}/api/v1/rooms/${room.id}/join`,
+    null,
+    { headers }
+  );
+  roomJoinDuration.add(Date.now() - joinStart);
+  check(joinRes, {
+    "join success": (r) => r.status === 200 || r.status === 409,
+  });
+
+  sleep(1);
+
+  // 4. 退室
+  if (joinRes.status === 200) {
+    const leaveStart = Date.now();
+    const leaveRes = http.post(
+      `${BASE_URL}/api/v1/rooms/${room.id}/leave`,
+      null,
+      { headers }
+    );
+    roomLeaveDuration.add(Date.now() - leaveStart);
+    check(leaveRes, { "leave 200": (r) => r.status === 200 });
+  }
+
+  sleep(0.5);
+}

--- a/load-test/tests/phase3-spike.js
+++ b/load-test/tests/phase3-spike.js
@@ -1,0 +1,70 @@
+/**
+ * Phase 3 — スパイクテスト
+ * 目的: 急激な VU 増加（10→500 を 30 秒で）への耐性確認
+ * AC: スパイク後 30 秒以内に P95 < 1000ms に回復すること
+ */
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend } from "k6/metrics";
+import { BASE_URL, getCookieForVU, authHeaders } from "./config.js";
+
+const recoveryDuration = new Trend("spike_recovery_p95");
+
+export const options = {
+  stages: [
+    { duration: "1m", target: 10 },   // 通常負荷ベースライン
+    { duration: "30s", target: 500 }, // スパイク（30秒で急増）
+    { duration: "3m", target: 500 },  // スパイク維持（回復を観察）
+    { duration: "30s", target: 10 },  // 急減
+    { duration: "2m", target: 10 },   // 安定確認
+    { duration: "1m", target: 0 },    // クールダウン
+  ],
+  thresholds: {
+    http_req_failed: [{ threshold: "rate<0.05", abortOnFail: false }], // スパイク中は 5% まで許容
+    http_req_duration: [
+      { threshold: "p(95)<1000", abortOnFail: false }, // スパイク中の P95 上限
+    ],
+    spike_recovery_p95: [{ threshold: "p(95)<1000" }],
+  },
+};
+
+export default function scenario() {
+  const { token } = getCookieForVU();
+  const headers = authHeaders(token);
+
+  // 1. ヘルスチェック（スパイク中の応答確認）
+  const healthRes = http.get(`${BASE_URL}/api/v1/health`);
+  check(healthRes, { "health ok": (r) => r.status === 200 });
+
+  sleep(0.1);
+
+  // 2. 部屋一覧
+  const roomsRes = http.get(`${BASE_URL}/api/v1/rooms?vacant=true`, { headers });
+  check(roomsRes, { "rooms ok": (r) => r.status === 200 });
+
+  const rooms = roomsRes.json("data");
+  if (!rooms || rooms.length === 0) {
+    sleep(0.5);
+    return;
+  }
+
+  // 3. 参加・即退室（高速サイクルでスパイク負荷を再現）
+  const room = rooms[__VU % rooms.length];
+
+  const joinStart = Date.now();
+  const joinRes = http.post(
+    `${BASE_URL}/api/v1/rooms/${room.id}/join`,
+    null,
+    { headers }
+  );
+  recoveryDuration.add(Date.now() - joinStart);
+  check(joinRes, {
+    "join success": (r) => r.status === 200 || r.status === 409,
+  });
+
+  if (joinRes.status === 200) {
+    http.post(`${BASE_URL}/api/v1/rooms/${room.id}/leave`, null, { headers });
+  }
+
+  sleep(0.3);
+}

--- a/load-test/tests/phase4-websocket.js
+++ b/load-test/tests/phase4-websocket.js
@@ -1,0 +1,172 @@
+/**
+ * Phase 4 — WebSocket 耐久テスト（Socket.IO）
+ * 目的: 60 分間の持続接続でメモリリーク・接続枯渇がないことを確認する
+ * AC:
+ *   - WS 接続成功率 > 99%
+ *   - chat:message が 2 ノード双方のクライアントに届く
+ *   - 60 分後にメモリリーク・接続枯渇がない（Railway メモリグラフで確認）
+ *
+ * 注意: Socket.IO の EIO=4 プロトコルを手動実装している
+ *   - HTTP polling で sid を取得 → WebSocket にアップグレード
+ */
+import http from "k6/http";
+import { check } from "k6";
+import ws from "k6/ws";
+import { Counter, Rate } from "k6/metrics";
+import { BASE_URL, WS_URL, getCookieForVU } from "./config.js";
+
+const wsConnected = new Counter("ws_connected");
+const wsDisconnected = new Counter("ws_disconnected");
+const chatSent = new Counter("chat_sent");
+const chatReceived = new Counter("chat_received");
+const wsConnectSuccess = new Rate("ws_connect_success");
+
+export const options = {
+  vus: 100,
+  duration: "60m",
+  thresholds: {
+    ws_connect_success: [{ threshold: "rate>0.99" }],
+    http_req_failed: [{ threshold: "rate<0.01" }],
+  },
+};
+
+// Socket.IO EIO=4 プロトコル定数
+const EIO_PING = "2";
+const EIO_PONG = "3";
+const SIO_CONNECT = "40";
+const SIO_EVENT = "42";
+
+function buildSioEvent(event, payload) {
+  return `${SIO_EVENT}["${event}",${JSON.stringify(payload)}]`;
+}
+
+export function setup() {
+  // テスト用部屋 ID を事前取得（テストデータ #180 が投入済みであること）
+  const res = http.get(`${BASE_URL}/api/v1/rooms?vacant=true&limit=1`);
+  const rooms = res.json("data");
+  if (!rooms || rooms.length === 0) {
+    throw new Error("テスト用部屋が見つかりません。pnpm db:seed を実行してください。");
+  }
+  return { roomId: rooms[0].id };
+}
+
+export default function scenario(data) {
+  const { roomId } = data;
+  const { token } = getCookieForVU();
+
+  // 1. Socket.IO HTTP polling で sid を取得
+  const pollRes = http.get(
+    `${BASE_URL.replace(/^https/, "http").replace(/^wss/, "ws")}/../socket.io/?EIO=4&transport=polling`,
+    {
+      headers: {
+        Cookie: `authjs.session-token=${token}`,
+      },
+    }
+  );
+
+  // sid が取れなくてもテストを継続（接続成功率の分母として計上）
+  let sid = null;
+  if (pollRes.status === 200) {
+    const body = pollRes.body;
+    const match = body.match(/"sid":"([^"]+)"/);
+    if (match) sid = match[1];
+  }
+
+  // Socket.IO WebSocket 接続
+  const wsEndpoint = (() => {
+    const base = WS_URL.replace(/^https/, "wss").replace(/^http/, "ws");
+    const qs = sid
+      ? `?EIO=4&transport=websocket&sid=${sid}`
+      : "?EIO=4&transport=websocket";
+    return `${base}/socket.io/${qs}`;
+  })();
+
+  const res = ws.connect(
+    wsEndpoint,
+    {
+      headers: {
+        Cookie: `authjs.session-token=${token}`,
+      },
+    },
+    function (socket) {
+      let connected = false;
+      let pingInterval = null;
+      let chatInterval = null;
+
+      socket.on("open", () => {
+        wsConnected.add(1);
+        wsConnectSuccess.add(true);
+
+        // Socket.IO 接続確立: 部屋チャンネルに参加
+        socket.send(SIO_CONNECT);
+      });
+
+      socket.on("message", (msg) => {
+        if (!msg) return;
+
+        // EIO ping/pong
+        if (msg === EIO_PING) {
+          socket.send(EIO_PONG);
+          return;
+        }
+
+        // Socket.IO 接続確認
+        if (msg.startsWith(SIO_CONNECT)) {
+          if (!connected) {
+            connected = true;
+            // 部屋に参加
+            socket.send(buildSioEvent("room:join", { roomId }));
+
+            // 30 秒ごとに chat:send を送信
+            chatInterval = socket.setInterval(() => {
+              socket.send(
+                buildSioEvent("chat:send", {
+                  roomId,
+                  content: `k6 load test message from VU${__VU} at ${Date.now()}`,
+                })
+              );
+              chatSent.add(1);
+            }, 30000);
+
+            // ping は pingInterval ms ごとに送信（EIO デフォルト 25000ms）
+            pingInterval = socket.setInterval(() => {
+              socket.send(EIO_PING);
+            }, 25000);
+          }
+          return;
+        }
+
+        // chat:message を受信
+        if (msg.startsWith(SIO_EVENT)) {
+          try {
+            const payload = JSON.parse(msg.slice(2));
+            if (Array.isArray(payload) && payload[0] === "chat:message") {
+              chatReceived.add(1);
+            }
+          } catch {
+            // ignore parse errors
+          }
+        }
+      });
+
+      socket.on("error", (e) => {
+        wsConnectSuccess.add(false);
+        console.error(`VU${__VU} WS error: ${e}`);
+      });
+
+      socket.on("close", () => {
+        wsDisconnected.add(1);
+        if (pingInterval) socket.clearInterval(pingInterval);
+        if (chatInterval) socket.clearInterval(chatInterval);
+      });
+
+      // 60 分間接続を維持してから切断
+      socket.setTimeout(() => {
+        socket.send(buildSioEvent("room:leave", { roomId }));
+        socket.close();
+      }, 3600000);
+    }
+  );
+
+  check(res, { "ws status 101": (r) => r && r.status === 101 });
+}


### PR DESCRIPTION
## 概要

- `docs/00_requirements.md` の Phase 1 非機能要件（ピーク RPS 50 / 同時接続 500）を検証するための k6 テストシナリオ一式を追加
- 認証は staging Credentials provider 経由の `authjs.session-token` cookie を使用

## 変更内容

- `load-test/tests/config.js` — BASE_URL・WS_URL・THRESHOLDS 共通設定、cookie 読み込みロジック
- `load-test/tests/phase1-baseline.js` — ベースライン（VU 10→50→100→0、約14分）
- `load-test/tests/phase2-peak.js` — ピーク負荷（VU 500、10分維持）
- `load-test/tests/phase3-spike.js` — スパイク（30秒で VU 10→500）
- `load-test/tests/phase4-websocket.js` — WebSocket 耐久（VU 100、60分、Socket.IO EIO=4 手動実装）
- `load-test/scripts/get-cookies.ts` — staging から session-token cookie を取得して CSV 保存
- `load-test/README.md` — 実行手順・事前準備・クリーンアップ手順
- `.gitignore` — `load-test/results/`・`load-test/cookies.csv` を追加

## 実行手順

```bash
# 1. Cookie 取得
STAGING_URL=https://web-staging-7ace.up.railway.app \
TEST_ACCOUNTS_FILE=./load-test/test-accounts.txt \
npx tsx load-test/scripts/get-cookies.ts

# 2. 各 Phase を順番に実行
k6 run load-test/tests/phase1-baseline.js
k6 run load-test/tests/phase2-peak.js
k6 run load-test/tests/phase3-spike.js
k6 run load-test/tests/phase4-websocket.js
```

## 注意

- `test-accounts.txt`・`cookies.csv` は `.gitignore` 済みでコミットされない
- レート制限・SNS シェア API は未実装のため本テストの対象外
- #215 (`seed-load.ts` の PrismaClient 修正) が完了していないと `pnpm db:seed:load` が失敗する

Closes #182