### PR TITLE
feat: エラー・成功メッセージを全てトーストで表示する (#281)

### DIFF
--- a/app/(onboarding)/onboarding/StepGames.tsx
+++ b/app/(onboarding)/onboarding/StepGames.tsx
@@ -10,7 +10,6 @@ interface StepGamesProps {
   onBack: () => void;
   onSubmit: () => void;
   saving: boolean;
-  error: string | null;
   status: "loading" | "authenticated" | "unauthenticated";
 }
 
@@ -20,7 +19,6 @@ export function StepGames({
   onBack,
   onSubmit,
   saving,
-  error,
   status,
 }: StepGamesProps) {
   return (
@@ -36,12 +34,6 @@ export function StepGames({
         </div>
 
         <GridGamePicker value={selectedGames} onChange={onGamesChange} max={20} />
-
-        {error && (
-          <p className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-400">
-            {error}
-          </p>
-        )}
       </div>
 
       <OnboardingNavButtons

--- a/app/(onboarding)/onboarding/page.tsx
+++ b/app/(onboarding)/onboarding/page.tsx
@@ -51,7 +51,7 @@ function OnboardingContent() {
     setAvatarFile(file);
   };
 
-  const { handleSubmit, saving, error } = useOnboardingSubmit({
+  const { handleSubmit, saving } = useOnboardingSubmit({
     avatarFile,
     username,
     bio,
@@ -102,7 +102,6 @@ function OnboardingContent() {
             onBack={() => setCurrentStep(4)}
             onSubmit={() => void handleSubmit()}
             saving={saving}
-            error={error}
             status={status}
           />
         )}

--- a/app/(onboarding)/onboarding/useOnboardingSubmit.test.ts
+++ b/app/(onboarding)/onboarding/useOnboardingSubmit.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+import { toast } from "@/lib/toast";
 
 const mockPush = vi.fn();
 vi.mock("next/navigation", () => ({
@@ -58,8 +59,8 @@ describe("useOnboardingSubmit", () => {
         })
       );
       expect(mockUpdate).toHaveBeenCalledWith({ username: "testuser" });
+      expect(vi.mocked(toast.success)).toHaveBeenCalledWith("プロフィールを設定しました");
       expect(mockPush).toHaveBeenCalledWith("/rooms");
-      expect(result.current.error).toBeNull();
       expect(result.current.saving).toBe(false);
     });
 
@@ -139,7 +140,7 @@ describe("useOnboardingSubmit", () => {
         await result.current.handleSubmit();
       });
 
-      expect(result.current.error).toBe("画像のアップロードに失敗しました");
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith("画像のアップロードに失敗しました");
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(mockPush).not.toHaveBeenCalled();
     });
@@ -156,7 +157,7 @@ describe("useOnboardingSubmit", () => {
         await result.current.handleSubmit();
       });
 
-      expect(result.current.error).toBe("ユーザー名が重複しています");
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith("ユーザー名が重複しています");
       expect(mockPush).not.toHaveBeenCalled();
     });
 
@@ -172,7 +173,7 @@ describe("useOnboardingSubmit", () => {
         await result.current.handleSubmit();
       });
 
-      expect(result.current.error).toBe("エラーが発生しました");
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith("エラーが発生しました");
     });
 
     it("通信エラー時にデフォルトエラーメッセージをセットする", async () => {
@@ -184,7 +185,7 @@ describe("useOnboardingSubmit", () => {
         await result.current.handleSubmit();
       });
 
-      expect(result.current.error).toBe("通信エラーが発生しました。再度お試しください");
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith("通信エラーが発生しました。再度お試しください");
       expect(mockPush).not.toHaveBeenCalled();
     });
   });

--- a/app/(onboarding)/onboarding/useOnboardingSubmit.ts
+++ b/app/(onboarding)/onboarding/useOnboardingSubmit.ts
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { type Game } from "@/lib/mock-data";
+import { toast } from "@/lib/toast";
 
 interface UseOnboardingSubmitParams {
   avatarFile: File | null;
@@ -21,13 +22,11 @@ export function useOnboardingSubmit({
   callbackUrl,
 }: UseOnboardingSubmitParams) {
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const { update } = useSession();
 
   const handleSubmit = async () => {
     setSaving(true);
-    setError(null);
 
     try {
       if (avatarFile) {
@@ -38,7 +37,7 @@ export function useOnboardingSubmit({
           body: formData,
         });
         if (!uploadRes.ok) {
-          setError("画像のアップロードに失敗しました");
+          toast.error("画像のアップロードに失敗しました");
           return;
         }
       }
@@ -56,19 +55,20 @@ export function useOnboardingSubmit({
       const json = (await res.json()) as { error?: string };
 
       if (!res.ok) {
-        setError(json.error ?? "エラーが発生しました");
+        toast.error(json.error ?? "エラーが発生しました");
         return;
       }
 
       await update({ username: username.trim() });
+      toast.success("プロフィールを設定しました");
       const dest = callbackUrl?.startsWith("/") ? callbackUrl : "/rooms";
       router.push(dest);
     } catch {
-      setError("通信エラーが発生しました。再度お試しください");
+      toast.error("通信エラーが発生しました。再度お試しください");
     } finally {
       setSaving(false);
     }
   };
 
-  return { handleSubmit, saving, error };
+  return { handleSubmit, saving };
 }

--- a/app/login/LoginErrorToast.tsx
+++ b/app/login/LoginErrorToast.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+import { toast } from "@/lib/toast";
+
+const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  OAuthAccountNotLinked: "このメールアドレスは別のログイン方法で登録されています",
+  OAuthSignin: "ログインに失敗しました。再度お試しください",
+  OAuthCallback: "ログインに失敗しました。再度お試しください",
+  AccessDenied: "アクセスが拒否されました",
+  Verification: "確認リンクが無効か期限切れです",
+  Default: "ログインに失敗しました",
+};
+
+export function LoginErrorToast({ error }: { error: string }) {
+  useEffect(() => {
+    toast.error(OAUTH_ERROR_MESSAGES[error] ?? OAUTH_ERROR_MESSAGES.Default);
+  }, [error]);
+
+  return null;
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,13 +2,14 @@ import { signIn } from "@/auth";
 import { Logo } from "@/components/ui/Logo";
 import { OAuthButton } from "@/components/ui/OAuthButton";
 import Link from "next/link";
+import { LoginErrorToast } from "./LoginErrorToast";
 
 type Props = {
-  searchParams: Promise<{ callbackUrl?: string }>;
+  searchParams: Promise<{ callbackUrl?: string; error?: string }>;
 };
 
 export default async function LoginPage({ searchParams }: Props) {
-  const { callbackUrl } = await searchParams;
+  const { callbackUrl, error } = await searchParams;
   const redirectTo = callbackUrl?.startsWith("/") ? callbackUrl : "/rooms";
   const hasInviteToken = callbackUrl?.includes("inviteToken=") ?? false;
 
@@ -17,6 +18,7 @@ export default async function LoginPage({ searchParams }: Props) {
       className="flex min-h-screen flex-col items-center justify-center px-4"
       style={{ backgroundColor: "var(--bg-base)" }}
     >
+      {error && <LoginErrorToast error={error} />}
       <div className="w-full max-w-md">
         {/* Logo */}
         <div className="mb-8 flex flex-col items-center animate-fade-in-up">

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,6 +4,7 @@ import { SessionProvider } from "next-auth/react";
 import type { Session } from "next-auth";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
+import { Toaster } from "@/components/ui/sonner";
 
 export function Providers({ children, session }: { children: React.ReactNode; session: Session | null }) {
   const [queryClient] = useState(
@@ -17,7 +18,10 @@ export function Providers({ children, session }: { children: React.ReactNode; se
 
   return (
     <SessionProvider session={session}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        {children}
+        <Toaster />
+      </QueryClientProvider>
     </SessionProvider>
   );
 }

--- a/app/rooms/[roomId]/InvitePanel.test.tsx
+++ b/app/rooms/[roomId]/InvitePanel.test.tsx
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { toast } from "@/lib/toast";
 
 vi.mock("@phosphor-icons/react", () => ({
   LinkSimple: () => <span data-testid="icon-link" />,
   Copy: () => <span data-testid="icon-copy" />,
   CircleNotch: () => <span data-testid="icon-spinner" />,
-  Check: () => <span data-testid="icon-check" />,
 }));
 
 vi.mock("@/lib/api/rooms", () => ({
@@ -70,7 +70,7 @@ describe("InvitePanel", () => {
     );
   });
 
-  it("コピー後に「コピーしました」に変わる", async () => {
+  it("コピー後に toast.success が呼ばれる", async () => {
     mockGenerateInviteToken.mockResolvedValue({ data: { inviteToken: "token-xyz" } });
     render(<InvitePanel roomId="room-1" />);
 
@@ -78,7 +78,7 @@ describe("InvitePanel", () => {
     fireEvent.click(screen.getByText("リンクをコピー"));
 
     await waitFor(() => {
-      expect(screen.getByText("コピーしました")).toBeInTheDocument();
+      expect(vi.mocked(toast.success)).toHaveBeenCalledWith("リンクをコピーしました");
     });
   });
 });

--- a/app/rooms/[roomId]/InvitePanel.tsx
+++ b/app/rooms/[roomId]/InvitePanel.tsx
@@ -1,31 +1,37 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { LinkSimple, Copy, CircleNotch, Check } from "@phosphor-icons/react";
+import { LinkSimple, Copy, CircleNotch } from "@phosphor-icons/react";
 import { generateInviteToken } from "@/lib/api/rooms";
+import { toast } from "@/lib/toast";
 
 type Props = { roomId: string };
 
 export function InvitePanel({ roomId }: Props) {
   const [inviteUrl, setInviteUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     generateInviteToken(roomId)
       .then((res) => {
         setInviteUrl(`${window.location.origin}/rooms/${roomId}?inviteToken=${res.data.inviteToken}`);
       })
-      .catch(() => {/* 取得失敗時は非表示 */})
+      .catch((err: unknown) => {
+        toast.error(err instanceof Error ? err.message : "招待リンクの取得に失敗しました");
+      })
       .finally(() => setIsLoading(false));
   }, [roomId]);
 
   const handleCopy = () => {
     if (!inviteUrl) return;
-    void navigator.clipboard.writeText(inviteUrl).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    void navigator.clipboard
+      .writeText(inviteUrl)
+      .then(() => {
+        toast.success("リンクをコピーしました");
+      })
+      .catch(() => {
+        toast.error("コピーに失敗しました");
+      });
   };
 
   if (!isLoading && !inviteUrl) return null;
@@ -49,13 +55,13 @@ export function InvitePanel({ roomId }: Props) {
             onClick={handleCopy}
             className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-all hover:opacity-80 active:scale-[0.97]"
             style={{
-              color: copied ? "var(--accent-light)" : "var(--text-secondary)",
-              backgroundColor: copied ? "rgba(124,58,237,0.15)" : "var(--bg-card-hover)",
+              color: "var(--text-secondary)",
+              backgroundColor: "var(--bg-card-hover)",
             }}
             title="コピー"
           >
-            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-            {copied ? "コピーしました" : "リンクをコピー"}
+            <Copy className="h-3.5 w-3.5" />
+            リンクをコピー
           </button>
         )}
       </div>

--- a/app/rooms/[roomId]/RoomActions.tsx
+++ b/app/rooms/[roomId]/RoomActions.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { DoorOpen, SignOut, CircleNotch, Trash } from "@phosphor-icons/react";
 import { joinRoom, leaveRoom, closeRoom } from "@/lib/api/rooms";
 import { ConfirmModal } from "@/components/ui/ConfirmModal";
+import { toast } from "@/lib/toast";
 
 type Props = {
   roomId: string;
@@ -24,8 +25,12 @@ export function RoomActions({ roomId, isParticipant, isHost, isGuest, status, on
   const joinMutation = useMutation({
     mutationFn: () => joinRoom(roomId),
     onSuccess: async () => {
+      toast.success("部屋に参加しました");
       await queryClient.invalidateQueries({ queryKey: ["room", roomId] });
       await queryClient.invalidateQueries({ queryKey: ["rooms"] });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
     },
   });
 
@@ -38,6 +43,9 @@ export function RoomActions({ roomId, isParticipant, isHost, isGuest, status, on
         router.push(`/rooms/${roomId}/ratings`);
       }
     },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
   });
 
   const closeMutation = useMutation({
@@ -46,6 +54,9 @@ export function RoomActions({ roomId, isParticipant, isHost, isGuest, status, on
       await queryClient.invalidateQueries({ queryKey: ["room", roomId] });
       await queryClient.invalidateQueries({ queryKey: ["rooms"] });
       router.push("/rooms");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
     },
   });
 
@@ -79,11 +90,6 @@ export function RoomActions({ roomId, isParticipant, isHost, isGuest, status, on
           )}
           {status === "playing" ? "満員" : "参加する"}
         </button>
-        {joinMutation.isError && (
-          <p className="text-center text-xs animate-slide-in-bottom" style={{ color: "#f87171" }}>
-            {joinMutation.error.message}
-          </p>
-        )}
       </div>
     );
   }
@@ -123,16 +129,6 @@ export function RoomActions({ roomId, isParticipant, isHost, isGuest, status, on
           </button>
         )}
       </div>
-      {leaveMutation.isError && (
-        <p className="text-center text-xs animate-slide-in-bottom" style={{ color: "#f87171" }}>
-          {leaveMutation.error.message}
-        </p>
-      )}
-      {closeMutation.isError && (
-        <p className="text-center text-xs animate-slide-in-bottom" style={{ color: "#f87171" }}>
-          {closeMutation.error.message}
-        </p>
-      )}
       {isConfirmOpen && (
         <ConfirmModal
           title="部屋を解散しますか？"

--- a/app/rooms/[roomId]/RoomDetailView.tsx
+++ b/app/rooms/[roomId]/RoomDetailView.tsx
@@ -7,6 +7,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 import { ArrowLeft, Chat } from "@phosphor-icons/react";
 import { fetchRoom, joinRoom } from "@/lib/api/rooms";
+import { toast } from "@/lib/toast";
 import { GuestJoinModal } from "@/components/rooms/GuestJoinModal";
 import { RoomActions } from "./RoomActions";
 import { InvitePanel } from "./InvitePanel";
@@ -50,8 +51,9 @@ export function RoomDetailView({ roomId }: Props) {
       .then(async () => {
         await queryClient.invalidateQueries({ queryKey: ["room", roomId] });
       })
-      .catch(() => {
+      .catch((err: unknown) => {
         autoJoinAttempted.current = false;
+        toast.error(err instanceof Error ? err.message : "参加に失敗しました");
       });
   }, [inviteToken, currentUserId, data, roomId, queryClient]);
 

--- a/app/rooms/[roomId]/chat/ChatInput.tsx
+++ b/app/rooms/[roomId]/chat/ChatInput.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { PaperPlaneTilt } from "@phosphor-icons/react";
 import { getSocket } from "@/lib/socket";
 import { useChatStore } from "@/lib/stores/chatStore";
+import { toast } from "@/lib/toast";
 
 const MAX_LENGTH = 1000;
 
@@ -21,8 +22,13 @@ export function ChatInput({ roomId }: Props) {
 
   const handleSend = () => {
     if (!canSend) return;
-    getSocket().emit("chat:send", { roomId, content: message.trim() });
+    const content = message.trim();
     setMessage("");
+    getSocket().emit("chat:send", { roomId, content }, (ack?: { error?: string }) => {
+      if (ack?.error) {
+        toast.error("メッセージの送信に失敗しました");
+      }
+    });
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/app/rooms/[roomId]/chat/useSocketRoom.ts
+++ b/app/rooms/[roomId]/chat/useSocketRoom.ts
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { getSocket, connectSocket, disconnectSocket } from "@/lib/socket";
 import { useChatStore, type ChatMessage, type Participant } from "@/lib/stores/chatStore";
+import { toast } from "@/lib/toast";
 
 type UseSocketRoomOptions = {
   roomId: string;
@@ -92,6 +93,9 @@ export function useSocketRoom({
     );
 
     socket.on("room:host_changed", ({ newHostId }: { newHostId: string }) => {
+      if (currentUserId != null && currentUserId === newHostId) {
+        toast.info("あなたがホストになりました");
+      }
       useChatStore.setState((state) => ({
         participants: state.participants.map((p) => ({
           ...p,

--- a/app/rooms/[roomId]/ratings/RatingForm.tsx
+++ b/app/rooms/[roomId]/ratings/RatingForm.tsx
@@ -2,9 +2,9 @@
 
 import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
-import { CheckCircle } from "@phosphor-icons/react";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { StarRating, RatingDisplay } from "@/components/ui/StarRating";
+import { toast } from "@/lib/toast";
 import clsx from "clsx";
 
 type User = {
@@ -47,6 +47,12 @@ export function RatingForm({ user, roomId }: Props) {
 
   const mutation = useMutation({
     mutationFn: (payload: RatingPayload) => postRating(roomId, payload),
+    onSuccess: () => {
+      toast.success("評価を送信しました");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
   });
 
   const handleSubmit = () => {
@@ -57,24 +63,6 @@ export function RatingForm({ user, roomId }: Props) {
       comment: comment || undefined,
     });
   };
-
-  if (mutation.isSuccess) {
-    return (
-      <div
-        className="flex items-center gap-4 rounded-2xl p-5 opacity-60 animate-scale-in"
-        style={{ backgroundColor: "var(--bg-card)" }}
-      >
-        <UserAvatar username={user.username} iconUrl={user.iconUrl} size="md" />
-        <div className="flex-1">
-          <p className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
-            {user.username}
-          </p>
-          <p className="text-xs" style={{ color: "#22c55e" }}>評価を送信しました</p>
-        </div>
-        <CheckCircle className="h-5 w-5 animate-scale-in" style={{ color: "#22c55e", animationDelay: "150ms" }} />
-      </div>
-    );
-  }
 
   return (
     <div
@@ -123,22 +111,16 @@ export function RatingForm({ user, roomId }: Props) {
         />
       </div>
 
-      {mutation.isError && (
-        <p className="mb-3 text-xs text-red-400 animate-slide-in-bottom">
-          {mutation.error instanceof Error ? mutation.error.message : "評価の送信に失敗しました"}
-        </p>
-      )}
-
       <button
         onClick={handleSubmit}
-        disabled={!score || mutation.isPending}
+        disabled={!score || mutation.isPending || mutation.isSuccess}
         className={clsx(
           "w-full rounded-xl py-2.5 text-sm font-semibold text-white transition-all",
-          score && !mutation.isPending ? "hover:opacity-90 active:scale-[0.97]" : "opacity-40 cursor-not-allowed"
+          score && !mutation.isPending && !mutation.isSuccess ? "hover:opacity-90 active:scale-[0.97]" : "opacity-40 cursor-not-allowed"
         )}
         style={{
           background:
-            score && !mutation.isPending
+            score && !mutation.isPending && !mutation.isSuccess
               ? "linear-gradient(135deg, var(--accent), #6d28d9)"
               : "var(--border)",
         }}

--- a/app/rooms/new/page.test.tsx
+++ b/app/rooms/new/page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { toast } from "@/lib/toast";
 import NewRoomPage from "./page";
 
 // ─── vi.mock ファクトリ内で参照できるようにホイスト ────────────────────────────
@@ -162,14 +163,14 @@ describe("NewRoomPage", () => {
     expect(mockPush).toHaveBeenCalledWith("/rooms/room-123");
   });
 
-  it("createRoom 失敗時にエラーメッセージが表示される", async () => {
+  it("createRoom 失敗時に toast.error が呼ばれる", async () => {
     render(<NewRoomPage />);
     selectGame();
     act(() => {
       mutationCallbacks.onError?.(new Error("作成に失敗しました"));
     });
     await waitFor(() => {
-      expect(screen.getByText("作成に失敗しました")).toBeInTheDocument();
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith("作成に失敗しました");
     });
   });
 });

--- a/app/rooms/new/page.tsx
+++ b/app/rooms/new/page.tsx
@@ -11,6 +11,7 @@ import { TagFilterToggle } from "@/components/ui/TagFilterToggle";
 import { TagFilterPanel } from "@/components/ui/TagFilterPanel";
 import { ActiveFilterBar } from "@/components/ui/ActiveFilterBar";
 import { createRoom } from "@/lib/api/rooms";
+import { toast } from "@/lib/toast";
 
 type Tag = {
   id: string;
@@ -40,7 +41,6 @@ export default function NewRoomPage() {
   const [selectedSlugs, setSelectedSlugs] = useState<string[]>([]);
   const [pendingSlugs, setPendingSlugs] = useState<string[]>([]);
   const [panelOpen, setPanelOpen] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const toggleRef = useRef<HTMLDivElement>(null);
 
   const { data: tags = [] } = useQuery({
@@ -57,17 +57,17 @@ export default function NewRoomPage() {
     setSelectedSlugs([]);
     setPendingSlugs([]);
     setPanelOpen(false);
-    setErrorMessage(null);
   };
 
   const mutation = useMutation({
     mutationFn: createRoom,
     onSuccess: (res) => {
+      toast.success("部屋を作成しました");
       resetForm();
       router.push(`/rooms/${res.data.id}`);
     },
     onError: (err: Error) => {
-      setErrorMessage(err.message);
+      toast.error(err.message);
     },
   });
 
@@ -92,7 +92,6 @@ export default function NewRoomPage() {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!selectedGame) return;
-    setErrorMessage(null);
     const playStyleTagIds = tags
       .filter((t) => selectedSlugs.includes(t.slug))
       .map((t) => t.id);
@@ -168,15 +167,6 @@ export default function NewRoomPage() {
           })}
         </div>
       </div>
-
-      {errorMessage && (
-        <div
-          className="mb-4 rounded-xl px-4 py-3 text-sm"
-          style={{ backgroundColor: "rgba(239,68,68,0.1)", color: "#f87171" }}
-        >
-          {errorMessage}
-        </div>
-      )}
 
       {/* ステップ1: ゲーム選択 */}
       {step === 1 && (

--- a/app/users/me/DeleteAccountButton.tsx
+++ b/app/users/me/DeleteAccountButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { signOut } from "next-auth/react";
 import { Trash } from "@phosphor-icons/react";
+import { toast } from "@/lib/toast";
 
 export function DeleteAccountButton() {
   const [confirming, setConfirming] = useState(false);
@@ -15,10 +16,12 @@ export function DeleteAccountButton() {
       if (res.ok) {
         await signOut({ callbackUrl: "/login" });
       } else {
+        toast.error("アカウントの削除に失敗しました");
         setDeleting(false);
         setConfirming(false);
       }
     } catch {
+      toast.error("アカウントの削除に失敗しました");
       setDeleting(false);
       setConfirming(false);
     }

--- a/app/users/me/edit/page.test.tsx
+++ b/app/users/me/edit/page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { toast } from "@/lib/toast";
 
 const mockInvalidateQueries = vi.fn();
 const mockPush = vi.fn();
@@ -101,7 +102,7 @@ describe("EditProfilePage", () => {
     });
   });
 
-  it("PATCH API 失敗時は invalidateQueries と router.push が呼ばれない", async () => {
+  it("PATCH API 失敗時は toast.error が呼ばれ invalidateQueries と router.push が呼ばれない", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: false,
       json: async () => ({ error: "ユーザー名が重複しています" }),
@@ -111,7 +112,7 @@ describe("EditProfilePage", () => {
     fireEvent.click(screen.getByRole("button", { name: "保存する" }));
 
     await waitFor(() => {
-      expect(screen.getByText("ユーザー名が重複しています")).toBeInTheDocument();
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith("ユーザー名が重複しています");
     });
 
     expect(mockInvalidateQueries).not.toHaveBeenCalled();

--- a/app/users/me/edit/page.tsx
+++ b/app/users/me/edit/page.tsx
@@ -10,6 +10,7 @@ import { type Game } from "@/lib/mock-data";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { MultiGamePicker } from "@/components/ui/GamePicker";
 import { BackButton } from "@/components/ui/BackButton";
+import { toast } from "@/lib/toast";
 
 type UserProfile = {
   username: string;
@@ -43,7 +44,6 @@ export default function EditProfilePage() {
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const [bio, setBio] = useState("");
   const [selectedGames, setSelectedGames] = useState<Game[]>([]);
-  const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [initialized, setInitialized] = useState(false);
 
@@ -72,7 +72,6 @@ export default function EditProfilePage() {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setError(null);
     setSaving(true);
 
     try {
@@ -97,7 +96,7 @@ export default function EditProfilePage() {
             INVALID_FILE_TYPE: "JPEG / PNG / WebP / GIF のみアップロード可能です",
             UPLOAD_FAILED: "画像のアップロードに失敗しました",
           };
-          setError(msgMap[uploadJson.error ?? ""] ?? "画像のアップロードに失敗しました");
+          toast.error(msgMap[uploadJson.error ?? ""] ?? "画像のアップロードに失敗しました");
           return;
         }
 
@@ -120,15 +119,16 @@ export default function EditProfilePage() {
       const json = (await res.json()) as { error?: string };
 
       if (!res.ok) {
-        setError(json.error ?? "エラーが発生しました");
+        toast.error(json.error ?? "エラーが発生しました");
         return;
       }
 
       await update({ username: username.trim() });
       queryClient.invalidateQueries({ queryKey: ["users", "me"] });
+      toast.success("プロフィールを保存しました");
       router.push("/users/me");
     } catch {
-      setError("通信エラーが発生しました。再度お試しください");
+      toast.error("通信エラーが発生しました。再度お試しください");
     } finally {
       setSaving(false);
     }
@@ -227,13 +227,6 @@ export default function EditProfilePage() {
           </label>
           <MultiGamePicker value={selectedGames} onChange={setSelectedGames} max={20} />
         </div>
-
-        {/* Error */}
-        {error && (
-          <p className="mb-4 rounded-xl bg-red-500/10 px-4 py-3 text-sm text-red-400">
-            {error}
-          </p>
-        )}
 
         {/* Sticky buttons */}
         <div

--- a/components/rooms/GuestJoinModal.test.tsx
+++ b/components/rooms/GuestJoinModal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { toast } from "@/lib/toast";
 
 const mockInvalidateQueries = vi.fn();
 const mockPush = vi.fn();
@@ -46,7 +47,7 @@ describe("GuestJoinModal — mode=invite", () => {
     expect(screen.getByText("Discordでログイン")).toBeInTheDocument();
   });
 
-  it("51文字入力時は fetch を呼ばずバリデーションエラーを表示する", async () => {
+  it("51文字入力時は fetch を呼ばず toast.error でバリデーションエラーを表示する", async () => {
     render(<GuestJoinModal {...inviteProps} />);
 
     fireEvent.change(screen.getByRole("textbox"), {
@@ -55,7 +56,7 @@ describe("GuestJoinModal — mode=invite", () => {
     fireEvent.click(screen.getByRole("button", { name: "ゲストとして参加" }));
 
     await waitFor(() => {
-      expect(screen.getByText("表示名は50文字以内で入力してください")).toBeInTheDocument();
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith("表示名は50文字以内で入力してください");
     });
     expect(fetch).not.toHaveBeenCalled();
   });
@@ -78,7 +79,7 @@ describe("GuestJoinModal — mode=invite", () => {
     });
   });
 
-  it("ROOM_CLOSED エラーコードで正しいメッセージを表示する", async () => {
+  it("ROOM_CLOSED エラーコードで toast.error に正しいメッセージが渡される", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: false,
       json: async () => ({ error: { code: "ROOM_CLOSED" } }),
@@ -88,11 +89,11 @@ describe("GuestJoinModal — mode=invite", () => {
     fireEvent.click(screen.getByRole("button", { name: "ゲストとして参加" }));
 
     await waitFor(() => {
-      expect(screen.getByText("この部屋はすでに終了しています")).toBeInTheDocument();
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith("この部屋はすでに終了しています");
     });
   });
 
-  it("ROOM_FULL エラーコードで正しいメッセージを表示する", async () => {
+  it("ROOM_FULL エラーコードで toast.error に正しいメッセージが渡される", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: false,
       json: async () => ({ error: { code: "ROOM_FULL" } }),
@@ -102,11 +103,11 @@ describe("GuestJoinModal — mode=invite", () => {
     fireEvent.click(screen.getByRole("button", { name: "ゲストとして参加" }));
 
     await waitFor(() => {
-      expect(screen.getByText("この部屋は満員です")).toBeInTheDocument();
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith("この部屋は満員です");
     });
   });
 
-  it("INVITE_NOT_FOUND エラーコードで正しいメッセージを表示する", async () => {
+  it("INVITE_NOT_FOUND エラーコードで toast.error に正しいメッセージが渡される", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: false,
       json: async () => ({ error: { code: "INVITE_NOT_FOUND" } }),
@@ -116,11 +117,11 @@ describe("GuestJoinModal — mode=invite", () => {
     fireEvent.click(screen.getByRole("button", { name: "ゲストとして参加" }));
 
     await waitFor(() => {
-      expect(screen.getByText("招待リンクが無効です")).toBeInTheDocument();
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith("招待リンクが無効です");
     });
   });
 
-  it("ALREADY_JOINED エラーコードで正しいメッセージを表示する", async () => {
+  it("ALREADY_JOINED エラーコードで toast.error に正しいメッセージが渡される", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: false,
       json: async () => ({ error: { code: "ALREADY_JOINED" } }),
@@ -130,7 +131,7 @@ describe("GuestJoinModal — mode=invite", () => {
     fireEvent.click(screen.getByRole("button", { name: "ゲストとして参加" }));
 
     await waitFor(() => {
-      expect(screen.getByText("すでにこの部屋に参加しています")).toBeInTheDocument();
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith("すでにこの部屋に参加しています");
     });
   });
 

--- a/components/rooms/GuestJoinModal.tsx
+++ b/components/rooms/GuestJoinModal.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { OAuthButtonGroup } from "@/components/ui/OAuthButtonGroup";
+import { toast } from "@/lib/toast";
 
 const ERROR_MESSAGES: Record<string, string> = {
   ROOM_CLOSED: "この部屋はすでに終了しています",
@@ -22,7 +23,6 @@ export function GuestJoinModal(props: Props) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const [displayName, setDisplayName] = useState("");
-  const [error, setError] = useState<string | null>(null);
   const [isPending, setIsPending] = useState(false);
 
   const callbackUrl = `/rooms/${props.roomId}?inviteToken=${props.inviteToken}`;
@@ -30,11 +30,10 @@ export function GuestJoinModal(props: Props) {
   const handleGuestSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (displayName.length > 50) {
-      setError("表示名は50文字以内で入力してください");
+      toast.error("表示名は50文字以内で入力してください");
       return;
     }
     setIsPending(true);
-    setError(null);
     try {
       const res = await fetch(`/api/v1/invite/${props.inviteToken}/join`, {
         method: "POST",
@@ -44,13 +43,13 @@ export function GuestJoinModal(props: Props) {
       });
       if (!res.ok) {
         const body = (await res.json()) as { error?: { code: string } };
-        setError(ERROR_MESSAGES[body.error?.code ?? ""] ?? "参加に失敗しました");
+        toast.error(ERROR_MESSAGES[body.error?.code ?? ""] ?? "参加に失敗しました");
         return;
       }
       await queryClient.invalidateQueries({ queryKey: ["room", props.roomId] });
       router.push(`/rooms/${props.roomId}/chat`);
     } catch {
-      setError("ネットワークエラーが発生しました");
+      toast.error("ネットワークエラーが発生しました");
     } finally {
       setIsPending(false);
     }
@@ -110,7 +109,6 @@ export function GuestJoinModal(props: Props) {
                   color: "var(--text-primary)",
                 }}
               />
-              {error && <p className="text-sm text-red-400">{error}</p>}
               <button
                 type="submit"
                 disabled={isPending}

--- a/components/rooms/KickButton.tsx
+++ b/components/rooms/KickButton.tsx
@@ -5,6 +5,7 @@ import { HandWaving } from "@phosphor-icons/react";
 import { useMutation } from "@tanstack/react-query";
 import { ConfirmModal } from "@/components/ui/ConfirmModal";
 import { kickParticipant, type KickTarget } from "@/lib/api/rooms";
+import { toast } from "@/lib/toast";
 
 type Props = {
   roomId: string;
@@ -19,8 +20,12 @@ export function KickButton({ roomId, target, targetName, onSuccess }: Props) {
   const kickMutation = useMutation({
     mutationFn: () => kickParticipant(roomId, target),
     onSuccess: () => {
+      toast.success("退室させました");
       setIsOpen(false);
       onSuccess?.();
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
     },
   });
 

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+
+export function Toaster({ ...props }: ToasterProps) {
+  return (
+    <Sonner
+      theme="dark"
+      position="top-center"
+      closeButton
+      toastOptions={{
+        style: {
+          background: "var(--bg-card)",
+          border: "1px solid var(--border)",
+          color: "var(--text-primary)",
+          fontFamily: "var(--font-sans)",
+        },
+        classNames: {
+          success: "toast-success",
+          error: "toast-error",
+          info: "toast-info",
+        },
+      }}
+      style={
+        {
+          "--success-bg": "var(--bg-card)",
+          "--success-border": "rgba(52,211,153,0.3)",
+          "--success-text": "#34d399",
+          "--error-bg": "var(--bg-card)",
+          "--error-border": "rgba(239,68,68,0.3)",
+          "--error-text": "#f87171",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  );
+}

--- a/components/users/BlockButton.tsx
+++ b/components/users/BlockButton.tsx
@@ -5,6 +5,7 @@ import { CircleNotch } from "@phosphor-icons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ConfirmModal } from "@/components/ui/ConfirmModal";
 import { blockUser, unblockUser } from "@/lib/api/users";
+import { toast } from "@/lib/toast";
 
 type Props = {
   userId: string;
@@ -19,8 +20,12 @@ export function BlockButton({ userId, isBlocked, username }: Props) {
   const mutation = useMutation({
     mutationFn: () => (isBlocked ? unblockUser(userId) : blockUser(userId)),
     onSuccess: () => {
+      toast.success(isBlocked ? "ブロックを解除しました" : "ブロックしました");
       setShowConfirm(false);
       void queryClient.invalidateQueries({ queryKey: ["users", userId] });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
     },
   });
 

--- a/components/users/ReportModal.tsx
+++ b/components/users/ReportModal.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import { CircleNotch } from "@phosphor-icons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createReport } from "@/lib/api/users";
+import { toast } from "@/lib/toast";
 
 const REASON_OPTIONS = [
   { value: "harassment", label: "ハラスメント・嫌がらせ" },
@@ -24,7 +25,6 @@ type Props = {
 export function ReportModal({ targetUserId, targetMessageId, targetName, onClose }: Props) {
   const [reason, setReason] = useState<string>("");
   const [detail, setDetail] = useState("");
-  const [succeeded, setSucceeded] = useState(false);
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
@@ -32,7 +32,11 @@ export function ReportModal({ targetUserId, targetMessageId, targetName, onClose
       createReport({ targetUserId, targetMessageId, reason, detail: detail.trim() || undefined }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["my-blocks"] });
-      setSucceeded(true);
+      toast.success("通報を受け付けました");
+      onClose();
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
     },
   });
 
@@ -46,26 +50,7 @@ export function ReportModal({ targetUserId, targetMessageId, targetName, onClose
         style={{ backgroundColor: "var(--bg-card)" }}
         onClick={(e) => e.stopPropagation()}
       >
-        {succeeded ? (
-          <>
-            <div className="space-y-1">
-              <h2 className="text-lg font-bold" style={{ color: "var(--text-primary)" }}>
-                通報を受け付けました
-              </h2>
-              <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                {targetName} さんを通報しました。ご協力ありがとうございます。
-              </p>
-            </div>
-            <button
-              onClick={onClose}
-              className="flex w-full items-center justify-center rounded-xl px-4 py-3 text-sm font-medium transition-all hover:opacity-80 active:scale-[0.97]"
-              style={{ backgroundColor: "var(--bg-card-hover)", color: "var(--text-secondary)" }}
-            >
-              閉じる
-            </button>
-          </>
-        ) : (
-          <>
+        <>
             <div className="space-y-1">
               <h2 className="text-lg font-bold" style={{ color: "var(--text-primary)" }}>
                 通報する
@@ -112,10 +97,6 @@ export function ReportModal({ targetUserId, targetMessageId, targetName, onClose
               />
             )}
 
-            {mutation.isError && (
-              <p className="text-sm text-red-400">{(mutation.error as Error).message}</p>
-            )}
-
             <div className="flex gap-3">
               <button
                 onClick={onClose}
@@ -136,7 +117,6 @@ export function ReportModal({ targetUserId, targetMessageId, targetName, onClose
               </button>
             </div>
           </>
-        )}
       </div>
     </div>,
     document.body

--- a/lib/toast.test.ts
+++ b/lib/toast.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("sonner", () => {
+  const toastFn = vi.fn();
+  toastFn.success = vi.fn();
+  toastFn.error = vi.fn();
+  return { toast: toastFn };
+});
+
+import { toast as sonnerToast } from "sonner";
+
+// グローバルモック（vitest.setup.ts）を回避して実体を直接テスト
+const { toast } = await vi.importActual<typeof import("./toast")>("./toast");
+
+const mockSonner = sonnerToast as unknown as {
+  success: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+} & ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("toast wrapper", () => {
+  describe("toast.success", () => {
+    it("sonnerToast.success にメッセージを委譲する", () => {
+      toast.success("保存しました");
+      expect(mockSonner.success).toHaveBeenCalledWith("保存しました");
+    });
+
+    it("sonnerToast.success は1回だけ呼ばれる", () => {
+      toast.success("test");
+      expect(mockSonner.success).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("toast.error", () => {
+    it("sonnerToast.error にメッセージを委譲する", () => {
+      toast.error("エラーが発生しました");
+      expect(mockSonner.error).toHaveBeenCalledWith("エラーが発生しました");
+    });
+
+    it("sonnerToast.error は1回だけ呼ばれる", () => {
+      toast.error("test");
+      expect(mockSonner.error).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("toast.info", () => {
+    it("sonnerToast 本体（デフォルト呼び出し）にメッセージを委譲する", () => {
+      toast.info("あなたがホストになりました");
+      expect(mockSonner).toHaveBeenCalledWith("あなたがホストになりました");
+    });
+
+    it("sonnerToast は1回だけ呼ばれる", () => {
+      toast.info("test");
+      expect(mockSonner).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -1,0 +1,7 @@
+import { toast as sonnerToast } from "sonner";
+
+export const toast = {
+  success: (message: string) => sonnerToast.success(message),
+  error: (message: string) => sonnerToast.error(message),
+  info: (message: string) => sonnerToast(message),
+};

--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
     "react-dom": "19.2.3",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
-    "web-vitals": "^5.2.0",
+    "sonner": "^2.0.7",
     "tsx": "^4.21.0",
+    "web-vitals": "^5.2.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@lhci/cli": "^0.14.0",
-    "puppeteer-core": "^22.15.0",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
@@ -72,6 +72,7 @@
     "eslint-config-next": "16.1.6",
     "jsdom": "^28.1.0",
     "prisma": "^7.4.1",
+    "puppeteer-core": "^22.15.0",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.0.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       socket.io-client:
         specifier: ^4.8.3
         version: 4.8.3
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -3853,6 +3856,12 @@ packages:
   socks@2.8.8:
     resolution: {integrity: sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -8435,6 +8444,11 @@ snapshots:
     dependencies:
       ip-address: 10.1.1
       smart-buffer: 4.2.0
+
+  sonner@2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   source-map-js@1.2.1: {}
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom'
+import { vi } from "vitest";
+
+vi.mock("@/lib/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));


### PR DESCRIPTION
## Summary

- sonner（shadcn/ui スタイル）によるトースト基盤を構築し、`top-center` / ダーク固定 / CSS変数テーマでデザイン統一
- 既存インライン表示（赤い `<p>`・バナー・成功カード・ボタン文言スワップ）を撤去してトーストに移行
- 従来はサイレント失敗だった箇所（クリップボードコピー、招待トークン生成、キック、ブロック、アカウント削除、OAuthエラー、チャット送信）にエラートーストを追加
- 持続的ステータス（接続切れバナー・キック済みバナー）はトースト化せず維持

## Changes

**新規ファイル**
- `components/ui/sonner.tsx` — Toaster コンポーネント（shadcn スタイル・ダーク固定・`top-center`）
- `lib/toast.ts` — `toast.success / error / info` 共通ラッパー
- `app/login/LoginErrorToast.tsx` — OAuth エラーコード → 日本語トーストの client コンポーネント
- `lib/toast.test.ts` — sonner への委譲を検証する新規テスト（6ケース）

**変更ファイル（実装）**
- `app/providers.tsx` — `<Toaster />` マウント
- `app/rooms/new/page.tsx` / `RoomActions.tsx` / `RoomDetailView.tsx` / `InvitePanel.tsx` / `ratings/RatingForm.tsx`
- `app/rooms/[roomId]/chat/ChatInput.tsx` — ack コールバック化・送信失敗トースト
- `app/rooms/[roomId]/chat/useSocketRoom.ts` — `room:host_changed` でホスト移譲トースト
- `components/rooms/KickButton.tsx` / `GuestJoinModal.tsx`
- `components/users/ReportModal.tsx` / `BlockButton.tsx`
- `app/users/me/edit/page.tsx` / `DeleteAccountButton.tsx`
- `app/(onboarding)/onboarding/useOnboardingSubmit.ts` / `StepGames.tsx` / `page.tsx`
- `app/login/page.tsx`

**変更ファイル（テスト）**
- `vitest.setup.ts` — `@/lib/toast` のグローバルモック追加
- 既存5ファイル更新: DOM文言検証 → `toast.error/success` 呼び出し検証に変更

## Test plan

- [x] `pnpm test` — 427テスト全パス（Prisma未生成による既存失敗2件は今回と無関係）
- [x] `pnpm lint` — 0 errors
- [ ] `pnpm dev` 起動し各操作でトーストが表示されることを手動確認
  - 部屋作成成功/失敗
  - 参加・退室・クローズ
  - 招待リンクコピー
  - 評価送信
  - プロフィール保存
  - ブロック/解除・通報
  - OAuth失敗 (`/login?error=OAuthAccountNotLinked`)

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)