### PR TITLE
fix: GET /rooms の block クエリを 2 本から 1 本に統合

### DIFF
--- a/app/api/v1/rooms/route.ts
+++ b/app/api/v1/rooms/route.ts
@@ -142,15 +142,15 @@ export async function GET(request: Request) {
 
   const tagSlugList = tagSlugs ? tagSlugs.split(",").filter(Boolean) : [];
 
-  const [blockedByMe, blockedByHost] = await Promise.all([
-    prisma.block.findMany({ where: { blockerId: userId }, select: { blockedId: true } }),
-    prisma.block.findMany({ where: { blockedId: userId }, select: { blockerId: true } }),
-  ]);
+  const blocks = await prisma.block.findMany({
+    where: { OR: [{ blockerId: userId }, { blockedId: userId }] },
+    select: { blockerId: true, blockedId: true },
+  });
 
   const excludedHostIds = [
     ...new Set([
-      ...blockedByMe.map((b) => b.blockedId),
-      ...blockedByHost.map((b) => b.blockerId),
+      ...blocks.filter((b) => b.blockerId === userId).map((b) => b.blockedId),
+      ...blocks.filter((b) => b.blockedId === userId).map((b) => b.blockerId),
     ]),
   ];
 


### PR DESCRIPTION
## 概要

- `GET /api/v1/rooms` で blocks テーブルへのクエリを `Promise.all` 2 本から OR 条件の単一クエリに統合
- 1リクエストあたりのDBクエリ数を 4 本 → 3 本に削減し、高負荷時のDB利用率を下げる

## 変更内容

```typescript
// Before（2クエリ）
const [blockedByMe, blockedByHost] = await Promise.all([
  prisma.block.findMany({ where: { blockerId: userId }, select: { blockedId: true } }),
  prisma.block.findMany({ where: { blockedId: userId }, select: { blockerId: true } }),
]);

// After（1クエリ）
const blocks = await prisma.block.findMany({
  where: { OR: [{ blockerId: userId }, { blockedId: userId }] },
  select: { blockerId: true, blockedId: true },
});
```

## テスト

- `pnpm lint` 通過（警告は既存のもの）
- `pnpm test` 全 454 件 pass

Closes #268