### PR TITLE
fix: タグ選択ドロップダウンがトグルボタンクリックで閉じない (#238)

### DIFF
--- a/app/rooms/RoomsFilter.tsx
+++ b/app/rooms/RoomsFilter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { MagnifyingGlass } from "@phosphor-icons/react";
 import { fetchRooms, type RoomSummary } from "@/lib/api/rooms";
@@ -30,6 +30,7 @@ export function RoomsFilter({ gameId }: { gameId?: string }) {
   const [appliedTags, setAppliedTags] = useState<string[]>([]);
   const [pendingTags, setPendingTags] = useState<string[]>([]);
   const [panelOpen, setPanelOpen] = useState(false);
+  const toggleRef = useRef<HTMLDivElement>(null);
 
   const { data: tagsData = [] } = useQuery({
     queryKey: ["play-style-tags"],
@@ -96,11 +97,13 @@ export function RoomsFilter({ gameId }: { gameId?: string }) {
       {/* Tag filters */}
       <div className="mb-6">
         <div className="flex items-center gap-2">
-          <TagFilterToggle
-            selectedCount={appliedTags.length}
-            panelOpen={panelOpen}
-            onPanelToggle={handlePanelToggle}
-          />
+          <div ref={toggleRef}>
+            <TagFilterToggle
+              selectedCount={appliedTags.length}
+              panelOpen={panelOpen}
+              onPanelToggle={handlePanelToggle}
+            />
+          </div>
           {appliedTags.length > 0 && (
             <button
               onClick={() => setAppliedTags([])}
@@ -118,6 +121,7 @@ export function RoomsFilter({ gameId }: { gameId?: string }) {
           open={panelOpen}
           onApply={handleApply}
           onClickOutside={handleApply}
+          ignoreRef={toggleRef}
         />
         <div className="mt-2 min-w-0">
           <ActiveFilterBar

--- a/app/rooms/new/page.tsx
+++ b/app/rooms/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import Image from "next/image";
@@ -41,6 +41,7 @@ export default function NewRoomPage() {
   const [pendingSlugs, setPendingSlugs] = useState<string[]>([]);
   const [panelOpen, setPanelOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const toggleRef = useRef<HTMLDivElement>(null);
 
   const { data: tags = [] } = useQuery({
     queryKey: ["play-style-tags"],
@@ -286,12 +287,14 @@ export default function NewRoomPage() {
               </span>
             </label>
             <div className="flex items-center gap-2">
-              <TagFilterToggle
-                selectedCount={selectedSlugs.length}
-                panelOpen={panelOpen}
-                onPanelToggle={handlePanelToggle}
-                label="タグを選択"
-              />
+              <div ref={toggleRef}>
+                <TagFilterToggle
+                  selectedCount={selectedSlugs.length}
+                  panelOpen={panelOpen}
+                  onPanelToggle={handlePanelToggle}
+                  label="タグを選択"
+                />
+              </div>
               {selectedSlugs.length > 0 && (
                 <button
                   type="button"
@@ -311,6 +314,7 @@ export default function NewRoomPage() {
               onApply={handleApply}
               applyLabel="決定"
               onClickOutside={handleApply}
+              ignoreRef={toggleRef}
             />
             <div className="mt-2 min-w-0">
               <ActiveFilterBar

--- a/components/ui/TagFilterPanel.test.tsx
+++ b/components/ui/TagFilterPanel.test.tsx
@@ -103,4 +103,28 @@ describe("TagFilterPanel", () => {
     fireEvent.mouseDown(document.body);
     expect(onClickOutside).not.toHaveBeenCalled();
   });
+
+  it("ignoreRef 要素の mousedown では onClickOutside が呼ばれない", () => {
+    const onClickOutside = vi.fn();
+    const toggleBtn = document.createElement("button");
+    document.body.appendChild(toggleBtn);
+    const ignoreRef = { current: toggleBtn };
+    render(
+      <TagFilterPanel tags={tags} selectedTags={[]} onToggle={vi.fn()} open={true} onClickOutside={onClickOutside} ignoreRef={ignoreRef} />
+    );
+    fireEvent.mouseDown(toggleBtn);
+    expect(onClickOutside).not.toHaveBeenCalled();
+    toggleBtn.remove();
+  });
+
+  it("ignoreRef 以外の外部要素の mousedown では onClickOutside が呼ばれる", () => {
+    const onClickOutside = vi.fn();
+    const toggleBtn = document.createElement("button");
+    const ignoreRef = { current: toggleBtn };
+    render(
+      <TagFilterPanel tags={tags} selectedTags={[]} onToggle={vi.fn()} open={true} onClickOutside={onClickOutside} ignoreRef={ignoreRef} />
+    );
+    fireEvent.mouseDown(document.body);
+    expect(onClickOutside).toHaveBeenCalledOnce();
+  });
 });

--- a/components/ui/TagFilterPanel.tsx
+++ b/components/ui/TagFilterPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useEffect } from "react";
+import React, { useRef, useEffect } from "react";
 import clsx from "clsx";
 
 type Tag = {
@@ -19,21 +19,23 @@ type TagFilterPanelProps = {
   onApply?: () => void;
   applyLabel?: string;
   onClickOutside?: () => void;
+  ignoreRef?: React.RefObject<HTMLElement | null>;
 };
 
-export function TagFilterPanel({ tags, selectedTags, onToggle, open, onApply, applyLabel, onClickOutside }: TagFilterPanelProps) {
+export function TagFilterPanel({ tags, selectedTags, onToggle, open, onApply, applyLabel, onClickOutside, ignoreRef }: TagFilterPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!open) return;
     const handleMouseDown = (e: MouseEvent) => {
+      if (ignoreRef?.current?.contains(e.target as Node)) return;
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         onClickOutside?.();
       }
     };
     document.addEventListener("mousedown", handleMouseDown);
     return () => document.removeEventListener("mousedown", handleMouseDown);
-  }, [open, onClickOutside]);
+  }, [open, onClickOutside, ignoreRef]);
 
   if (!open) return null;
 


### PR DESCRIPTION
## 概要

パネルが開いている状態でトグルボタンをクリックすると、パネルが閉じずに再オープンするバグを修正。

**根本原因:** `mousedown` → `onClickOutside` → `setPanelOpen(false)` が発火した直後に、トグルボタンの `click` → `setPanelOpen((prev) => !prev)` → `true` が発火し競合していた。

**修正内容:**
- `TagFilterPanel` に `ignoreRef?: React.RefObject<HTMLElement | null>` プロップを追加
- `handleMouseDown` で `ignoreRef.current.contains(e.target)` の場合は `onClickOutside` を呼ばないよう guard を追加
- `RoomsFilter` / `new/page.tsx` でトグルボタンの ref を作成し `ignoreRef` に渡す

## 変更ファイル

- `components/ui/TagFilterPanel.tsx` — `ignoreRef` プロップ追加・`handleMouseDown` ロジック修正
- `app/rooms/RoomsFilter.tsx` — `toggleRef` 作成・`TagFilterToggle` を div でラップ・`ignoreRef` 受け渡し
- `app/rooms/new/page.tsx` — 同上
- `components/ui/TagFilterPanel.test.tsx` — `ignoreRef` 動作テスト2件追加

## テスト

- [ ] パネルが開いている状態でトグルボタンを押すと、パネルが閉じる（再オープンしない）
- [ ] パネル外の任意の場所をクリックしてもパネルが閉じる
- [ ] パネル内のチェックボックス操作ではパネルが閉じない
- [ ] `/rooms` 検索画面と `/rooms/new` 作成画面の両方で同じ挙動になる
- [ ] `pnpm lint` / `pnpm test` パス（11テスト全件グリーン）

Closes #238