### PR TITLE
fix: E2E の seed 前に batch:games でゲームデータを投入

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,6 +67,13 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/questlink_e2e
 
+      - name: Sync games from IGDB
+        run: pnpm batch:games
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/questlink_e2e
+          TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
+          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
+
       - name: Seed database
         run: pnpm db:seed
         env:


### PR DESCRIPTION
## 概要

- E2E ジョブで `pnpm db:seed` 実行前に `pnpm batch:games` を実行しゲームデータを投入
- `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` シークレットを使用

## 必要な GitHub Secrets

- `TWITCH_CLIENT_ID`
- `TWITCH_CLIENT_SECRET`