### PR TITLE
fix: vitestのworktreeテスト混入とavatarモック不一致を修正

### DIFF
--- a/app/api/v1/users/me/avatar/route.test.ts
+++ b/app/api/v1/users/me/avatar/route.test.ts
@@ -17,9 +17,9 @@ const { mockUpload, mockGetPublicUrl, mockFrom } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/supabase", () => ({
-  supabase: {
+  getSupabaseClient: vi.fn(() => ({
     storage: { from: mockFrom },
-  },
+  })),
   AVATAR_BUCKET: "avatar_images",
 }));
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
-    exclude: ['**/node_modules/**', '.worktrees/**', 'e2e/**'],
+    exclude: ['**/node_modules/**', '.worktrees/**', '.pnpm-store/**', 'e2e/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- `vitest.config.ts` に `.pnpm-store/**` を除外追加し、pnpm store 経由で発見されていた worktree のテスト（e2e・旧モック・React競合）127件の誤実行を解消
- `avatar/route.test.ts` のモックを廃止済みの `supabase` シングルトンから `getSupabaseClient: vi.fn()` に変更し、3件の失敗を修正

## 原因

**問題1（〜124件）**: `pnpm` はワークツリーのプロジェクトを `.pnpm-store/v10/projects/` にも展開するが、vitest の exclude に `.pnpm-store/**` が含まれておらず、worktree 内の旧テスト・e2e・React競合テストが全て実行されていた。

**問題2（3件）**: `lib/supabase.ts` が `supabase` シングルトンから `getSupabaseClient()` 関数に変更された際に `avatar/route.test.ts` のモックが更新されず不一致が発生していた。

## Test plan

- [x] `pnpm test` で 425件全て PASS を確認済み（修正前: 127件失敗）

🤖 Generated with [Claude Code](https://claude.com/claude-code)