### PR TITLE
perf: DB接続プールサイズを5→45に拡大しリクエスト詰まりを解消

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -7,7 +7,7 @@ const globalForPrisma = globalThis as unknown as {
 };
 
 function createPrismaClient() {
-  const pool = new Pool({ connectionString: process.env["DATABASE_URL"], max: 5 });
+  const pool = new Pool({ connectionString: process.env["DATABASE_URL"], max: 45 });
   const adapter = new PrismaPg(pool);
   return new PrismaClient({ adapter });
 }


### PR DESCRIPTION
## 概要

k6負荷テストで30VU同時リクエスト時にP95レイテンシ7.17秒・エラー率3.14%が発生していた問題を修正する。

原因は`lib/prisma.ts`の`pg.Pool`接続上限が`max: 5`に制限されており、25リクエストが接続待ちのボトルネックになっていたため。Supabase Freeプランの上限60接続の範囲内で`max: 45`に拡大する。

## 変更内容

- `lib/prisma.ts`: `pg.Pool` の `max` を `5` → `45` に変更

## 期待される効果

- 100VU負荷テストでエラー率 < 5% を達成
- P95レイテンシの大幅改善

Closes #218