### PR TITLE
feat: お問い合わせメールアドレスを CONTACT_EMAIL 環境変数で設定可能にする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,6 @@ LHCI_TEST_PASSWORD=
 LHCI_ROOM_ID=
 # 計測対象のゲームID（DB から取得した UUID を設定。省略時は /games/{id}/rooms をスキップ）
 LHCI_GAME_ID=
+
+# お問い合わせ先メールアドレス（contact・privacy ページに表示される）
+CONTACT_EMAIL="your-contact-email@example.com"

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 export default function ContactPage() {
+  const contactEmail = process.env.CONTACT_EMAIL ?? "7021time.is.money@gmail.com";
   return (
     <div className="mx-auto max-w-3xl px-4 py-10 pb-28 sm:px-6 sm:pb-10">
       <Link
@@ -46,11 +47,11 @@ export default function ContactPage() {
               </dt>
               <dd>
                 <a
-                  href="mailto:7021time.is.money@gmail.com"
+                  href={`mailto:${contactEmail}`}
                   className="transition-opacity hover:opacity-70 hover:underline"
                   style={{ color: "var(--accent-light)" }}
                 >
-                  7021time.is.money@gmail.com
+                  {contactEmail}
                 </a>
               </dd>
             </div>
@@ -134,11 +135,11 @@ export default function ContactPage() {
           <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
             報告先:{" "}
             <a
-              href="mailto:7021time.is.money@gmail.com"
+              href={`mailto:${contactEmail}`}
               className="transition-opacity hover:opacity-70 hover:underline"
               style={{ color: "var(--accent-light)" }}
             >
-              7021time.is.money@gmail.com
+              {contactEmail}
             </a>
             （件名に「コンテンツ報告」とご記入ください）
           </p>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
 };
 
 export default function PrivacyPage() {
+  const contactEmail = process.env.CONTACT_EMAIL ?? "support@questlink.app";
   return (
     <div className="mx-auto max-w-3xl px-4 py-10 pb-24 md:pb-10">
       <h1 className="mb-8 text-2xl font-bold" style={{ color: "var(--text-primary)" }}>
@@ -87,11 +88,11 @@ export default function PrivacyPage() {
           <p>
             お問い合わせ先：
             <a
-              href="mailto:support@questlink.app"
+              href={`mailto:${contactEmail}`}
               className="ml-1 underline transition-colors hover:text-white"
               style={{ color: "var(--accent-light)" }}
             >
-              support@questlink.app
+              {contactEmail}
             </a>
           </p>
         </section>


### PR DESCRIPTION
## Summary

- `app/contact/page.tsx` と `app/privacy/page.tsx` にハードコードされていたメールアドレスを `CONTACT_EMAIL` 環境変数から読み込むよう変更
- `.env.example` に `CONTACT_EMAIL` の記載を追加
- 環境変数未設定時は既存の値にフォールバック（contact: `7021time.is.money@gmail.com`、privacy: `support@questlink.app`）

## Test plan

- [ ] `.env` に `CONTACT_EMAIL=test@example.com` を設定して `pnpm dev` 起動
- [ ] `/contact` を開き、表示アドレスと mailto リンクが `test@example.com` になっていることを確認
- [ ] `/privacy` を開き、同様に `test@example.com` になっていることを確認
- [ ] `CONTACT_EMAIL` を削除してリロード → フォールバック値が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)