### PR TITLE
fix: チャットメッセージで改行が反映されない (#237)

### DIFF
--- a/app/rooms/[roomId]/chat/ChatMessageList.test.tsx
+++ b/app/rooms/[roomId]/chat/ChatMessageList.test.tsx
@@ -101,6 +101,17 @@ describe("ChatMessageList", () => {
       render(<ChatMessageList currentUserId="u1" currentGuestSessionId={null} />);
       expect(screen.queryByTestId("user-avatar")).not.toBeInTheDocument();
     });
+
+    it("改行を含むメッセージ本文が whitespace-pre-wrap クラスで描画される", () => {
+      useChatStore.setState({
+        messages: [makeMsg({ content: "line1\nline2" })],
+      });
+      const { container } = render(<ChatMessageList currentUserId="u2" currentGuestSessionId={null} />);
+      const msgEl = container.querySelector(".whitespace-pre-wrap");
+      expect(msgEl).not.toBeNull();
+      expect(msgEl?.textContent).toContain("line1");
+      expect(msgEl?.textContent).toContain("line2");
+    });
   });
 
   describe("ゲストメッセージ", () => {

--- a/app/rooms/[roomId]/chat/ChatMessageList.tsx
+++ b/app/rooms/[roomId]/chat/ChatMessageList.tsx
@@ -79,7 +79,7 @@ export function ChatMessageList({ currentUserId, currentGuestSessionId }: Props)
                   </span>
                 )}
                 <div
-                  className="rounded-2xl px-3 py-2 text-sm leading-relaxed break-words"
+                  className="rounded-2xl px-3 py-2 text-sm leading-relaxed break-words whitespace-pre-wrap"
                   style={
                     isMe
                       ? {


### PR DESCRIPTION
## 概要

チャット画面で Shift+Enter による改行を含むメッセージを送信すると、受信側で改行が無視されて1行で表示されるバグを修正。

- `ChatMessageList.tsx` L82 の本文 `<div>` の className に `whitespace-pre-wrap` を追加
- デフォルト CSS では `\n` が空白1文字に丸められるが、`whitespace-pre-wrap` により改行として描画される
- `break-words`（`overflow-wrap: break-word`）との併用で長い単語の折り返しも維持

## テスト

改行を含むメッセージ `"line1\nline2"` を送信したとき、本文要素に `whitespace-pre-wrap` クラスが付与され、`line1`・`line2` 両方がテキストコンテンツに含まれることを検証するテストを追加。

## AC確認

- [x] 改行を含むメッセージを送信すると、受信側でも改行が保たれて表示される
- [x] 既存テストが通る（427テスト全パス）
- [x] 新規テストで `content: "line1\nline2"` が複数行として描画されることを検証
- [x] `pnpm lint` がパス（変更ファイルにエラーなし）

Closes #237