### PR TITLE
fix: プライバシーポリシー・利用規約の戻るリンクのテキストを修正

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -106,7 +106,7 @@ export default function PrivacyPage() {
           className="inline-flex items-center gap-1 text-sm transition-colors hover:opacity-80"
           style={{ color: "var(--accent-light)" }}
         >
-          ← ログインに戻る
+          ← 戻る
         </Link>
       </div>
     </div>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -82,7 +82,7 @@ export default function TermsPage() {
           className="inline-flex items-center gap-1 text-sm transition-colors hover:opacity-80"
           style={{ color: "var(--accent-light)" }}
         >
-          ← ログインに戻る
+          ← 戻る
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- `app/privacy/page.tsx` と `app/terms/page.tsx` の戻るリンクのテキストを「← ログインに戻る」から「← 戻る」に変更
- ログイン画面以外（例: フッターリンク等）からアクセスした場合でも違和感のない表現に統一

## Test plan

- [ ] プライバシーポリシーページ (`/privacy`) を開き、戻るリンクに「← 戻る」と表示されることを確認
- [ ] 利用規約ページ (`/terms`) を開き、同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)