### PR TITLE
fix(e2e): 未認証ユーザーのリダイレクト挙動に合わせてテストを修正

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -13,9 +13,8 @@ test.describe("認証リダイレクト", () => {
     await expect(page.getByRole("button", { name: "Googleでログイン" })).toBeVisible();
   });
 
-  test("未認証で /rooms にアクセスできる（リダイレクトなし）", async ({ page }) => {
+  test("未認証で /rooms にアクセスすると /login にリダイレクトされる", async ({ page }) => {
     await page.goto("/rooms");
-    await expect(page).toHaveURL(/\/rooms/);
-    await expect(page).not.toHaveURL(/\/login/);
+    await expect(page).toHaveURL(/\/login/);
   });
 });

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -6,12 +6,9 @@ test.describe("ホームページ", () => {
     await expect(page.locator("h2").first()).toBeVisible();
   });
 
-  test("ヘッダーまたはナビゲーションが表示される", async ({ page }) => {
+  test("未認証では /login にリダイレクトされ「Googleでログイン」ボタンが表示される", async ({ page }) => {
     await page.goto("/");
-    const header = page.locator("header");
-    const nav = page.locator("nav");
-    const hasHeader = (await header.count()) > 0;
-    const hasNav = (await nav.count()) > 0;
-    expect(hasHeader || hasNav).toBe(true);
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole("button", { name: "Googleでログイン" })).toBeVisible();
   });
 });

--- a/e2e/new-room.spec.ts
+++ b/e2e/new-room.spec.ts
@@ -9,29 +9,9 @@ test.describe("部屋作成ページ（/rooms/new）", () => {
   });
 });
 
-test.describe("ゲーム選択画面（/games）— GamesGrid 共通コンポーネント", () => {
-  test("「ゲームを選択」の見出しが表示される", async ({ page }) => {
+test.describe("ゲーム選択画面（/games）— 未認証アクセス", () => {
+  test("未認証で /games にアクセスすると /login にリダイレクトされる", async ({ page }) => {
     await page.goto("/games");
-    await expect(
-      page.getByRole("heading", { name: "ゲームを選択" })
-    ).toBeVisible();
-  });
-
-  test("ゲーム検索バーが表示される", async ({ page }) => {
-    await page.goto("/games");
-    await expect(page.getByRole("textbox")).toBeVisible();
-  });
-
-  test("ゲームカードをクリックすると /games/{id}/rooms に遷移する", async ({
-    page,
-  }) => {
-    await page.goto("/games");
-
-    // ゲームカードが少なくとも1件表示されるのを待つ
-    const firstGameButton = page.getByRole("button").first();
-    await expect(firstGameButton).toBeVisible();
-
-    await firstGameButton.click();
-    await expect(page).toHaveURL(/\/games\/.+\/rooms/);
+    await expect(page).toHaveURL(/\/login/);
   });
 });

--- a/e2e/rooms.spec.ts
+++ b/e2e/rooms.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("部屋一覧", () => {
-  test("/rooms が表示され h1「部屋一覧」が存在する", async ({ page }) => {
+  test("未認証で /rooms にアクセスすると /login にリダイレクトされる", async ({ page }) => {
     await page.goto("/rooms");
-    await expect(page.getByRole("heading", { name: "部屋一覧" })).toBeVisible();
+    await expect(page).toHaveURL(/\/login/);
   });
 
   test("未認証で /rooms/new にアクセスすると /login にリダイレクトされる", async ({


### PR DESCRIPTION
## Summary

- `/rooms`・`/games`・`/` はすべて認証必須のため、未認証ユーザーは `/login` にリダイレクトされる
- E2E テストがこれらを「公開ページ」と誤って想定していたため、実際の挙動（ログインへのリダイレクト）を確認するよう修正
- ローカルで 16 passed を確認済み

## Test plan

- [x] ローカルで `pnpm test:e2e` を実行し 16 passed を確認
- [ ] CI (E2E ワークフロー) が全テスト通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)