### PR TITLE
perf(rooms): parallelize leave queries and defer socket emit with after()

### DIFF
--- a/app/api/v1/rooms/[roomId]/leave/route.test.ts
+++ b/app/api/v1/rooms/[roomId]/leave/route.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>();
+  return { ...actual, after: vi.fn((fn: () => Promise<void>) => fn()) };
+});
+
 vi.mock("@/auth", () => ({
   auth: vi.fn(),
 }));

--- a/app/api/v1/rooms/[roomId]/leave/route.ts
+++ b/app/api/v1/rooms/[roomId]/leave/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { after, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { emitToRoom } from "@/lib/socket-emitter";
@@ -22,9 +22,11 @@ export async function POST(request: Request, { params }: RouteParams) {
       );
     }
 
-    const guestParticipant = await prisma.roomParticipant.findFirst({
-      where: { roomId, guestSessionId, leftAt: null },
-    });
+    const [guestParticipant, guest] = await Promise.all([
+      prisma.roomParticipant.findFirst({ where: { roomId, guestSessionId, leftAt: null } }),
+      prisma.guest.findUnique({ where: { guestSessionId }, select: { displayName: true } }),
+    ]);
+
     if (!guestParticipant) {
       return NextResponse.json(
         { error: { code: "NOT_IN_ROOM", message: "この部屋に参加していません" } },
@@ -32,10 +34,6 @@ export async function POST(request: Request, { params }: RouteParams) {
       );
     }
 
-    const guest = await prisma.guest.findUnique({
-      where: { guestSessionId },
-      select: { displayName: true },
-    });
     const displayName = guest?.displayName ?? "ゲスト";
     const now = new Date();
 
@@ -44,32 +42,37 @@ export async function POST(request: Request, { params }: RouteParams) {
       data: { leftAt: now },
     });
 
-    const leaveMsg = await prisma.chatMessage.create({
-      data: { roomId, content: `${displayName}さんが退室しました`, isSystem: true },
+    const response = new NextResponse(null, { status: 204 });
+    after(async () => {
+      const leaveMsg = await prisma.chatMessage.create({
+        data: { roomId, content: `${displayName}さんが退室しました`, isSystem: true },
+      });
+      await Promise.all([
+        emitToRoom("chat:message", roomId, {
+          id: leaveMsg.id,
+          roomId,
+          user: null,
+          content: leaveMsg.content,
+          isSystem: true,
+          createdAt: leaveMsg.createdAt,
+        }),
+        emitToRoom("room:user_left", roomId, {
+          userId: guestSessionId,
+          username: displayName,
+          leftAt: now,
+        }),
+      ]);
     });
-    await emitToRoom("chat:message", roomId, {
-      id: leaveMsg.id,
-      roomId,
-      user: null,
-      content: leaveMsg.content,
-      isSystem: true,
-      createdAt: leaveMsg.createdAt,
-    });
-    await emitToRoom("room:user_left", roomId, {
-      userId: guestSessionId,
-      username: displayName,
-      leftAt: now,
-    });
-
-    return new NextResponse(null, { status: 204 });
+    return response;
   }
 
   const userId = session.user.id;
 
-  const room = await prisma.room.findUnique({
-    where: { id: roomId },
-    select: { id: true, status: true },
-  });
+  const [room, participant, leavingUser] = await Promise.all([
+    prisma.room.findUnique({ where: { id: roomId }, select: { id: true, status: true } }),
+    prisma.roomParticipant.findFirst({ where: { roomId, userId, leftAt: null } }),
+    prisma.user.findUnique({ where: { id: userId }, select: { username: true } }),
+  ]);
 
   if (!room) {
     return NextResponse.json(
@@ -78,10 +81,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     );
   }
 
-  const participant = await prisma.roomParticipant.findFirst({
-    where: { roomId, userId, leftAt: null },
-  });
-
   if (!participant) {
     return NextResponse.json(
       { error: { code: "NOT_IN_ROOM", message: "この部屋に参加していません" } },
@@ -89,13 +88,8 @@ export async function POST(request: Request, { params }: RouteParams) {
     );
   }
 
-  const now = new Date();
-
-  const leavingUser = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { username: true },
-  });
   const leavingUsername = leavingUser?.username ?? "ユーザー";
+  const now = new Date();
 
   const result = await prisma.$transaction((tx) =>
     leaveRoomInTx(tx, {
@@ -108,7 +102,9 @@ export async function POST(request: Request, { params }: RouteParams) {
     })
   );
 
-  await emitLeaveRoomEvents(roomId, userId, leavingUsername, result);
-
-  return new NextResponse(null, { status: 204 });
+  const response = new NextResponse(null, { status: 204 });
+  after(async () => {
+    await emitLeaveRoomEvents(roomId, userId, leavingUsername, result);
+  });
+  return response;
 }

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -7,7 +7,13 @@ const globalForPrisma = globalThis as unknown as {
 };
 
 function createPrismaClient() {
-  const pool = new Pool({ connectionString: process.env["DATABASE_URL"], max: 45 });
+  const pool = new Pool({
+    connectionString: process.env["DATABASE_URL"],
+    max: Number(process.env["PG_POOL_MAX"] ?? 45),
+    connectionTimeoutMillis: 5_000,
+    idleTimeoutMillis: 30_000,
+    keepAlive: true,
+  });
   const adapter = new PrismaPg(pool);
   return new PrismaClient({ adapter });
 }


### PR DESCRIPTION
## 概要

負荷テスト（phase2-discovery）で 250VU 以降のエラー率が閾値を超えている問題に対処する。

Supabase PgBouncer の pool_size を 15→45 に変更したが効果がなかったため、ボトルネックは DB 接続数ではなく**リクエストあたりのイベントループ占有時間**と判断。leave ルートの直列 RTT を削減する。

## 変更内容

### `app/api/v1/rooms/[roomId]/leave/route.ts`
- **ユーザー路**: `room.findUnique` / `roomParticipant.findFirst` / `user.findUnique` の 3 SELECT を `Promise.all` で並列化（3 RTT → 1 RTT）
- **ゲスト路**: `guestParticipant.findFirst` / `guest.findUnique` の 2 SELECT を `Promise.all` で並列化
- **両路**: socket emit（`emitLeaveRoomEvents` / `emitToRoom`）を `after()` に移動しレスポンス後に非同期実行（`POST /join` と同パターン）

### `lib/prisma.ts`
- `connectionTimeoutMillis: 5_000` — pool 枯渇時に 5s で fail-fast（従来は無限待ち）
- `idleTimeoutMillis: 30_000` — アイドル接続を 30s で解放
- `keepAlive: true` — Railway の TCP アイドル切断対策
- `max` を `PG_POOL_MAX` 環境変数で上書き可能に

### `app/api/v1/rooms/[roomId]/leave/route.test.ts`
- `next/server` の `after` をモック追加（join ルートと同パターン）

## 機能影響

- socket emit がレスポンス完了後数十ms遅延して発火する（`POST /join` で既採用済み）
- エラーパスで余分な SELECT が発生するが、エラーケースの頻度は低く実質的な影響なし
- `connectionTimeoutMillis` 追加により pool 枯渇時に status=0 ではなく 500 が返るようになる（可観測性向上）

## 期待効果

leave の平均レイテンシを 150ms → 60ms に短縮（−60%）し、400VU 帯のエラー率を 1% 未満に収束させることを目指す。

## テスト

- [x] `pnpm test leave/route.test.ts` — 11 tests passed
- [x] `pnpm lint` — エラーなし（warning は既存）
- [ ] staging デプロイ後 `phase2-discovery` 再実行で 400VU エラー率 < 1% を確認