### PR TITLE
feat: チャット安全対策（サーバ側検証・レート制限）

### DIFF
--- a/lib/moderation.test.ts
+++ b/lib/moderation.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  MAX_CHAT_LENGTH,
+  RATE_LIMIT_MAX,
+  RATE_LIMIT_WINDOW_MS,
+  validateLength,
+  checkRateLimit,
+  clearRateLimitMap,
+} from "./moderation";
+
+describe("validateLength", () => {
+  it("999文字はOK", () => {
+    expect(validateLength("a".repeat(999))).toBe(true);
+  });
+
+  it("1000文字はOK（境界値）", () => {
+    expect(validateLength("a".repeat(MAX_CHAT_LENGTH))).toBe(true);
+  });
+
+  it("1001文字はNG（境界値+1）", () => {
+    expect(validateLength("a".repeat(MAX_CHAT_LENGTH + 1))).toBe(false);
+  });
+
+  it("空文字はOK", () => {
+    expect(validateLength("")).toBe(true);
+  });
+});
+
+describe("checkRateLimit", () => {
+  beforeEach(() => {
+    clearRateLimitMap();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it(`${RATE_LIMIT_MAX}件以内は通過する`, () => {
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      expect(checkRateLimit("user-1")).toBe(true);
+    }
+  });
+
+  it(`${RATE_LIMIT_MAX + 1}件目はブロックされる`, () => {
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      checkRateLimit("user-1");
+    }
+    expect(checkRateLimit("user-1")).toBe(false);
+  });
+
+  it("ウィンドウ経過後はリセットされる", () => {
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      checkRateLimit("user-1");
+    }
+    expect(checkRateLimit("user-1")).toBe(false);
+
+    vi.advanceTimersByTime(RATE_LIMIT_WINDOW_MS + 1);
+
+    expect(checkRateLimit("user-1")).toBe(true);
+  });
+
+  it("ユーザーごとに独立してカウントされる", () => {
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      checkRateLimit("user-1");
+    }
+    expect(checkRateLimit("user-1")).toBe(false);
+    expect(checkRateLimit("user-2")).toBe(true);
+  });
+});

--- a/lib/moderation.ts
+++ b/lib/moderation.ts
@@ -1,5 +1,33 @@
 export const MAX_CHAT_LENGTH = 1000;
+export const RATE_LIMIT_WINDOW_MS = 10_000;
+export const RATE_LIMIT_MAX = 10;
+
+const rateLimitMap = new Map<string, number[]>();
 
 export function validateLength(content: string): boolean {
   return content.length <= MAX_CHAT_LENGTH;
+}
+
+export function checkRateLimit(key: string): boolean {
+  const now = Date.now();
+  const timestamps = (rateLimitMap.get(key) ?? []).filter(
+    (t) => now - t < RATE_LIMIT_WINDOW_MS
+  );
+  if (timestamps.length >= RATE_LIMIT_MAX) return false;
+  timestamps.push(now);
+  rateLimitMap.set(key, timestamps);
+  return true;
+}
+
+export function clearRateLimitMap(): void {
+  rateLimitMap.clear();
+}
+
+export function pruneRateLimitMap(): void {
+  const now = Date.now();
+  for (const [key, timestamps] of rateLimitMap) {
+    const valid = timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+    if (valid.length === 0) rateLimitMap.delete(key);
+    else rateLimitMap.set(key, valid);
+  }
 }

--- a/lib/moderation.ts
+++ b/lib/moderation.ts
@@ -1,0 +1,5 @@
+export const MAX_CHAT_LENGTH = 1000;
+
+export function validateLength(content: string): boolean {
+  return content.length <= MAX_CHAT_LENGTH;
+}

--- a/socket-server/index.ts
+++ b/socket-server/index.ts
@@ -13,7 +13,7 @@ import { decode } from "next-auth/jwt";
 import { PrismaClient } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { Pool } from "pg";
-import { validateLength } from "../lib/moderation";
+import { validateLength, checkRateLimit, pruneRateLimitMap } from "../lib/moderation";
 
 type AuthenticatedSocketData =
   | { kind: "user"; userId: string; username: string; iconUrl: string | null; avgRating: number }
@@ -44,29 +44,7 @@ if (process.env.NODE_ENV === "production" && NEXT_APP_URL === "http://localhost:
 }
 const INTERNAL_SECRET = process.env.SOCKET_INTERNAL_SECRET;
 
-const RATE_LIMIT_WINDOW_MS = 10_000;
-const RATE_LIMIT_MAX = 10;
-const rateLimitMap = new Map<string, number[]>();
-
-function checkRateLimit(key: string): boolean {
-  const now = Date.now();
-  const timestamps = (rateLimitMap.get(key) ?? []).filter(
-    (t) => now - t < RATE_LIMIT_WINDOW_MS
-  );
-  if (timestamps.length >= RATE_LIMIT_MAX) return false;
-  timestamps.push(now);
-  rateLimitMap.set(key, timestamps);
-  return true;
-}
-
-setInterval(() => {
-  const now = Date.now();
-  for (const [key, timestamps] of rateLimitMap) {
-    const valid = timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
-    if (valid.length === 0) rateLimitMap.delete(key);
-    else rateLimitMap.set(key, valid);
-  }
-}, 5 * 60 * 1000);
+setInterval(pruneRateLimitMap, 5 * 60 * 1000);
 
 function parseCookies(cookieHeader: string): Record<string, string> {
   const result: Record<string, string> = {};

--- a/socket-server/index.ts
+++ b/socket-server/index.ts
@@ -13,6 +13,7 @@ import { decode } from "next-auth/jwt";
 import { PrismaClient } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { Pool } from "pg";
+import { validateLength } from "../lib/moderation";
 
 type AuthenticatedSocketData =
   | { kind: "user"; userId: string; username: string; iconUrl: string | null; avgRating: number }
@@ -42,6 +43,30 @@ if (process.env.NODE_ENV === "production" && NEXT_APP_URL === "http://localhost:
   console.warn("[socket-server] NEXTAUTH_URL is not set. CORS will reject production origins.");
 }
 const INTERNAL_SECRET = process.env.SOCKET_INTERNAL_SECRET;
+
+const RATE_LIMIT_WINDOW_MS = 10_000;
+const RATE_LIMIT_MAX = 10;
+const rateLimitMap = new Map<string, number[]>();
+
+function checkRateLimit(key: string): boolean {
+  const now = Date.now();
+  const timestamps = (rateLimitMap.get(key) ?? []).filter(
+    (t) => now - t < RATE_LIMIT_WINDOW_MS
+  );
+  if (timestamps.length >= RATE_LIMIT_MAX) return false;
+  timestamps.push(now);
+  rateLimitMap.set(key, timestamps);
+  return true;
+}
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, timestamps] of rateLimitMap) {
+    const valid = timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+    if (valid.length === 0) rateLimitMap.delete(key);
+    else rateLimitMap.set(key, valid);
+  }
+}, 5 * 60 * 1000);
 
 function parseCookies(cookieHeader: string): Record<string, string> {
   const result: Record<string, string> = {};
@@ -259,6 +284,24 @@ io.on("connection", (socket) => {
         !content.trim()
       )
         return;
+
+      if (!validateLength(content.trim())) {
+        socket.emit("chat:error", {
+          code: "MESSAGE_TOO_LONG",
+          message: "メッセージは1000文字以内で入力してください。",
+        });
+        return;
+      }
+
+      const rateLimitKey =
+        socketData.kind === "user" ? socketData.userId : socketData.guestSessionId;
+      if (!checkRateLimit(rateLimitKey)) {
+        socket.emit("chat:error", {
+          code: "RATE_LIMITED",
+          message: "送信が速すぎます。しばらく待ってから再試行してください。",
+        });
+        return;
+      }
 
       try {
         if (socketData.kind === "user") {


### PR DESCRIPTION
## 概要

- `chat:send` ハンドラにサーバ側メッセージ長検証を追加（1000文字超を拒否）
- ユーザー/ゲスト単位のレート制限を実装（10秒間に10件超でブロック）
- コンテンツモデレーション基盤として `lib/moderation.ts` を新規作成

## 変更内容

### `lib/moderation.ts`（新規）
- `MAX_CHAT_LENGTH = 1000` 定数
- `validateLength(content)` 関数

### `socket-server/index.ts`（修正）
- `validateLength` による1000文字超の拒否 → 送信者に `chat:error { code: "MESSAGE_TOO_LONG" }` を返す
- スライディングウィンドウ方式のレート制限（10秒/10件）→ `chat:error { code: "RATE_LIMITED" }`
- 5分ごとの Map クリーンアップでメモリリーク防止

## 対応する法的要件

- C-4: レート制限・サーバ側検証

Closes #252