### PR TITLE
fix: ホスト退会時の 500 エラーを修正（ルーム自動クローズ + SetNull）

### DIFF
--- a/app/HomeRecruitingRooms.tsx
+++ b/app/HomeRecruitingRooms.tsx
@@ -49,12 +49,14 @@ function formatRoom(room: RawRoom): RoomSummary {
     status: room.status as "waiting" | "playing" | "closed",
     createdAt: room.createdAt.toISOString(),
     game: room.game,
-    host: {
-      id: room.host.id,
-      username: room.host.username,
-      iconUrl: room.host.iconUrl,
-      avgRating: Number(room.host.avgRating),
-    },
+    host: room.host
+      ? {
+          id: room.host.id,
+          username: room.host.username,
+          iconUrl: room.host.iconUrl,
+          avgRating: Number(room.host.avgRating),
+        }
+      : null,
     playStyleTags: room.playStyleTags.map((t) => t.tag),
   };
 }

--- a/app/api/v1/rooms/[roomId]/leave/route.test.ts
+++ b/app/api/v1/rooms/[roomId]/leave/route.test.ts
@@ -36,6 +36,7 @@ type MockTx = {
   roomParticipant: {
     update: ReturnType<typeof vi.fn>;
     findFirst: ReturnType<typeof vi.fn>;
+    updateMany: ReturnType<typeof vi.fn>;
   };
   room: { update: ReturnType<typeof vi.fn> };
   chatMessage: { create: ReturnType<typeof vi.fn> };
@@ -57,6 +58,7 @@ beforeEach(() => {
     roomParticipant: {
       update: vi.fn(),
       findFirst: vi.fn(),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
     },
     room: { update: vi.fn() },
     chatMessage: { create: vi.fn().mockResolvedValue({ id: "leave-msg-1", content: "leaving", createdAt: new Date() }) },

--- a/app/api/v1/rooms/[roomId]/leave/route.ts
+++ b/app/api/v1/rooms/[roomId]/leave/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { emitToRoom } from "@/lib/socket-emitter";
+import { leaveRoomInTx, emitLeaveRoomEvents } from "@/lib/leave-room";
 
 type RouteParams = { params: Promise<{ roomId: string }> };
 
@@ -96,127 +97,18 @@ export async function POST(request: Request, { params }: RouteParams) {
   });
   const leavingUsername = leavingUser?.username ?? "ユーザー";
 
-  type LeaveResult =
-    | { type: "host_changed"; newHostId: string; newHostUsername: string; systemMessageId: string; systemMessageContent: string; systemMessageCreatedAt: Date; leaveMessageId: string; leaveMessageContent: string; leaveMessageCreatedAt: Date }
-    | { type: "room_closed"; closedAt: Date; leaveMessageId: string; leaveMessageContent: string; leaveMessageCreatedAt: Date }
-    | { type: "normal"; leaveMessageId: string; leaveMessageContent: string; leaveMessageCreatedAt: Date };
-
-  const result = await prisma.$transaction(async (tx): Promise<LeaveResult> => {
-    // 退室時刻を記録
-    await tx.roomParticipant.update({
-      where: { id: participant.id },
-      data: { leftAt: now },
-    });
-
-    if (participant.isHost) {
-      // ホスト退室: 最も早く参加した残余参加者へ引き継ぎ
-      const nextHost = await tx.roomParticipant.findFirst({
-        where: { roomId, leftAt: null, userId: { not: userId } },
-        orderBy: { joinedAt: "asc" },
-        select: { id: true, userId: true, user: { select: { username: true } } },
-      });
-
-      if (nextHost) {
-        await tx.roomParticipant.update({
-          where: { id: nextHost.id },
-          data: { isHost: true },
-        });
-        await tx.room.update({
-          where: { id: roomId },
-          data: { hostId: nextHost.userId ?? undefined },
-        });
-        // 退室メッセージ
-        const leaveMsg = await tx.chatMessage.create({
-          data: {
-            roomId,
-            content: `${leavingUsername}さんが退室しました`,
-            isSystem: true,
-          },
-        });
-        // ホスト変更のシステムメッセージ
-        const systemMsg = await tx.chatMessage.create({
-          data: {
-            roomId,
-            content: `${nextHost.user?.username ?? "新しいホスト"}さんがホストになりました`,
-            isSystem: true,
-          },
-        });
-        return {
-          type: "host_changed",
-          newHostId: nextHost.userId ?? "",
-          newHostUsername: nextHost.user?.username ?? "",
-          systemMessageId: systemMsg.id,
-          systemMessageContent: systemMsg.content,
-          systemMessageCreatedAt: systemMsg.createdAt,
-          leaveMessageId: leaveMsg.id,
-          leaveMessageContent: leaveMsg.content,
-          leaveMessageCreatedAt: leaveMsg.createdAt,
-        };
-      } else {
-        // 残余参加者なし → 部屋を closed に
-        const closedAt = now;
-        await tx.room.update({
-          where: { id: roomId },
-          data: { status: "closed", closedAt },
-        });
-        // 退室メッセージ
-        const leaveMsg = await tx.chatMessage.create({
-          data: {
-            roomId,
-            content: `${leavingUsername}さんが退室しました`,
-            isSystem: true,
-          },
-        });
-        return { type: "room_closed", closedAt, leaveMessageId: leaveMsg.id, leaveMessageContent: leaveMsg.content, leaveMessageCreatedAt: leaveMsg.createdAt };
-      }
-    }
-
-    // 退室メッセージ
-    const leaveMsg = await tx.chatMessage.create({
-      data: {
-        roomId,
-        content: `${leavingUsername}さんが退室しました`,
-        isSystem: true,
-      },
-    });
-    return { type: "normal", leaveMessageId: leaveMsg.id, leaveMessageContent: leaveMsg.content, leaveMessageCreatedAt: leaveMsg.createdAt };
-  });
-
-  // Socket.IOサーバー（別プロセス）へイベントを送信
-  // 全ケースで退室メッセージと room:user_left を送信
-  await emitToRoom("chat:message", roomId, {
-    id: result.leaveMessageId,
-    roomId,
-    user: null,
-    content: result.leaveMessageContent,
-    isSystem: true,
-    createdAt: result.leaveMessageCreatedAt,
-  });
-  await emitToRoom("room:user_left", roomId, {
-    userId,
-    username: leavingUsername,
-    leftAt: now,
-  });
-
-  if (result.type === "host_changed") {
-    await emitToRoom("chat:message", roomId, {
-      id: result.systemMessageId,
+  const result = await prisma.$transaction((tx) =>
+    leaveRoomInTx(tx, {
       roomId,
-      user: null,
-      content: result.systemMessageContent,
-      isSystem: true,
-      createdAt: result.systemMessageCreatedAt,
-    });
-    await emitToRoom("room:host_changed", roomId, {
-      newHostId: result.newHostId,
-      newHostUsername: result.newHostUsername,
-    });
-  } else if (result.type === "room_closed") {
-    await emitToRoom("room:closed", roomId, {
-      roomId,
-      closedAt: result.closedAt,
-    });
-  }
+      participantId: participant.id,
+      isHost: participant.isHost,
+      userId,
+      username: leavingUsername,
+      now,
+    })
+  );
+
+  await emitLeaveRoomEvents(roomId, userId, leavingUsername, result);
 
   return new NextResponse(null, { status: 204 });
 }

--- a/app/api/v1/rooms/[roomId]/route.ts
+++ b/app/api/v1/rooms/[roomId]/route.ts
@@ -40,12 +40,14 @@ function formatRoom(room: RawRoom, guestMap: Map<string, string>) {
     createdAt: room.createdAt,
     closedAt: room.closedAt,
     game: room.game,
-    host: {
-      id: room.host.id,
-      username: room.host.username,
-      iconUrl: room.host.iconUrl,
-      avgRating: Number(room.host.avgRating),
-    },
+    host: room.host
+      ? {
+          id: room.host.id,
+          username: room.host.username,
+          iconUrl: room.host.iconUrl,
+          avgRating: Number(room.host.avgRating),
+        }
+      : null,
     playStyleTags: room.playStyleTags.map((t) => t.tag),
     participants: room.participants.map((p) => ({
       userId: p.userId,

--- a/app/api/v1/rooms/current/route.ts
+++ b/app/api/v1/rooms/current/route.ts
@@ -40,12 +40,14 @@ function formatRoom(room: RawRoom) {
     createdAt: room.createdAt,
     closedAt: room.closedAt,
     game: room.game,
-    host: {
-      id: room.host.id,
-      username: room.host.username,
-      iconUrl: room.host.iconUrl,
-      avgRating: Number(room.host.avgRating),
-    },
+    host: room.host
+      ? {
+          id: room.host.id,
+          username: room.host.username,
+          iconUrl: room.host.iconUrl,
+          avgRating: Number(room.host.avgRating),
+        }
+      : null,
     playStyleTags: room.playStyleTags.map((t) => t.tag),
     participants: room.participants.map((p) => ({
       userId: p.userId,

--- a/app/api/v1/rooms/route.ts
+++ b/app/api/v1/rooms/route.ts
@@ -66,12 +66,14 @@ function formatRoomList(room: RawRoomList) {
     createdAt: room.createdAt,
     closedAt: room.closedAt,
     game: room.game,
-    host: {
-      id: room.host.id,
-      username: room.host.username,
-      iconUrl: room.host.iconUrl,
-      avgRating: Number(room.host.avgRating),
-    },
+    host: room.host
+      ? {
+          id: room.host.id,
+          username: room.host.username,
+          iconUrl: room.host.iconUrl,
+          avgRating: Number(room.host.avgRating),
+        }
+      : null,
     playStyleTags: room.playStyleTags.map((t) => t.tag),
   };
 }
@@ -88,12 +90,14 @@ function formatRoom(room: RawRoom) {
     createdAt: room.createdAt,
     closedAt: room.closedAt,
     game: room.game,
-    host: {
-      id: room.host.id,
-      username: room.host.username,
-      iconUrl: room.host.iconUrl,
-      avgRating: Number(room.host.avgRating),
-    },
+    host: room.host
+      ? {
+          id: room.host.id,
+          username: room.host.username,
+          iconUrl: room.host.iconUrl,
+          avgRating: Number(room.host.avgRating),
+        }
+      : null,
     playStyleTags: room.playStyleTags.map((t) => t.tag),
     participants: room.participants.map((p) => ({
       userId: p.userId,

--- a/app/api/v1/users/me/route.test.ts
+++ b/app/api/v1/users/me/route.test.ts
@@ -16,7 +16,11 @@ vi.mock("@/lib/prisma", () => ({
       updateMany: vi.fn(),
     },
     roomParticipant: {
+      findMany: vi.fn(),
       updateMany: vi.fn(),
+    },
+    chatMessage: {
+      create: vi.fn(),
     },
     rating: { findMany: vi.fn() },
     playStyleTag: { findMany: vi.fn() },
@@ -27,6 +31,10 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 
+vi.mock("@/lib/socket-emitter", () => ({
+  emitToRoom: vi.fn(),
+}));
+
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
@@ -34,6 +42,7 @@ import { GET, PATCH, DELETE } from "./route";
 
 const mockAuth = vi.mocked(auth);
 const mockFindUnique = vi.mocked(prisma.user.findUnique);
+const mockParticipantFindMany = vi.mocked(prisma.roomParticipant.findMany);
 const mockRatingFindMany = vi.mocked(prisma.rating.findMany);
 const mockTransaction = prisma.$transaction as ReturnType<typeof vi.fn>;
 
@@ -230,35 +239,15 @@ describe("DELETE /api/v1/users/me", () => {
     expect(body.error).toBe("UNAUTHORIZED");
   });
 
-  it("ホスト中ルームなしで正常退会できる場合 204 を返す", async () => {
+  it("参加中ルームなしで正常退会できる場合 204 を返す", async () => {
     mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
-    mockTransaction.mockImplementation(
-      async (fn: (tx: typeof prisma) => Promise<unknown>) =>
-        fn({
-          ...prisma,
-          room: { findMany: vi.fn().mockResolvedValue([]), updateMany: vi.fn() },
-          roomParticipant: { updateMany: vi.fn() },
-          user: { delete: vi.fn().mockResolvedValue(undefined) },
-        } as never)
-    );
-
-    const res = await DELETE();
-
-    expect(res.status).toBe(204);
-  });
-
-  it("ホスト中のアクティブルームがある場合、参加者を退室させクローズしてから退会する", async () => {
-    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
-    const mockRoomFindMany = vi.fn().mockResolvedValue([{ id: "room-1" }, { id: "room-2" }]);
-    const mockRoomUpdateMany = vi.fn().mockResolvedValue({ count: 2 });
-    const mockParticipantUpdateMany = vi.fn().mockResolvedValue({ count: 5 });
+    mockFindUnique.mockResolvedValue({ username: "testuser" } as never);
     const mockDelete = vi.fn().mockResolvedValue(undefined);
     mockTransaction.mockImplementation(
       async (fn: (tx: typeof prisma) => Promise<unknown>) =>
         fn({
           ...prisma,
-          room: { findMany: mockRoomFindMany, updateMany: mockRoomUpdateMany },
-          roomParticipant: { updateMany: mockParticipantUpdateMany },
+          roomParticipant: { findMany: vi.fn().mockResolvedValue([]) },
           user: { delete: mockDelete },
         } as never)
     );
@@ -266,12 +255,89 @@ describe("DELETE /api/v1/users/me", () => {
     const res = await DELETE();
 
     expect(res.status).toBe(204);
-    expect(mockParticipantUpdateMany).toHaveBeenCalledWith({
-      where: { roomId: { in: ["room-1", "room-2"] }, leftAt: null },
-      data: expect.objectContaining({ leftAt: expect.any(Date) }),
+    expect(mockDelete).toHaveBeenCalledWith({ where: { id: "user-1" } });
+  });
+
+  it("ホストとして参加中ルームがある場合、leave 処理を経て退会する", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue({ username: "hostuser" } as never);
+    const leaveMsg = { id: "msg-1", content: "hostuserさんが退室しました", createdAt: new Date() };
+    const systemMsg = { id: "msg-2", content: "nextさんがホストになりました", createdAt: new Date() };
+    const mockParticipantFindFirst = vi.fn().mockResolvedValue({
+      id: "p-2",
+      userId: "user-2",
+      user: { username: "next" },
     });
-    expect(mockRoomUpdateMany).toHaveBeenCalledWith({
-      where: { id: { in: ["room-1", "room-2"] } },
+    const mockChatCreate = vi.fn()
+      .mockResolvedValueOnce(leaveMsg)
+      .mockResolvedValueOnce(systemMsg);
+    const mockParticipantUpdate = vi.fn().mockResolvedValue({});
+    const mockRoomUpdate = vi.fn().mockResolvedValue({});
+    const mockDelete = vi.fn().mockResolvedValue(undefined);
+    mockTransaction.mockImplementation(
+      async (fn: (tx: typeof prisma) => Promise<unknown>) =>
+        fn({
+          ...prisma,
+          room: { update: mockRoomUpdate },
+          roomParticipant: {
+            findMany: vi.fn().mockResolvedValue([{ id: "p-1", roomId: "room-1", isHost: true }]),
+            findFirst: mockParticipantFindFirst,
+            update: mockParticipantUpdate,
+          },
+          chatMessage: { create: mockChatCreate },
+          user: { delete: mockDelete },
+        } as never)
+    );
+
+    const res = await DELETE();
+
+    expect(res.status).toBe(204);
+    expect(mockParticipantUpdate).toHaveBeenCalledWith({
+      where: { id: "p-1" },
+      data: { leftAt: expect.any(Date) },
+    });
+    expect(mockParticipantUpdate).toHaveBeenCalledWith({
+      where: { id: "p-2" },
+      data: { isHost: true },
+    });
+    expect(mockRoomUpdate).toHaveBeenCalledWith({
+      where: { id: "room-1" },
+      data: { hostId: "user-2" },
+    });
+    expect(mockDelete).toHaveBeenCalledWith({ where: { id: "user-1" } });
+  });
+
+  it("ホスト中ルームに他の参加者がいない場合、ルームをクローズして退会する", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockFindUnique.mockResolvedValue({ username: "hostuser" } as never);
+    const leaveMsg = { id: "msg-1", content: "hostuserさんが退室しました", createdAt: new Date() };
+    const mockParticipantFindFirst = vi.fn().mockResolvedValue(null);
+    const mockChatCreate = vi.fn().mockResolvedValue(leaveMsg);
+    const mockParticipantUpdate = vi.fn().mockResolvedValue({});
+    const mockParticipantUpdateMany = vi.fn().mockResolvedValue({ count: 0 });
+    const mockRoomUpdate = vi.fn().mockResolvedValue({});
+    const mockDelete = vi.fn().mockResolvedValue(undefined);
+    mockTransaction.mockImplementation(
+      async (fn: (tx: typeof prisma) => Promise<unknown>) =>
+        fn({
+          ...prisma,
+          room: { update: mockRoomUpdate },
+          roomParticipant: {
+            findMany: vi.fn().mockResolvedValue([{ id: "p-1", roomId: "room-1", isHost: true }]),
+            findFirst: mockParticipantFindFirst,
+            update: mockParticipantUpdate,
+            updateMany: mockParticipantUpdateMany,
+          },
+          chatMessage: { create: mockChatCreate },
+          user: { delete: mockDelete },
+        } as never)
+    );
+
+    const res = await DELETE();
+
+    expect(res.status).toBe(204);
+    expect(mockRoomUpdate).toHaveBeenCalledWith({
+      where: { id: "room-1" },
       data: expect.objectContaining({ status: "closed" }),
     });
     expect(mockDelete).toHaveBeenCalledWith({ where: { id: "user-1" } });

--- a/app/api/v1/users/me/route.test.ts
+++ b/app/api/v1/users/me/route.test.ts
@@ -12,6 +12,10 @@ vi.mock("@/lib/prisma", () => ({
       delete: vi.fn(),
     },
     room: {
+      findMany: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    roomParticipant: {
       updateMany: vi.fn(),
     },
     rating: { findMany: vi.fn() },
@@ -232,7 +236,8 @@ describe("DELETE /api/v1/users/me", () => {
       async (fn: (tx: typeof prisma) => Promise<unknown>) =>
         fn({
           ...prisma,
-          room: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+          room: { findMany: vi.fn().mockResolvedValue([]), updateMany: vi.fn() },
+          roomParticipant: { updateMany: vi.fn() },
           user: { delete: vi.fn().mockResolvedValue(undefined) },
         } as never)
     );
@@ -242,15 +247,18 @@ describe("DELETE /api/v1/users/me", () => {
     expect(res.status).toBe(204);
   });
 
-  it("ホスト中のアクティブルームがある場合、クローズしてから退会する", async () => {
+  it("ホスト中のアクティブルームがある場合、参加者を退室させクローズしてから退会する", async () => {
     mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
-    const mockUpdateMany = vi.fn().mockResolvedValue({ count: 2 });
+    const mockRoomFindMany = vi.fn().mockResolvedValue([{ id: "room-1" }, { id: "room-2" }]);
+    const mockRoomUpdateMany = vi.fn().mockResolvedValue({ count: 2 });
+    const mockParticipantUpdateMany = vi.fn().mockResolvedValue({ count: 5 });
     const mockDelete = vi.fn().mockResolvedValue(undefined);
     mockTransaction.mockImplementation(
       async (fn: (tx: typeof prisma) => Promise<unknown>) =>
         fn({
           ...prisma,
-          room: { updateMany: mockUpdateMany },
+          room: { findMany: mockRoomFindMany, updateMany: mockRoomUpdateMany },
+          roomParticipant: { updateMany: mockParticipantUpdateMany },
           user: { delete: mockDelete },
         } as never)
     );
@@ -258,8 +266,12 @@ describe("DELETE /api/v1/users/me", () => {
     const res = await DELETE();
 
     expect(res.status).toBe(204);
-    expect(mockUpdateMany).toHaveBeenCalledWith({
-      where: { hostId: "user-1", status: { not: "closed" } },
+    expect(mockParticipantUpdateMany).toHaveBeenCalledWith({
+      where: { roomId: { in: ["room-1", "room-2"] }, leftAt: null },
+      data: expect.objectContaining({ leftAt: expect.any(Date) }),
+    });
+    expect(mockRoomUpdateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["room-1", "room-2"] } },
       data: expect.objectContaining({ status: "closed" }),
     });
     expect(mockDelete).toHaveBeenCalledWith({ where: { id: "user-1" } });

--- a/app/api/v1/users/me/route.test.ts
+++ b/app/api/v1/users/me/route.test.ts
@@ -11,6 +11,9 @@ vi.mock("@/lib/prisma", () => ({
       update: vi.fn(),
       delete: vi.fn(),
     },
+    room: {
+      updateMany: vi.fn(),
+    },
     rating: { findMany: vi.fn() },
     playStyleTag: { findMany: vi.fn() },
     game: { findMany: vi.fn() },
@@ -23,7 +26,7 @@ vi.mock("@/lib/prisma", () => ({
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
-import { GET, PATCH } from "./route";
+import { GET, PATCH, DELETE } from "./route";
 
 const mockAuth = vi.mocked(auth);
 const mockFindUnique = vi.mocked(prisma.user.findUnique);
@@ -209,5 +212,56 @@ describe("PATCH /api/v1/users/me", () => {
 
     expect(res.status).toBe(409);
     expect(body.error).toBe("USERNAME_TAKEN");
+  });
+});
+
+describe("DELETE /api/v1/users/me", () => {
+  it("未認証の場合 401 UNAUTHORIZED を返す", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const res = await DELETE();
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("UNAUTHORIZED");
+  });
+
+  it("ホスト中ルームなしで正常退会できる場合 204 を返す", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    mockTransaction.mockImplementation(
+      async (fn: (tx: typeof prisma) => Promise<unknown>) =>
+        fn({
+          ...prisma,
+          room: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+          user: { delete: vi.fn().mockResolvedValue(undefined) },
+        } as never)
+    );
+
+    const res = await DELETE();
+
+    expect(res.status).toBe(204);
+  });
+
+  it("ホスト中のアクティブルームがある場合、クローズしてから退会する", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } } as never);
+    const mockUpdateMany = vi.fn().mockResolvedValue({ count: 2 });
+    const mockDelete = vi.fn().mockResolvedValue(undefined);
+    mockTransaction.mockImplementation(
+      async (fn: (tx: typeof prisma) => Promise<unknown>) =>
+        fn({
+          ...prisma,
+          room: { updateMany: mockUpdateMany },
+          user: { delete: mockDelete },
+        } as never)
+    );
+
+    const res = await DELETE();
+
+    expect(res.status).toBe(204);
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { hostId: "user-1", status: { not: "closed" } },
+      data: expect.objectContaining({ status: "closed" }),
+    });
+    expect(mockDelete).toHaveBeenCalledWith({ where: { id: "user-1" } });
   });
 });

--- a/app/api/v1/users/me/route.ts
+++ b/app/api/v1/users/me/route.ts
@@ -184,7 +184,13 @@ export async function DELETE() {
     return NextResponse.json({ error: "UNAUTHORIZED" }, { status: 401 });
   }
 
-  await prisma.user.delete({ where: { id: session.user.id } });
+  await prisma.$transaction(async (tx) => {
+    await tx.room.updateMany({
+      where: { hostId: session.user.id, status: { not: "closed" } },
+      data: { status: "closed", closedAt: new Date() },
+    });
+    await tx.user.delete({ where: { id: session.user.id } });
+  });
 
   return new NextResponse(null, { status: 204 });
 }

--- a/app/api/v1/users/me/route.ts
+++ b/app/api/v1/users/me/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { leaveRoomInTx, emitLeaveRoomEvents } from "@/lib/leave-room";
 import { z } from "zod";
 import { Prisma } from "@prisma/client";
 
@@ -184,28 +185,40 @@ export async function DELETE() {
     return NextResponse.json({ error: "UNAUTHORIZED" }, { status: 401 });
   }
 
-  await prisma.$transaction(async (tx) => {
-    const closedAt = new Date();
+  const userId = session.user.id;
 
-    const activeRooms = await tx.room.findMany({
-      where: { hostId: session.user.id, status: { not: "closed" } },
-      select: { id: true },
+  const leavingUser = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { username: true },
+  });
+  const username = leavingUser?.username ?? "ユーザー";
+
+  const now = new Date();
+  const leaveResults: Array<{ roomId: string; result: Awaited<ReturnType<typeof leaveRoomInTx>> }> = [];
+
+  await prisma.$transaction(async (tx) => {
+    const activeParticipants = await tx.roomParticipant.findMany({
+      where: { userId, leftAt: null },
+      select: { id: true, roomId: true, isHost: true },
     });
 
-    if (activeRooms.length > 0) {
-      const roomIds = activeRooms.map((r) => r.id);
-      await tx.roomParticipant.updateMany({
-        where: { roomId: { in: roomIds }, leftAt: null },
-        data: { leftAt: closedAt },
+    for (const p of activeParticipants) {
+      const result = await leaveRoomInTx(tx, {
+        roomId: p.roomId,
+        participantId: p.id,
+        isHost: p.isHost,
+        userId,
+        username,
+        now,
       });
-      await tx.room.updateMany({
-        where: { id: { in: roomIds } },
-        data: { status: "closed", closedAt },
-      });
+      leaveResults.push({ roomId: p.roomId, result });
     }
-
-    await tx.user.delete({ where: { id: session.user.id } });
+    await tx.user.delete({ where: { id: userId } });
   });
+
+  for (const { roomId, result } of leaveResults) {
+    await emitLeaveRoomEvents(roomId, userId, username, result);
+  }
 
   return new NextResponse(null, { status: 204 });
 }

--- a/app/api/v1/users/me/route.ts
+++ b/app/api/v1/users/me/route.ts
@@ -185,10 +185,25 @@ export async function DELETE() {
   }
 
   await prisma.$transaction(async (tx) => {
-    await tx.room.updateMany({
+    const closedAt = new Date();
+
+    const activeRooms = await tx.room.findMany({
       where: { hostId: session.user.id, status: { not: "closed" } },
-      data: { status: "closed", closedAt: new Date() },
+      select: { id: true },
     });
+
+    if (activeRooms.length > 0) {
+      const roomIds = activeRooms.map((r) => r.id);
+      await tx.roomParticipant.updateMany({
+        where: { roomId: { in: roomIds }, leftAt: null },
+        data: { leftAt: closedAt },
+      });
+      await tx.room.updateMany({
+        where: { id: { in: roomIds } },
+        data: { status: "closed", closedAt },
+      });
+    }
+
     await tx.user.delete({ where: { id: session.user.id } });
   });
 

--- a/app/rooms/[roomId]/RoomDetailView.tsx
+++ b/app/rooms/[roomId]/RoomDetailView.tsx
@@ -113,7 +113,7 @@ export function RoomDetailView({ roomId }: Props) {
   const isParticipant =
     (currentUserId != null && room.participants.some((p) => p.userId === currentUserId)) ||
     room.isCurrentGuestParticipant;
-  const isHost = currentUserId != null && room.host.id === currentUserId;
+  const isHost = currentUserId != null && room.host?.id === currentUserId;
   const isGuest = currentUserId === null && isParticipant;
 
   // 招待URL + 未ログイン + 未参加 → 参加ボタン押下でダイアログを表示

--- a/components/ui/RoomCard.tsx
+++ b/components/ui/RoomCard.tsx
@@ -109,15 +109,17 @@ export const RoomCard = memo(function RoomCard({ room }: Props) {
         </div>
 
         {/* Host */}
-        <div className="mt-3 flex items-center gap-2 pt-3">
-          <UserAvatar username={room.host.username} iconUrl={room.host.iconUrl} size="sm" />
-          <span className="text-xs" style={{ color: "var(--text-secondary)" }}>
-            {room.host.username}
-          </span>
-          <div className="ml-auto">
-            <RatingDisplay avgRating={room.host.avgRating} ratingCount={room.host.avgRating != null ? 10 : 3} size="sm" />
+        {room.host && (
+          <div className="mt-3 flex items-center gap-2 pt-3">
+            <UserAvatar username={room.host.username} iconUrl={room.host.iconUrl} size="sm" />
+            <span className="text-xs" style={{ color: "var(--text-secondary)" }}>
+              {room.host.username}
+            </span>
+            <div className="ml-auto">
+              <RatingDisplay avgRating={room.host.avgRating} ratingCount={room.host.avgRating != null ? 10 : 3} size="sm" />
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </Link>
   );

--- a/lib/api/rooms.ts
+++ b/lib/api/rooms.ts
@@ -39,7 +39,7 @@ export type RoomSummary = {
   currentPlayers: number;
   status: "waiting" | "playing" | "closed";
   playStyleTags: RoomTag[];
-  host: RoomHost;
+  host: RoomHost | null;
   createdAt: string;
 };
 

--- a/lib/leave-room.ts
+++ b/lib/leave-room.ts
@@ -1,0 +1,138 @@
+import { prisma } from "@/lib/prisma";
+import { emitToRoom } from "@/lib/socket-emitter";
+
+type TxClient = Parameters<Parameters<typeof prisma.$transaction>[0]>[0];
+
+export type LeaveRoomResult =
+  | {
+      type: "host_changed";
+      newHostId: string;
+      newHostUsername: string;
+      leaveMessageId: string;
+      leaveMessageContent: string;
+      leaveMessageCreatedAt: Date;
+      systemMessageId: string;
+      systemMessageContent: string;
+      systemMessageCreatedAt: Date;
+    }
+  | {
+      type: "room_closed";
+      closedAt: Date;
+      leaveMessageId: string;
+      leaveMessageContent: string;
+      leaveMessageCreatedAt: Date;
+    }
+  | {
+      type: "normal";
+      leaveMessageId: string;
+      leaveMessageContent: string;
+      leaveMessageCreatedAt: Date;
+    };
+
+export async function leaveRoomInTx(
+  tx: TxClient,
+  params: {
+    roomId: string;
+    participantId: string;
+    isHost: boolean;
+    userId: string;
+    username: string;
+    now: Date;
+  }
+): Promise<LeaveRoomResult> {
+  const { roomId, participantId, isHost, userId, username, now } = params;
+
+  await tx.roomParticipant.update({
+    where: { id: participantId },
+    data: { leftAt: now },
+  });
+
+  if (isHost) {
+    const nextHost = await tx.roomParticipant.findFirst({
+      where: { roomId, leftAt: null, userId: { not: userId } },
+      orderBy: { joinedAt: "asc" },
+      select: { id: true, userId: true, user: { select: { username: true } } },
+    });
+
+    const leaveMsg = await tx.chatMessage.create({
+      data: { roomId, content: `${username}さんが退室しました`, isSystem: true },
+    });
+
+    if (nextHost?.userId) {
+      await tx.roomParticipant.update({ where: { id: nextHost.id }, data: { isHost: true } });
+      await tx.room.update({ where: { id: roomId }, data: { hostId: nextHost.userId } });
+      const newHostUsername = nextHost.user?.username ?? "新しいホスト";
+      const systemMsg = await tx.chatMessage.create({
+        data: { roomId, content: `${newHostUsername}さんがホストになりました`, isSystem: true },
+      });
+      return {
+        type: "host_changed",
+        newHostId: nextHost.userId,
+        newHostUsername,
+        leaveMessageId: leaveMsg.id,
+        leaveMessageContent: leaveMsg.content,
+        leaveMessageCreatedAt: leaveMsg.createdAt,
+        systemMessageId: systemMsg.id,
+        systemMessageContent: systemMsg.content,
+        systemMessageCreatedAt: systemMsg.createdAt,
+      };
+    } else {
+      await tx.roomParticipant.updateMany({
+        where: { roomId, leftAt: null },
+        data: { leftAt: now },
+      });
+      await tx.room.update({ where: { id: roomId }, data: { status: "closed", closedAt: now } });
+      return {
+        type: "room_closed",
+        closedAt: now,
+        leaveMessageId: leaveMsg.id,
+        leaveMessageContent: leaveMsg.content,
+        leaveMessageCreatedAt: leaveMsg.createdAt,
+      };
+    }
+  }
+
+  const leaveMsg = await tx.chatMessage.create({
+    data: { roomId, content: `${username}さんが退室しました`, isSystem: true },
+  });
+  return {
+    type: "normal",
+    leaveMessageId: leaveMsg.id,
+    leaveMessageContent: leaveMsg.content,
+    leaveMessageCreatedAt: leaveMsg.createdAt,
+  };
+}
+
+export async function emitLeaveRoomEvents(
+  roomId: string,
+  userId: string,
+  username: string,
+  result: LeaveRoomResult
+): Promise<void> {
+  await emitToRoom("chat:message", roomId, {
+    id: result.leaveMessageId,
+    roomId,
+    user: null,
+    content: result.leaveMessageContent,
+    isSystem: true,
+    createdAt: result.leaveMessageCreatedAt,
+  });
+  await emitToRoom("room:user_left", roomId, { userId, username, leftAt: new Date() });
+
+  if (result.type === "host_changed") {
+    await emitToRoom("chat:message", roomId, {
+      id: result.systemMessageId,
+      roomId,
+      user: null,
+      content: result.systemMessageContent,
+      isSystem: true,
+      createdAt: result.systemMessageCreatedAt,
+    });
+    await emitToRoom("room:host_changed", roomId, {
+      newHostId: result.newHostId,
+      newHostUsername: result.newHostUsername,
+    });
+  } else if (result.type === "room_closed") {
+    await emitToRoom("room:closed", roomId, { roomId, closedAt: result.closedAt });
+  }
+}

--- a/prisma/migrations/20260526000000_fix_host_delete_constraint/migration.sql
+++ b/prisma/migrations/20260526000000_fix_host_delete_constraint/migration.sql
@@ -1,7 +1,11 @@
--- AlterTable: host_id を nullable に変更
+-- AlterTable
 ALTER TABLE "rooms" ALTER COLUMN "host_id" DROP NOT NULL;
 
--- AlterForeignKey: RESTRICT → SET NULL に変更
+-- DropForeignKey
 ALTER TABLE "rooms" DROP CONSTRAINT "rooms_host_id_fkey";
-ALTER TABLE "rooms" ADD CONSTRAINT "rooms_host_id_fkey"
-  FOREIGN KEY ("host_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "rooms" ADD CONSTRAINT "rooms_host_id_fkey" FOREIGN KEY ("host_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- DropCheckConstraint: user_id SET NULL 時に違反するため削除
+ALTER TABLE "chat_messages" DROP CONSTRAINT IF EXISTS "chk_user_or_system";

--- a/prisma/migrations/20260526000000_fix_host_delete_constraint/migration.sql
+++ b/prisma/migrations/20260526000000_fix_host_delete_constraint/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable: host_id を nullable に変更
+ALTER TABLE "rooms" ALTER COLUMN "host_id" DROP NOT NULL;
+
+-- AlterForeignKey: RESTRICT → SET NULL に変更
+ALTER TABLE "rooms" DROP CONSTRAINT "rooms_host_id_fkey";
+ALTER TABLE "rooms" ADD CONSTRAINT "rooms_host_id_fkey"
+  FOREIGN KEY ("host_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,7 +65,7 @@ model OauthProviderAccount {
 
 model Room {
   id          String     @id @default(uuid()) @db.Uuid
-  hostId      String     @map("host_id") @db.Uuid
+  hostId      String?    @map("host_id") @db.Uuid
   title       String     @db.VarChar(100)
   gameId      String     @map("game_id") @db.Uuid
   maxPlayers  Int        @map("max_players") @db.SmallInt
@@ -76,7 +76,7 @@ model Room {
   closedAt    DateTime?  @map("closed_at") @db.Timestamptz
   inviteToken String?    @unique @map("invite_token") @db.VarChar(64)
 
-  host          User               @relation("RoomHost", fields: [hostId], references: [id], onDelete: Restrict)
+  host          User?              @relation("RoomHost", fields: [hostId], references: [id], onDelete: SetNull)
   game          Game               @relation(fields: [gameId], references: [id])
   participants  RoomParticipant[]
   chatMessages  ChatMessage[]


### PR DESCRIPTION
## 概要

`DELETE /api/v1/users/me` でホスト中ユーザーを退会させようとすると `Room.hostId` の `onDelete: Restrict` により P2003 外部キー制約エラーが発生し 500 を返すバグを修正。

あわせて退室処理を leave ルートと共通化し、アカウント削除時もホスト引き継ぎ・退室メッセージ・ソケットイベントが正しく動作するよう修正。

## 変更内容

### スキーマ・マイグレーション
- `Room.hostId`: `String` → `String?`、`onDelete: Restrict` → `onDelete: SetNull`
- `chat_messages.chk_user_or_system` 制約を削除（退会時に `user_id → NULL` で違反するため）

### 退室ロジックの共通化（`lib/leave-room.ts` 新設）
- `leaveRoomInTx` / `emitLeaveRoomEvents` を切り出し
- `leave/route.ts` と DELETE ハンドラの両方から再利用

### DELETE ハンドラの動作（`app/api/v1/users/me/route.ts`）

| 状況 | 修正前 | 修正後 |
|------|--------|--------|
| ホスト中ルームなしで退会 | 成功（204） | 成功（204） |
| ホスト中ルームあり・他の参加者いる | 500 エラー | ホスト引き継ぎ + 退室/ホスト変更メッセージ送信 |
| ホスト中ルームあり・参加者なし | 500 エラー | ルームをクローズ + 退室メッセージ送信 |
| チャット履歴 | - | `userId = NULL` で匿名として残存 |

トランザクション内で `findMany` を実行することで、kick や leave と同時リクエスト時の TOCTOU レース条件も解消。

### null-safety 対応
`room.host` が nullable になったことによる TypeScript エラーを修正（`rooms/route.ts`、`[roomId]/route.ts`、`current/route.ts`、`HomeRecruitingRooms.tsx`、`RoomCard.tsx`、`RoomDetailView.tsx`、`lib/api/rooms.ts`）

## 別途作成した issue
- #261: `room:closed` イベント受信時のフロントエンド未対応（このPR対象外）

## テスト

- `pnpm test`: 444 tests passed
- `pnpm lint`: 新規エラーなし

Closes #251