### PR TITLE
feat: 利用規約・プライバシーポリシーページの作成と法的導線の追加

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 import "./globals.css";
 import { Header } from "@/components/ui/Header";
 import { BottomNav } from "@/components/ui/BottomNav";
+import { Footer } from "@/components/ui/Footer";
 import { WebVitalsReporter } from "@/components/ui/WebVitalsReporter";
 import { Providers } from "./providers";
 import { auth } from "@/auth";
@@ -29,6 +30,7 @@ async function LayoutProviders({ children }: { children: React.ReactNode }) {
       <Header />
       <main className="min-h-screen md:min-h-[calc(100vh_-_64px)] pb-[calc(60px_+_env(safe-area-inset-bottom))] md:pb-0">{children}</main>
       <BottomNav />
+      <Footer />
     </Providers>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,7 @@
 import { signIn } from "@/auth";
 import { Logo } from "@/components/ui/Logo";
 import { OAuthButton } from "@/components/ui/OAuthButton";
+import Link from "next/link";
 
 type Props = {
   searchParams: Promise<{ callbackUrl?: string }>;
@@ -54,7 +55,7 @@ export default async function LoginPage({ searchParams }: Props) {
             ソーシャルアカウントでかんたんにはじめられます
           </p>
 
-          <div className="space-y-3">
+          <div className="mb-6 space-y-4">
             <form
               action={async () => {
                 "use server";
@@ -131,9 +132,17 @@ export default async function LoginPage({ searchParams }: Props) {
 
           <p className="mt-4 text-center text-xs" style={{ color: "var(--text-muted)" }}>
             ログインすることで
-            <span style={{ color: "var(--accent-light)" }}>利用規約</span>・
-            <span style={{ color: "var(--accent-light)" }}>プライバシーポリシー</span>
+            <Link href="/terms" className="underline" style={{ color: "var(--accent-light)" }}>
+              利用規約
+            </Link>
+            ・
+            <Link href="/privacy" className="underline" style={{ color: "var(--accent-light)" }}>
+              プライバシーポリシー
+            </Link>
             に同意したものとみなされます
+          </p>
+          <p className="mt-2 text-center text-xs" style={{ color: "var(--text-muted)" }}>
+            未成年者の方は保護者の同意を得てからご利用ください
           </p>
         </div>
       </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "プライバシーポリシー | QuestLink",
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-10 pb-24 md:pb-10">
+      <h1 className="mb-8 text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
+        プライバシーポリシー
+      </h1>
+      <div className="space-y-8 text-sm" style={{ color: "var(--text-secondary)" }}>
+        <section>
+          <h2 className="mb-3 text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+            1. はじめに
+          </h2>
+          <p>
+            QuestLink（以下「本サービス」）は、ユーザーの個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下「本ポリシー」）を定めます。本サービスをご利用の際は、本ポリシーをお読みいただき、内容をご理解いただいたうえでご利用ください。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+            2. 取得する個人情報と利用目的
+          </h2>
+          <p className="mb-2">本サービスは、OAuthログイン時に以下の情報を取得します。</p>
+          <ul className="mb-3 list-inside list-disc space-y-1">
+            <li>メールアドレス</li>
+            <li>表示名・プロフィール画像URL</li>
+            <li>OAuthプロバイダが発行するユーザー識別子</li>
+          </ul>
+          <p>取得した情報は、アカウント認証・プロフィール表示・サービス運営のためにのみ使用します。</p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+            3. 第三者提供
+          </h2>
+          <p className="mb-3">
+            本サービスは、法令に基づく場合またはユーザーの同意がある場合を除き、取得した個人情報を第三者に提供しません。以下はサービス提供に伴う委託先への提供です。
+          </p>
+          <p className="mb-2 font-medium" style={{ color: "var(--text-primary)" }}>
+            OAuthプロバイダ（認証連携）
+          </p>
+          <ul className="mb-3 list-inside list-disc space-y-1">
+            <li>Google LLC（Google ログイン）</li>
+            <li>X Corp.（X / Twitter ログイン）</li>
+            <li>Discord Inc.（Discord ログイン）</li>
+          </ul>
+          <p className="mb-2 font-medium" style={{ color: "var(--text-primary)" }}>
+            インフラ委託先
+          </p>
+          <ul className="list-inside list-disc space-y-1">
+            <li>Vercel Inc.（Webホスティング）</li>
+            <li>Railway（バックエンド・データベースホスティング）</li>
+            <li>Supabase Inc.（データベース）</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+            4. 保存期間
+          </h2>
+          <p>
+            ユーザーが退会した場合、アカウント情報は速やかに削除します。ただし、退会前に投稿したチャットメッセージについては、サービスの性質上、送信者情報を匿名化したうえで保持する場合があります。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+            5. Cookieおよび外部送信について
+          </h2>
+          <p>
+            本サービスは、セッション管理のためにCookieを使用します。また、OAuthログイン時にGoogle・X・Discordなどの外部サービスへ認証情報が送信されます。ブラウザの設定によりCookieを無効にすることができますが、その場合一部の機能が利用できなくなることがあります。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+            6. 個人情報の開示・訂正・削除の請求窓口
+          </h2>
+          <p className="mb-2">
+            個人情報の開示・訂正・削除・利用停止等のご請求は、以下の窓口までメールにてご連絡ください。ご本人確認のうえ、合理的な期間内にご対応いたします。
+          </p>
+          <p>
+            お問い合わせ先：
+            <a
+              href="mailto:support@questlink.app"
+              className="ml-1 underline transition-colors hover:text-white"
+              style={{ color: "var(--accent-light)" }}
+            >
+              support@questlink.app
+            </a>
+          </p>
+        </section>
+
+        <p className="pt-4 text-xs" style={{ color: "var(--text-muted)" }}>
+          制定日：2026年5月26日
+        </p>
+      </div>
+      <div className="mt-10">
+        <Link
+          href="/login"
+          className="inline-flex items-center gap-1 text-sm transition-colors hover:opacity-80"
+          style={{ color: "var(--accent-light)" }}
+        >
+          ← ログインに戻る
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "利用規約 | QuestLink",
+};
+
+export default function TermsPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-10 pb-24 md:pb-10">
+      <h1 className="mb-8 text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
+        利用規約
+      </h1>
+      <div className="space-y-8 text-sm" style={{ color: "var(--text-secondary)" }}>
+        <section>
+          <h2 className="mb-3 text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+            第1条（適用）
+          </h2>
+          <p>
+            本規約は、QuestLink（以下「本サービス」）の利用に関する条件を定めるものであり、本サービスを利用するすべてのユーザーに適用されます。本サービスをご利用になった場合、本規約に同意したものとみなします。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+            第2条（禁止事項）
+          </h2>
+          <p className="mb-2">ユーザーは、本サービスの利用にあたり以下の行為を行ってはなりません。</p>
+          <ul className="list-inside list-disc space-y-1">
+            <li>不正アクセスその他のサービスへの攻撃行為</li>
+            <li>荒らし・嫌がらせ・他のユーザーへの迷惑行為</li>
+            <li>スパム・広告・勧誘目的のメッセージ送信</li>
+            <li>他のユーザーや第三者へのなりすまし行為</li>
+            <li>法令または公序良俗に違反する行為</li>
+            <li>その他、運営が不適切と判断する行為</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+            第3条（免責事項）
+          </h2>
+          <p>
+            本サービスは現状有姿で提供されます。運営は、サービスの中断・停止・変更・終了、またはユーザーが被った損害について、法令上の責任を負う場合を除き、一切の責任を負いません。ユーザー間のトラブルについても同様とします。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+            第4条（未成年者の利用）
+          </h2>
+          <p>
+            未成年者が本サービスを利用する場合は、保護者の同意を得たうえでご利用ください。未成年者が保護者の同意なく本サービスを利用した場合、保護者はその利用行為に同意したものとみなします。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+            第5条（規約の変更）
+          </h2>
+          <p>
+            本規約は、民法第548条の4に基づく定型約款の変更として、ユーザーの一般の利益に適合する場合、または変更の必要性・内容の相当性その他の事情に照らして合理的なものである場合に、あらかじめ変更の内容および効力発生時期を本サービス上で告知することにより、変更することができます。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-base font-semibold" style={{ color: "var(--text-primary)" }}>
+            第6条（準拠法および裁判管轄）
+          </h2>
+          <p>
+            本規約は日本法を準拠法とします。本サービスに関して紛争が生じた場合は、東京地方裁判所を第一審の専属的合意管轄裁判所とします。
+          </p>
+        </section>
+
+        <p className="pt-4 text-xs" style={{ color: "var(--text-muted)" }}>
+          制定日：2026年5月26日
+        </p>
+      </div>
+      <div className="mt-10">
+        <Link
+          href="/login"
+          className="inline-flex items-center gap-1 text-sm transition-colors hover:opacity-80"
+          style={{ color: "var(--accent-light)" }}
+        >
+          ← ログインに戻る
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -92,6 +92,9 @@ export const authConfig = {
       const pathname = nextUrl.pathname;
       const isLoginPage = pathname === "/login";
       const isOnboardingPage = pathname === "/onboarding";
+      const isPublicPage = pathname === "/privacy" || pathname === "/terms";
+
+      if (isPublicPage) return true;
 
       if (isLoginPage) {
         if (isLoggedIn) return Response.redirect(new URL("/", nextUrl));

--- a/components/ui/Footer.tsx
+++ b/components/ui/Footer.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export function Footer() {
+  const pathname = usePathname();
+  if (pathname === "/login" || pathname === "/onboarding") return null;
+
+  return (
+    <footer
+      className="mt-auto py-6 px-4 pb-[calc(60px_+_env(safe-area-inset-bottom))] md:pb-6 text-center"
+      style={{
+        borderTop: "1px solid var(--border)",
+        backgroundColor: "var(--bg-base)",
+      }}
+    >
+      <nav className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 mb-2">
+        <Link
+          href="/privacy"
+          className="text-xs transition-colors hover:text-white"
+          style={{ color: "var(--text-muted)" }}
+        >
+          プライバシーポリシー
+        </Link>
+        <span className="text-xs select-none" style={{ color: "var(--text-muted)" }} aria-hidden="true">
+          ·
+        </span>
+        <Link
+          href="/terms"
+          className="text-xs transition-colors hover:text-white"
+          style={{ color: "var(--text-muted)" }}
+        >
+          利用規約
+        </Link>
+        <span className="text-xs select-none" style={{ color: "var(--text-muted)" }} aria-hidden="true">
+          ·
+        </span>
+        <Link
+          href="/contact"
+          className="text-xs transition-colors hover:text-white"
+          style={{ color: "var(--text-muted)" }}
+        >
+          お問い合わせ
+        </Link>
+      </nav>
+      <p className="text-xs" style={{ color: "var(--text-muted)" }}>
+        © 2024 QuestLink
+      </p>
+    </footer>
+  );
+}

--- a/components/ui/Footer.tsx
+++ b/components/ui/Footer.tsx
@@ -45,7 +45,7 @@ export function Footer() {
         </Link>
       </nav>
       <p className="text-xs" style={{ color: "var(--text-muted)" }}>
-        © 2024 QuestLink
+        © 2026 QuestLink
       </p>
     </footer>
   );


### PR DESCRIPTION
## 概要

- `/privacy`（プライバシーポリシー）、`/terms`（利用規約）ページを新規作成
- 全画面共通フッター（`Footer.tsx`）を新規作成し `layout.tsx` に組み込み
- ログイン画面の同意文言（利用規約・プライバシーポリシー）を `<span>` からリンクに変更
- 未ログインユーザーが `/privacy` `/terms` にアクセスできるよう `auth.config.ts` を更新

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `auth.config.ts` | `/privacy` `/terms` を公開パスとして認証ガードをバイパス |
| `components/ui/Footer.tsx` | プライバシーポリシー・利用規約・お問い合わせリンクを持つ全画面共通フッター（`/login` `/onboarding` では非表示） |
| `app/layout.tsx` | `Footer` コンポーネントを組み込み |
| `app/privacy/page.tsx` | プライバシーポリシーページ（取得情報・利用目的・第三者提供・保存期間・Cookie・開示窓口） |
| `app/terms/page.tsx` | 利用規約ページ（禁止事項・免責・未成年条項・規約変更手続・準拠法/管轄） |
| `app/login/page.tsx` | 同意文言をリンク化、未成年者向け注意書きを追加 |

## テスト項目

- [x] `/privacy` が表示され全セクションが記載されている
- [x] `/terms` が表示され全条文が記載されている
- [x] 全ページのフッターに3リンクが表示される（`/login`・`/onboarding` では非表示）
- [x] ログイン画面の「利用規約」「プライバシーポリシー」がリンクになっている
- [x] 未ログイン状態で `/privacy` `/terms` にアクセスできる

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)