### PR TITLE
perf: アクティブ参加者の一意部分インデックス追加 & P2002ハンドリング

### DIFF
--- a/app/api/v1/rooms/[roomId]/join/route.test.ts
+++ b/app/api/v1/rooms/[roomId]/join/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Prisma } from "@prisma/client";
 
 vi.mock("@/auth", () => ({
   auth: vi.fn(),
@@ -203,6 +204,26 @@ describe("POST /api/v1/rooms/[roomId]/join", () => {
     expect(mockEmitToRoom).toHaveBeenCalledTimes(2);
     expect(mockEmitToRoom).toHaveBeenCalledWith("chat:message", "room-1", expect.objectContaining({ isSystem: true }));
     expect(mockEmitToRoom).toHaveBeenCalledWith("room:user_joined", "room-1", expect.objectContaining({ userId: "user-1" }));
+  });
+
+  it("DB一意制約違反（P2002）の場合 409 ALREADY_JOINED を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockRoomFindUnique.mockResolvedValue({ id: "room-1", status: "open", maxPlayers: 4 } as never);
+
+    mockTx.roomParticipant.count.mockResolvedValue(1);
+    mockTx.roomParticipant.findFirst.mockResolvedValue(null);
+    const p2002 = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+      code: "P2002",
+      clientVersion: "7.0.0",
+      meta: { target: "room_participants_active_unique" },
+    });
+    mockTx.roomParticipant.create.mockRejectedValue(p2002);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("ALREADY_JOINED");
   });
 
   it("正常参加（満員になる）場合 room.update({ status: 'full' }) が呼ばれる", async () => {

--- a/app/api/v1/rooms/[roomId]/join/route.ts
+++ b/app/api/v1/rooms/[roomId]/join/route.ts
@@ -121,6 +121,12 @@ export async function POST(_request: Request, { params }: RouteParams) {
       },
     });
   } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return NextResponse.json(
+        { error: { code: "ALREADY_JOINED", message: "既にこの部屋に参加しています" } },
+        { status: 409 }
+      );
+    }
     if (error instanceof Error) {
       if (error.message === "ALREADY_JOINED") {
         return NextResponse.json(

--- a/prisma/migrations/20260523000000_add_active_participant_unique/migration.sql
+++ b/prisma/migrations/20260523000000_add_active_participant_unique/migration.sql
@@ -1,0 +1,4 @@
+-- 同一ユーザーが同じ部屋にアクティブな状態（left_at IS NULL）で二重参加しないよう部分インデックスを追加
+CREATE UNIQUE INDEX room_participants_active_unique
+ON room_participants (room_id, user_id)
+WHERE left_at IS NULL AND user_id IS NOT NULL;


### PR DESCRIPTION
## 概要

- `room_participants` テーブルに部分ユニークインデックスを追加し、同一ユーザーの同一ルームへの二重参加をDBレベルで防止する
- 高並行時に P2002 が発生した場合も `409 ALREADY_JOINED` を正しく返すようハンドリングを追加

## 変更内容

### 1. マイグレーション
```sql
CREATE UNIQUE INDEX room_participants_active_unique
ON room_participants (room_id, user_id)
WHERE left_at IS NULL AND user_id IS NOT NULL;
```
退出済み行（`left_at IS NOT NULL`）とゲストユーザー（`user_id IS NULL`）は対象外のため、再参加や複数ゲストの同時参加は従来通り機能する。

### 2. P2002エラーハンドリング（`join/route.ts`）
アプリ層の `findFirst` チェックをすり抜けた場合でも、DB制約が P2002 を返した際に `409 ALREADY_JOINED` として処理する。

### 3. テスト（`join/route.test.ts`）
`roomParticipant.create` が P2002 を投げた場合に `409 ALREADY_JOINED` が返ることを確認するテストを追加。

## テスト結果

```
✓ app/api/v1/rooms/[roomId]/join/route.test.ts (9 tests)
✓ app/api/v1/invite/[token]/join/route.test.ts (11 tests)
20 passed
```

Closes #226