### PR TITLE
fix: join エンドポイントのトランザクション分離レベルを Serializable → ReadCommitted に変更

### DIFF
--- a/app/api/v1/rooms/[roomId]/join/route.ts
+++ b/app/api/v1/rooms/[roomId]/join/route.ts
@@ -70,7 +70,7 @@ export async function POST(_request: Request, { params }: RouteParams) {
 
         return newParticipant;
       },
-      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+      { isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted }
     );
 
     // 入室システムメッセージとイベント通知


### PR DESCRIPTION
## 概要

`POST /api/v1/rooms/[roomId]/join` が並行負荷下で 500 エラーを返すバグを修正。

`SELECT FOR UPDATE` で行ロックを取得済みのため `Serializable` は不要かつ逆効果。`ReadCommitted` に変更し、並行参加時の SQLSTATE 40001 競合エラーを解消する。

## 変更内容

- `app/api/v1/rooms/[roomId]/join/route.ts:73` — `Serializable` → `ReadCommitted`

## 期待される改善

- join 500 エラー率: 12% → ほぼ 0%

Closes #220