### PR TITLE
fix: add Prisma.TransactionClient type to transaction callbacks

### DIFF
--- a/app/api/v1/rooms/[roomId]/close/route.ts
+++ b/app/api/v1/rooms/[roomId]/close/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { emitToRoom } from "@/lib/socket-emitter";
+import { Prisma } from "@prisma/client";
 
 type RouteParams = { params: Promise<{ roomId: string }> };
 
@@ -32,7 +33,7 @@ export async function POST(_request: Request, { params }: RouteParams) {
 
   const closedAt = new Date();
 
-  await prisma.$transaction(async (tx) => {
+  await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     // 全参加者を退室状態に
     await tx.roomParticipant.updateMany({
       where: { roomId, leftAt: null },

--- a/app/api/v1/rooms/[roomId]/kick/route.ts
+++ b/app/api/v1/rooms/[roomId]/kick/route.ts
@@ -104,7 +104,7 @@ export async function POST(request: Request, { params }: RouteParams) {
   });
   const shouldUpdateToWaiting = room.status === "full" && currentCount - 1 < room.maxPlayers;
 
-  const kickMsg = await prisma.$transaction(async (tx) => {
+  const kickMsg = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     await tx.roomParticipant.update({
       where: { id: targetParticipant.id },
       data: { leftAt: kickedAt },

--- a/app/api/v1/rooms/[roomId]/kick/route.ts
+++ b/app/api/v1/rooms/[roomId]/kick/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { emitToRoom } from "@/lib/socket-emitter";
+import { Prisma } from "@prisma/client";
 
 type RouteParams = { params: Promise<{ roomId: string }> };
 

--- a/app/api/v1/rooms/[roomId]/ratings/route.ts
+++ b/app/api/v1/rooms/[roomId]/ratings/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
 
 type RouteParams = { params: Promise<{ roomId: string }> };
 

--- a/app/api/v1/rooms/[roomId]/ratings/route.ts
+++ b/app/api/v1/rooms/[roomId]/ratings/route.ts
@@ -123,7 +123,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     );
   }
 
-  const rating = await prisma.$transaction(async (tx) => {
+  const rating = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const newRating = await tx.rating.create({
       data: {
         roomId,

--- a/app/api/v1/rooms/route.ts
+++ b/app/api/v1/rooms/route.ts
@@ -246,7 +246,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const room = await prisma.$transaction(async (tx) => {
+    const room = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const newRoom = await tx.room.create({
         data: {
           title,

--- a/app/api/v1/users/me/route.ts
+++ b/app/api/v1/users/me/route.ts
@@ -128,7 +128,7 @@ export async function PATCH(request: Request) {
   }
 
   try {
-    const user = await prisma.$transaction(async (tx) => {
+    const user = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       if (playStyleTagIds !== undefined) {
         await tx.userPlayStyleTag.deleteMany({
           where: { userId: session.user.id },
@@ -196,7 +196,7 @@ export async function DELETE() {
   const now = new Date();
   const leaveResults: Array<{ roomId: string; result: Awaited<ReturnType<typeof leaveRoomInTx>> }> = [];
 
-  await prisma.$transaction(async (tx) => {
+  await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const activeParticipants = await tx.roomParticipant.findMany({
       where: { userId, leftAt: null },
       select: { id: true, roomId: true, isHost: true },


### PR DESCRIPTION
## 概要

Vercel ビルド時に `tsc` の `noImplicitAny` チェックで失敗していた TypeScript エラーを修正する。

## 原因

`prisma.$transaction(async (tx) => { ... })` のコールバック引数 `tx` に型アノテーションがなく、暗黙的に `any` と推論されていた。

ローカルの `pnpm dev` は SWC でトランスパイルのみ行い型チェックをスキップするため気づかず、Vercel の `pnpm build`（`tsc` 実行）で初めて検出された。

## 変更ファイル

- `app/api/v1/rooms/[roomId]/close/route.ts`
- `app/api/v1/rooms/[roomId]/kick/route.ts`
- `app/api/v1/rooms/[roomId]/ratings/route.ts`
- `app/api/v1/rooms/route.ts`
- `app/api/v1/users/me/route.ts`

すべて `(tx)` → `(tx: Prisma.TransactionClient)` に変更。