### PR TITLE
perf: GET /rooms のブロックフィルタークエリをサブクエリに統合

### DIFF
--- a/app/api/v1/rooms/route.test.ts
+++ b/app/api/v1/rooms/route.test.ts
@@ -9,7 +9,6 @@ vi.mock("@/lib/prisma", () => ({
     game: { findUnique: vi.fn() },
     playStyleTag: { findMany: vi.fn() },
     roomParticipant: { findFirst: vi.fn() },
-    block: { findMany: vi.fn() },
     $transaction: vi.fn(),
   },
 }));
@@ -104,11 +103,8 @@ function makePostRequest(body: unknown): Request {
 
 // ─── テスト ────────────────────────────────────────────────────────────────────
 
-const mockBlockFindMany = vi.mocked(prisma.block.findMany);
-
 beforeEach(() => {
   vi.clearAllMocks();
-  mockBlockFindMany.mockResolvedValue([]);
 });
 
 describe("GET /api/v1/rooms", () => {
@@ -265,6 +261,27 @@ describe("GET /api/v1/rooms", () => {
     expect(mockRoomFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.not.objectContaining({ AND: expect.anything() }),
+      })
+    );
+  });
+
+  it("ブロックフィルター: NOT サブクエリが where 句に常に含まれる", async () => {
+    mockAuth.mockResolvedValueOnce(AUTHENTICATED_SESSION);
+    mockRoomFindMany.mockResolvedValueOnce([]);
+    mockRoomCount.mockResolvedValueOnce(0);
+
+    await GET(makeGetRequest());
+
+    expect(mockRoomFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          NOT: {
+            OR: [
+              { host: { blocksReceived: { some: { blockerId: "user-1" } } } },
+              { host: { blocksGiven: { some: { blockedId: "user-1" } } } },
+            ],
+          },
+        }),
       })
     );
   });

--- a/app/api/v1/rooms/route.ts
+++ b/app/api/v1/rooms/route.ts
@@ -142,21 +142,14 @@ export async function GET(request: Request) {
 
   const tagSlugList = tagSlugs ? tagSlugs.split(",").filter(Boolean) : [];
 
-  const blocks = await prisma.block.findMany({
-    where: { OR: [{ blockerId: userId }, { blockedId: userId }] },
-    select: { blockerId: true, blockedId: true },
-  });
-
-  const excludedHostIds = [
-    ...new Set([
-      ...blocks.filter((b) => b.blockerId === userId).map((b) => b.blockedId),
-      ...blocks.filter((b) => b.blockedId === userId).map((b) => b.blockerId),
-    ]),
-  ];
-
   const where: Prisma.RoomWhereInput = {
     status,
-    ...(excludedHostIds.length > 0 && { hostId: { notIn: excludedHostIds } }),
+    NOT: {
+      OR: [
+        { host: { blocksReceived: { some: { blockerId: userId } } } },
+        { host: { blocksGiven: { some: { blockedId: userId } } } },
+      ],
+    },
     ...(gameId && { gameId }),
     ...(tagSlugList.length > 0 && {
       AND: tagSlugList.map(slug => ({


### PR DESCRIPTION
## 概要

- `GET /api/v1/rooms` で毎リクエスト直列実行していた `prisma.block.findMany()` を削除
- Prisma のリレーションフィルター（`NOT OR` ネストサブクエリ）で room クエリに統合
- DB ラウンドトリップを **3RTT → 2RTT** に削減

## 背景

負荷テストにより、ブロック機能追加後に `GET /rooms` の p95 レイテンシが 150VU 時点で 613ms（閾値 500ms 超）まで悪化していることを確認。

## 変更内容

Before: block.findMany() を直列実行後に room.findMany()
After: NOT OR リレーションフィルターで room クエリにサブクエリとして統合

## テスト

- 既存 19 テスト全通過
- NOT フィルター検証テストを追加